### PR TITLE
[#6] feat: LLM refinement Model (claude-sonnet-4-5) 연동

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
@@ -4,5 +4,11 @@ public enum ArtifactKind {
     JOB_MANIFEST,
     BUILD_MANIFEST,
     FACTS_JSON,
-    GRAPH_STATS
+    GRAPH_STATS,
+
+    // LLM Meaning Refinement 결과물
+    LLM_REFINED_RULES,
+    LLM_SCENARIO_SPECS,
+    LLM_SUBSYSTEM_SUMMARIES,
+    LLM_API_DOCS
 }

--- a/src/main/java/com/example/ossdoc/global/config/LlmConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/LlmConfig.java
@@ -1,0 +1,47 @@
+package com.example.ossdoc.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "claude")
+public class LlmConfig {
+
+    /**
+     * Anthropic API Key
+     * 환경변수 CLAUDE_API_KEY 로 주입
+     * 예: sk-ant-api03-...
+     */
+    private String apiKey;
+
+    /**
+     * 사용할 Claude 모델 ID
+     * 예: claude-sonnet-4-5
+     */
+    private String model = "claude-sonnet-4-5";
+
+    /**
+     * 응답 최대 토큰 수
+     */
+    private int maxTokens = 8192;
+
+    /**
+     * Claude API 호출용 RestClient Bean.
+     * spring-webflux 없이 spring-boot-starter-web 의 RestClient 사용.
+     */
+    @Bean
+    public RestClient claudeRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", apiKey)
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .defaultHeader("content-type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/llm/controller/LlmController.java
+++ b/src/main/java/com/example/ossdoc/global/llm/controller/LlmController.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.global.llm.controller;
+
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.llm.dto.request.LlmRequest;
+import com.example.ossdoc.global.llm.dto.response.LlmResponse;
+import com.example.ossdoc.global.llm.service.LlmService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/llm")
+public class LlmController {
+
+    private final LlmService llmService;
+
+    @PostMapping("/refine")
+    public ApiResponse<LlmResponse> refine(@Valid @RequestBody LlmRequest request) {
+        LlmResponse response = llmService.refine(request);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/llm/dto/json/LlmResult.java
+++ b/src/main/java/com/example/ossdoc/global/llm/dto/json/LlmResult.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.global.llm.dto.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.*;
+
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class LlmResult {
+
+    private String runId;
+
+    /** 규칙 후보 병합 / 이름 / 방어 vs 도메인 분류 → refined_rules.json */
+    private JsonNode refinedRules;
+
+    /** 시나리오 템플릿 문장화 (각 단계별 근거 링크 포함) → scenario_specs.json */
+    private JsonNode scenarioSpecs;
+
+    /** 서브시스템 라벨링 (짧은 이름 + 간략 설명) → subsystem_summaries.json */
+    private JsonNode subsystemSummaries;
+
+    /** Public API 문서화 → api_docs.json */
+    private JsonNode apiDocs;
+}

--- a/src/main/java/com/example/ossdoc/global/llm/dto/request/LlmRequest.java
+++ b/src/main/java/com/example/ossdoc/global/llm/dto/request/LlmRequest.java
@@ -1,0 +1,40 @@
+package com.example.ossdoc.global.llm.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LlmRequest {
+
+    @NotNull
+    private String runId;
+
+    /**
+     * 구조 엔진 분석 출력물 JSON.
+     * Jackson 3.x(Spring Boot 4.x)에서 JsonNode 직접 역직렬화 불가 → Map 사용
+     */
+    @NotNull
+    private Map<String, Object> structureEngineOutput;
+
+    @NotNull
+    private List<EvidenceSnippet> evidenceBundle;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EvidenceSnippet {
+        private Long evidenceId;
+        private String filePath;
+        private Integer startLine;
+        private Integer endLine;
+        private String snippet;
+        private String evidenceType;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/llm/dto/response/LlmResponse.java
+++ b/src/main/java/com/example/ossdoc/global/llm/dto/response/LlmResponse.java
@@ -1,0 +1,15 @@
+package com.example.ossdoc.global.llm.dto.response;
+
+import com.example.ossdoc.global.llm.dto.json.LlmResult;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LlmResponse {
+
+    private String runId;
+    private LlmResult result;
+}

--- a/src/main/java/com/example/ossdoc/global/llm/exception/LlmException.java
+++ b/src/main/java/com/example/ossdoc/global/llm/exception/LlmException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.global.llm.exception;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+import com.example.ossdoc.global.llm.exception.code.LlmErrorCode;
+
+public class LlmException extends GeneralException {
+
+    public LlmException(LlmErrorCode code) {
+        super(code);
+    }
+
+    public LlmException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/llm/exception/code/LlmErrorCode.java
+++ b/src/main/java/com/example/ossdoc/global/llm/exception/code/LlmErrorCode.java
@@ -1,0 +1,51 @@
+package com.example.ossdoc.global.llm.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum LlmErrorCode implements BaseCode {
+
+    // Run 조회 실패
+    RUN_NOT_FOUND(HttpStatus.NOT_FOUND, "LLM_404_001", "RepoRun not found."),
+
+    // Claude API 호출 관련
+    CLAUDE_API_ERROR(HttpStatus.BAD_GATEWAY, "LLM_502_001", "Claude API returned an error response."),
+    CLAUDE_API_CALL_FAILED(HttpStatus.BAD_GATEWAY, "LLM_502_002", "Failed to call Claude API."),
+
+    // 요청 직렬화 실패
+    REQUEST_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "LLM_500_001", "Failed to build Claude request body."),
+
+    // 응답 파싱 실패
+    RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "LLM_500_002", "LLM response is not valid JSON."),
+
+    // Artifact 저장 실패
+    ARTIFACT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "LLM_500_003", "Failed to save LLM artifact.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
@@ -6,6 +6,8 @@ import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.global.config.LlmConfig;
 import com.example.ossdoc.global.llm.dto.json.LlmResult;
+import com.example.ossdoc.global.llm.exception.LlmException;
+import com.example.ossdoc.global.llm.exception.code.LlmErrorCode;
 import com.example.ossdoc.global.llm.dto.request.LlmRequest;
 import com.example.ossdoc.global.llm.dto.response.LlmResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -112,8 +114,7 @@ public class LlmService {
         log.info("[LlmService] Starting refinement. runId={}", request.getRunId());
 
         RepoRun run = repoRunRepository.findById(request.getRunId())
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "RepoRun not found: " + request.getRunId()));
+                .orElseThrow(() -> new LlmException(LlmErrorCode.RUN_NOT_FOUND));
 
         String baseContext = buildContext(request);
 
@@ -192,7 +193,7 @@ public class LlmService {
 
             return objectMapper.writeValueAsString(root);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to build Claude request body", e);
+            throw new LlmException(LlmErrorCode.REQUEST_SERIALIZE_FAILED);
         }
     }
 
@@ -203,7 +204,8 @@ public class LlmService {
 
             if (root.has("error")) {
                 String msg = root.path("error").path("message").asText("unknown");
-                throw new RuntimeException("Claude API error: " + msg);
+                log.error("[LlmService] Claude API error: {}", msg);
+                throw new LlmException(LlmErrorCode.CLAUDE_API_ERROR);
             }
 
             String text = "";
@@ -217,7 +219,7 @@ public class LlmService {
             return objectMapper.readTree(stripFence(text.trim()));
         } catch (JsonProcessingException e) {
             log.error("[LlmService] Failed to parse Claude response: {}", raw);
-            throw new RuntimeException("LLM response is not valid JSON", e);
+            throw new LlmException(LlmErrorCode.RESPONSE_PARSE_FAILED);
         }
     }
 

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
@@ -1,0 +1,264 @@
+package com.example.ossdoc.global.llm.service;
+
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.global.config.LlmConfig;
+import com.example.ossdoc.global.llm.dto.json.LlmResult;
+import com.example.ossdoc.global.llm.dto.request.LlmRequest;
+import com.example.ossdoc.global.llm.dto.response.LlmResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LlmService {
+
+    private final RestClient claudeRestClient;
+    private final LlmConfig llmConfig;
+    private final ObjectMapper objectMapper;
+    private final ArtifactService artifactService;
+    private final RepoRunRepository repoRunRepository;
+
+    // ── Artifact Paths ────────────────────────────────────────────────────────
+
+    private static final String PATH_REFINED_RULES       = "llm/refined_rules.json";
+    private static final String PATH_SCENARIO_SPECS      = "llm/scenario_specs.json";
+    private static final String PATH_SUBSYSTEM_SUMMARIES = "llm/subsystem_summaries.json";
+    private static final String PATH_API_DOCS            = "llm/api_docs.json";
+
+    // ── System Prompts ────────────────────────────────────────────────────────
+
+    private static final String PROMPT_REFINED_RULES = """
+            You are a software architecture analyst specializing in code rule extraction.
+            Analyze rule candidates from a static analysis engine and produce merged, named, classified rules.
+            
+            For each rule group:
+            1. Merge duplicate or overlapping candidates into one canonical rule
+            2. Assign a short kebab-case name (max 5 words)
+            3. Classify as "defensive" (guard/validation/null-check/error-handling) or "domain" (business logic/invariant)
+            4. Write a concise description (1-2 sentences)
+            5. List supporting evidence IDs
+            
+            Respond with ONLY valid JSON. No markdown fences, no explanation.
+            Schema: {"rules":[{"ruleId":"string","name":"string","classification":"defensive|domain",
+            "description":"string","mergedFromGroups":["groupId"],"evidenceIds":[1],"confidence":0.0}]}
+            """;
+
+    private static final String PROMPT_SCENARIO_SPECS = """
+            You are a software documentation expert specializing in scenario specification.
+            Convert rule candidates and graph edges into structured scenario specifications.
+            
+            For each scenario:
+            1. Write a concise title (Given-When-Then style, 1 sentence)
+            2. Break into ordered steps (precondition → trigger → main flow → outcome)
+            3. For EACH step, link back to evidence IDs that justify that step
+            4. Identify the primary subsystem involved
+            
+            Respond with ONLY valid JSON. No markdown fences, no explanation.
+            Schema: {"scenarios":[{"scenarioId":"string","title":"string","subsystem":"string",
+            "steps":[{"stepNo":1,"description":"string",
+            "evidenceLinks":[{"evidenceId":1,"filePath":"string","lines":"10-15"}]}]}]}
+            """;
+
+    private static final String PROMPT_SUBSYSTEM_SUMMARIES = """
+            You are a software architect performing subsystem decomposition.
+            Analyze symbols, edges, and module structure to identify and label subsystems.
+            
+            For each subsystem:
+            1. Assign a short PascalCase label (max 3 words, e.g. "AuthGuard", "OrderDomain")
+            2. Write a brief description (1 sentence, max 20 words)
+            3. List top symbol FQNs belonging to this subsystem
+            4. Indicate layer: "infrastructure", "domain", or "application"
+            
+            Respond with ONLY valid JSON. No markdown fences, no explanation.
+            Schema: {"subsystems":[{"subsystemId":"string","label":"string","description":"string",
+            "layer":"infrastructure|domain|application","topSymbols":["fqn1"],"ruleIds":["ruleId1"]}]}
+            """;
+
+    private static final String PROMPT_API_DOCS = """
+            You are a technical writer generating API documentation from static analysis.
+            Produce developer-facing documentation for each public API entry.
+            
+            For each public API:
+            1. Write a clear summary (1 sentence)
+            2. Document each parameter with name, type, and description
+            3. Document the return type and what it represents
+            4. Note any exceptions that may be thrown
+            5. Link to relevant scenario IDs
+            
+            Respond with ONLY valid JSON. No markdown fences, no explanation.
+            Schema: {"apiEntries":[{"fqn":"string","summary":"string",
+            "parameters":[{"name":"string","type":"string","description":"string"}],
+            "returns":{"type":"string","description":"string"},
+            "throws":[{"type":"string","condition":"string"}],
+            "relatedScenarios":["scenarioId1"],"subsystem":"string"}]}
+            """;
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    @Transactional
+    public LlmResponse refine(LlmRequest request) {
+        log.info("[LlmService] Starting refinement. runId={}", request.getRunId());
+
+        RepoRun run = repoRunRepository.findById(request.getRunId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "RepoRun not found: " + request.getRunId()));
+
+        String baseContext = buildContext(request);
+
+        // Step 1 - Refined Rules
+        log.info("[LlmService] Step 1/4 - refined_rules");
+        JsonNode refinedRules = callClaude(PROMPT_REFINED_RULES, baseContext);
+        artifactService.saveJsonArtifact(run, ArtifactKind.LLM_REFINED_RULES,
+                "1.0", PATH_REFINED_RULES, refinedRules);
+
+        // Step 2 - Scenario Specs
+        log.info("[LlmService] Step 2/4 - scenario_specs");
+        String scenarioContext = baseContext
+                + "\n\n--- Refined Rules ---\n" + toJson(refinedRules);
+        JsonNode scenarioSpecs = callClaude(PROMPT_SCENARIO_SPECS, scenarioContext);
+        artifactService.saveJsonArtifact(run, ArtifactKind.LLM_SCENARIO_SPECS,
+                "1.0", PATH_SCENARIO_SPECS, scenarioSpecs);
+
+        // Step 3 - Subsystem Summaries
+        log.info("[LlmService] Step 3/4 - subsystem_summaries");
+        String subsystemContext = baseContext
+                + "\n\n--- Refined Rules ---\n" + toJson(refinedRules)
+                + "\n\n--- Scenario Specs ---\n" + toJson(scenarioSpecs);
+        JsonNode subsystemSummaries = callClaude(PROMPT_SUBSYSTEM_SUMMARIES, subsystemContext);
+        artifactService.saveJsonArtifact(run, ArtifactKind.LLM_SUBSYSTEM_SUMMARIES,
+                "1.0", PATH_SUBSYSTEM_SUMMARIES, subsystemSummaries);
+
+        // Step 4 - API Docs
+        log.info("[LlmService] Step 4/4 - api_docs");
+        String apiContext = baseContext
+                + "\n\n--- Subsystem Summaries ---\n" + toJson(subsystemSummaries)
+                + "\n\n--- Scenario Specs ---\n" + toJson(scenarioSpecs);
+        JsonNode apiDocs = callClaude(PROMPT_API_DOCS, apiContext);
+        artifactService.saveJsonArtifact(run, ArtifactKind.LLM_API_DOCS,
+                "1.0", PATH_API_DOCS, apiDocs);
+
+        log.info("[LlmService] Refinement complete. runId={}", request.getRunId());
+
+        LlmResult llmResult = LlmResult.builder()
+                .runId(request.getRunId())
+                .refinedRules(refinedRules)
+                .scenarioSpecs(scenarioSpecs)
+                .subsystemSummaries(subsystemSummaries)
+                .apiDocs(apiDocs)
+                .build();
+
+        return new LlmResponse(request.getRunId(), llmResult);
+    }
+
+    // ── Private Helpers ───────────────────────────────────────────────────────
+
+    // RestClient로 /v1/messages 호출 후 parseResponse()
+    private JsonNode callClaude(String systemPrompt, String userMessage) {
+        String requestBody = buildRequestBody(systemPrompt, userMessage);
+
+        String raw = claudeRestClient.post()
+                .uri("/v1/messages")
+                .body(requestBody)
+                .retrieve()
+                .body(String.class);
+
+        return parseResponse(raw);
+    }
+
+    // Anthropic API 규격에 맞는 요청 JSON 생성 (system + messages)
+    private String buildRequestBody(String systemPrompt, String userMessage) {
+        try {
+            ObjectNode root = objectMapper.createObjectNode();
+            root.put("model", llmConfig.getModel());
+            root.put("max_tokens", llmConfig.getMaxTokens());
+            root.put("system", systemPrompt);
+
+            ArrayNode messages = root.putArray("messages");
+            ObjectNode userMsg = messages.addObject();
+            userMsg.put("role", "user");
+            userMsg.put("content", userMessage);
+
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to build Claude request body", e);
+        }
+    }
+
+    // Claude 응답의 content[].text 블록 추출 후 JsonNode로 파싱
+    private JsonNode parseResponse(String raw) {
+        try {
+            JsonNode root = objectMapper.readTree(raw);
+
+            if (root.has("error")) {
+                String msg = root.path("error").path("message").asText("unknown");
+                throw new RuntimeException("Claude API error: " + msg);
+            }
+
+            String text = "";
+            for (JsonNode block : root.path("content")) {
+                if ("text".equals(block.path("type").asText())) {
+                    text = block.path("text").asText();
+                    break;
+                }
+            }
+
+            return objectMapper.readTree(stripFence(text.trim()));
+        } catch (JsonProcessingException e) {
+            log.error("[LlmService] Failed to parse Claude response: {}", raw);
+            throw new RuntimeException("LLM response is not valid JSON", e);
+        }
+    }
+
+    // LLM이 응답을 ```json ```으로 감쌀 경우 제거
+    private String stripFence(String text) {
+        if (!text.startsWith("```")) return text;
+        int firstNewline = text.indexOf('\n');
+        int lastFence = text.lastIndexOf("```");
+        if (firstNewline >= 0 && lastFence > firstNewline) {
+            return text.substring(firstNewline + 1, lastFence).trim();
+        }
+        return text;
+    }
+
+    // 구조 엔진 출력 + Evidence 스니펫을 하나의 텍스트로 합침
+    // structureEngineOutput + evidenceBundle을 Claude에 보낼 텍스트로 조합
+    private String buildContext(LlmRequest request) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("=== Structure Engine Output ===\n");
+        sb.append(toJson(request.getStructureEngineOutput()));
+        sb.append("\n\n=== Evidence Bundle ===\n");
+
+        for (LlmRequest.EvidenceSnippet ev : request.getEvidenceBundle()) {
+            sb.append("# Evidence ").append(ev.getEvidenceId())
+                    .append(" [").append(ev.getEvidenceType()).append("]\n");
+            sb.append("File: ").append(ev.getFilePath())
+                    .append(" (lines ").append(ev.getStartLine())
+                    .append("-").append(ev.getEndLine()).append(")\n");
+            sb.append(ev.getSnippet()).append("\n\n");
+        }
+
+        return sb.toString();
+    }
+
+    // JsonNode/Map 모두 처리 가능한 범용 직렬화
+    private String toJson(Object obj) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            return obj.toString();
+        }
+    }
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2>전체 흐름</h2>
<pre><code>클라이언트
    │
    │  POST /api/v1/llm/refine
    │  { runId, structureEngineOutput, evidenceBundle }
    ▼
LlmController
    │  @Valid 검증 후 LlmService.refine() 호출
    ▼
LlmService.refine()
    │
    ├─ 1. RepoRun DB 조회 (runId로 존재 여부 확인)
    │
    ├─ 2. buildContext() → 구조 엔진 출력 + Evidence 스니펫을 하나의 텍스트로 합침
    │
    ├─ 3. Claude API 4회 순차 호출
    │      Step 1 → refined_rules        (규칙 후보 병합/이름/분류)
    │      Step 2 → scenario_specs       (시나리오 문장화 + 근거 링크)
    │      Step 3 → subsystem_summaries  (서브시스템 라벨링)
    │      Step 4 → api_docs             (Public API 문서화)
    │      ※ 각 단계 결과가 다음 단계 컨텍스트에 누적됨
    │
    ├─ 4. 각 단계 결과를 Artifact로 DB 저장
    │      llm/refined_rules.json
    │      llm/scenario_specs.json
    │      llm/subsystem_summaries.json
    │      llm/api_docs.json
    │
    └─ 5. LlmResponse 반환
    ▼
클라이언트
    { runId, refinedRules, scenarioSpecs, subsystemSummaries, apiDocs }
</code></pre>
<hr>
<h2>파일별 역할</h2>
<h3>LlmConfig.java</h3>
<pre><code>global/config/LlmConfig.java
</code></pre>
<ul>
<li><code>application.yml</code>의 <code>claude.*</code> 설정값을 바인딩</li>
<li><code>RestClient</code> Bean을 생성해서 Anthropic API 공통 헤더(x-api-key, anthropic-version) 주입</li>
<li><code>spring-webflux</code> 없이 Spring Boot 기본 <code>RestClient</code>(동기 방식) 사용</li>
</ul>
<pre><code class="language-yaml"># application.yml
claude:
  api-key: ${CLAUDE_API_KEY}   # 환경변수로 주입 필수
  model: claude-sonnet-4-5
  max-tokens: 8192
</code></pre>
<hr>
<h3>LlmRequest.java</h3>
<pre><code>global/llm/dto/request/LlmRequest.java
</code></pre>

필드 | 타입 | 설명
-- | -- | --
runId | String | 어떤 RepoRun에 대한 정제인지 (RepoRun PK)
structureEngineOutput | Map<String, Object> | 구조 엔진 분석 결과 JSON
evidenceBundle | List<EvidenceSnippet> | 근거 코드 스니펫 목록


<hr>
<h3>ArtifactKind.java (추가된 항목)</h3>
<pre><code>domain/artifact/enums/ArtifactKind.java
</code></pre>
<p>LLM 결과물 저장을 위해 아래 4개 enum 값 추가:</p>
<pre><code class="language-java">LLM_REFINED_RULES
LLM_SCENARIO_SPECS
LLM_SUBSYSTEM_SUMMARIES
LLM_API_DOCS
</code></pre>
<hr>
<h2>실행 전 필수 설정</h2>
<p>환경변수 <code>CLAUDE_API_KEY</code> 세팅 필요.</p>
<pre><code class="language-bash"># IntelliJ Run Configuration → Environment Variables
CLAUDE_API_KEY=sk-ant-api03-...
</code></pre>
※ 자세한 키는 노션 application.yml에 올려둠.<br>
※ 연동은 잘 된거 확인했으나, LlmService 로직 경우 우리 파이프 라인 변경에 따라 수정이 필요.<br>
※ LLm 사용 전 리펙토링 필수 요청!!!!!<br>
<!-- notionvc: ceada2ec-9313-4ccb-acbc-d47894a2b4a0 --><!--EndFragment-->
</body>
</html>