### PR TITLE
[#10]Feat:Spring 씨큐리티 적용 (구글 연동)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
+
     // PostgreSQL
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/example/ossdoc/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.example.ossdoc.domain.auth.controller;
+
+import com.example.ossdoc.domain.auth.dto.response.CurrentUserResponse;
+import com.example.ossdoc.domain.auth.service.AuthService;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/me")
+    public ApiResponse<CurrentUserResponse> me(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        return ApiResponse.onSuccess(authService.getCurrentUser(authenticatedUser));
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<String> refresh(HttpServletRequest request, HttpServletResponse response) {
+        authService.refresh(request, response);
+        return ApiResponse.onSuccess("토큰 재발급 완료");
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<String> logout(HttpServletResponse response,
+                                      @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        authService.logout(response, authenticatedUser);
+        return ApiResponse.onSuccess("로그아웃 완료");
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/dto/response/CurrentUserResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/dto/response/CurrentUserResponse.java
@@ -1,0 +1,9 @@
+package com.example.ossdoc.domain.auth.dto.response;
+
+public record CurrentUserResponse(
+        Long userId,
+        String email,
+        String name,
+        String role
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.auth.entity;
+
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, length = 1000)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    public void rotate(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+
+    public boolean matches(String token) {
+        return this.token.equals(token);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.auth.exception;
+
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class AuthException extends GeneralException{
+    public AuthException(BaseCode code) {
+        super(code);
+    }
+
+    public AuthException(AuthErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
@@ -1,0 +1,47 @@
+package com.example.ossdoc.domain.auth.exception.code;
+
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseCode {
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_002", "접근 권한이 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "만료된 토큰입니다."),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH_005", "잘못된 토큰 타입입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_006", "리프레시 토큰이 없습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_007", "리프레시 토큰이 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_008", "사용자를 찾을 수 없습니다."),
+    INACTIVE_USER(HttpStatus.FORBIDDEN, "AUTH_009", "비활성화된 사용자입니다."),
+    OAUTH2_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_010", "구글 로그인 처리에 실패했습니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "AUTH_0011", "인증 사용자 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.auth.repository;
+
+import com.example.ossdoc.domain.auth.entity.RefreshToken;
+import com.example.ossdoc.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUser(User user);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/service/AuthService.java
@@ -1,0 +1,157 @@
+package com.example.ossdoc.domain.auth.service;
+
+import com.example.ossdoc.domain.auth.dto.response.CurrentUserResponse;
+import com.example.ossdoc.domain.auth.entity.RefreshToken;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.repository.RefreshTokenRepository;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.repository.UserRepository;
+import com.example.ossdoc.global.properties.AuthProperties;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import com.example.ossdoc.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthProperties authProperties;
+
+    @Transactional
+    public void issueLoginTokens(User user, HttpServletResponse response) {
+        String accessToken = jwtTokenProvider.generateAccessToken(user);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        LocalDateTime refreshExpiresAt =
+                LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenMaxAgeSeconds());
+
+        refreshTokenRepository.findByUser(user)
+                .ifPresentOrElse(
+                        saved -> saved.rotate(refreshToken, refreshExpiresAt),
+                        () -> refreshTokenRepository.save(
+                                RefreshToken.builder()
+                                        .user(user)
+                                        .token(refreshToken)
+                                        .expiresAt(refreshExpiresAt)
+                                        .build()
+                        )
+                );
+
+        addCookie(response, authProperties.getAccessCookieName(), accessToken, jwtTokenProvider.getAccessTokenMaxAgeSeconds());
+        addCookie(response, authProperties.getRefreshCookieName(), refreshToken, jwtTokenProvider.getRefreshTokenMaxAgeSeconds());
+    }
+
+    @Transactional
+    public void refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = getCookieValue(request, authProperties.getRefreshCookieName());
+        if (refreshToken == null) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByUser(user)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        if (savedRefreshToken.isExpired(LocalDateTime.now())) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        }
+
+        if (!savedRefreshToken.matches(refreshToken)) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        savedRefreshToken.rotate(
+                newRefreshToken,
+                LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenMaxAgeSeconds())
+        );
+
+        addCookie(response, authProperties.getAccessCookieName(), newAccessToken, jwtTokenProvider.getAccessTokenMaxAgeSeconds());
+        addCookie(response, authProperties.getRefreshCookieName(), newRefreshToken, jwtTokenProvider.getRefreshTokenMaxAgeSeconds());
+    }
+
+    @Transactional
+    public void logout(HttpServletResponse response, AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser != null) {
+            User user = userRepository.findById(authenticatedUser.getUserId())
+                    .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+            refreshTokenRepository.deleteByUser(user);
+        }
+
+        deleteCookie(response, authProperties.getAccessCookieName());
+        deleteCookie(response, authProperties.getRefreshCookieName());
+    }
+
+    public CurrentUserResponse getCurrentUser(AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        User user = userRepository.findById(authenticatedUser.getUserId())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        return new CurrentUserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name()
+        );
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, long maxAgeSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(authProperties.isSecureCookie())
+                .path("/")
+                .sameSite(authProperties.getSameSite())
+                .maxAge(maxAgeSeconds)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(authProperties.isSecureCookie())
+                .path("/")
+                .sameSite(authProperties.getSameSite())
+                .maxAge(0)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/controller/RepoRunController.java
+++ b/src/main/java/com/example/ossdoc/domain/run/controller/RepoRunController.java
@@ -1,12 +1,15 @@
-// domain/run/controller/RepoRunController.java
 package com.example.ossdoc.domain.run.controller;
 
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.run.dto.RepoRunCreateRequest;
 import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
 import com.example.ossdoc.domain.run.service.RepoRunService;
 import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,8 +20,13 @@ public class RepoRunController {
     private final RepoRunService repoRunService;
 
     @PostMapping
-    public ApiResponse<RepoRunCreateResponse> create(@Valid @RequestBody RepoRunCreateRequest request) {
-        RepoRunCreateResponse response = repoRunService.createRun(request);
+    public ApiResponse<RepoRunCreateResponse> create(@Valid @RequestBody RepoRunCreateRequest request,
+                                                     @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
+
+        RepoRunCreateResponse response = repoRunService.createRun(request, authenticatedUser.getUserId());
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
+++ b/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
@@ -1,6 +1,7 @@
 package com.example.ossdoc.domain.run.entity;
 
 import com.example.ossdoc.domain.run.enums.RunStatus;
+import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
 import com.example.ossdoc.global.apiPayload.code.BaseCreatedEntity;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,6 +23,10 @@ public class RepoRun extends BaseAuditedEntity {
     @Id
     @Column(name = "run_id", nullable = false)
     private String runId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
 
     @Column(name = "repo_url", nullable = false)
     private String repoUrl;
@@ -48,4 +53,8 @@ public class RepoRun extends BaseAuditedEntity {
 
     @Column(name = "workspace_root")
     private String workspaceRoot;
+
+    public void assignOwner(User owner) {
+        this.owner = owner;
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -3,12 +3,16 @@ package com.example.ossdoc.domain.run.service;
 
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.run.dto.RepoRunCreateRequest;
 import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.domain.run.support.*;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +28,7 @@ import java.util.UUID;
 public class RepoRunService {
 
     private final RepoRunRepository repoRunRepository;
+    private final UserRepository userRepository;
     private final ArtifactService artifactService;
 
     private final GithubClient githubClient;
@@ -31,7 +36,11 @@ public class RepoRunService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public RepoRunCreateResponse createRun(RepoRunCreateRequest req) {
+    public RepoRunCreateResponse createRun(RepoRunCreateRequest req, Long userId) {
+        User owner= userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+
         // 1) URL 파싱
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
 
@@ -66,6 +75,7 @@ public class RepoRunService {
         // 7) DB 저장 (RepoRun)
         RepoRun run = new RepoRun(
                 runId,
+                owner,
                 req.getRepoUrl(),
                 commitSha,
                 RunStatus.QUEUED,

--- a/src/main/java/com/example/ossdoc/domain/user/entity/User.java
+++ b/src/main/java/com/example/ossdoc/domain/user/entity/User.java
@@ -1,0 +1,57 @@
+package com.example.ossdoc.domain.user.entity;
+
+import com.example.ossdoc.domain.user.enums.AuthProvider;
+import com.example.ossdoc.domain.user.enums.UserRole;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_provider_provider_id", columnNames = {"provider", "provider_id"}),
+                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean active = true;
+
+    public void updateProfile(String email, String name) {
+        this.email = email;
+        this.name = name;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/user/enums/AuthProvider.java
+++ b/src/main/java/com/example/ossdoc/domain/user/enums/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.example.ossdoc.domain.user.enums;
+
+public enum AuthProvider {
+    GOOGLE
+}

--- a/src/main/java/com/example/ossdoc/domain/user/enums/UserRole.java
+++ b/src/main/java/com/example/ossdoc/domain/user/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.ossdoc.domain.user.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/ossdoc/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.user.repository;
+
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.enums.AuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
@@ -1,0 +1,92 @@
+package com.example.ossdoc.global.config;
+
+import com.example.ossdoc.global.properties.AuthProperties;
+import com.example.ossdoc.global.security.jwt.JwtAuthenticationFilter;
+import com.example.ossdoc.global.security.oauth.CustomOidcUserService;
+import com.example.ossdoc.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CorsConfigurationSource corsConfigurationSource;
+    private final CustomOidcUserService customOidcUserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final AuthProperties authProperties;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) ->
+                                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                writeError(response, HttpServletResponse.SC_FORBIDDEN, "AUTH_002", "접근 권한이 없습니다."))
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/actuator/health"
+                        ).permitAll()
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/me").authenticated()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .oidcUserService(customOidcUserService)
+                        )
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler((request, response, exception) ->
+                                response.sendRedirect(authProperties.getFrontendFailureRedirectUri()))
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    private void writeError(HttpServletResponse response, int status, String code, String message) throws java.io.IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("isSuccess", false);
+        body.put("code", code);
+        body.put("message", message);
+        body.put("result", null);
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/config/WebConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/WebConfig.java
@@ -1,0 +1,35 @@
+package com.example.ossdoc.global.config;
+
+import com.example.ossdoc.global.properties.CorsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig {
+
+    private final CorsProperties corsProperties;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Set-Cookie"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/properties/AuthProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/AuthProperties.java
@@ -1,0 +1,20 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.auth")
+public class AuthProperties {
+
+    private String frontendSuccessRedirectUri;
+    private String frontendFailureRedirectUri;
+    private String accessCookieName;
+    private String refreshCookieName;
+    private boolean secureCookie;
+    private String sameSite;
+}

--- a/src/main/java/com/example/ossdoc/global/properties/CorsProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/CorsProperties.java
@@ -1,0 +1,18 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/global/properties/JwtProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String issuer;
+    private String secret;
+    private long accessExpirationMs;
+    private long refreshExpirationMs;
+}

--- a/src/main/java/com/example/ossdoc/global/security/jwt/AuthenticatedUser.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/AuthenticatedUser.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.global.security.jwt;
+
+import com.example.ossdoc.domain.user.enums.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthenticatedUser {
+
+    private Long userId;
+    private String email;
+    private UserRole role;
+}

--- a/src/main/java/com/example/ossdoc/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package com.example.ossdoc.global.security.jwt;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import com.example.ossdoc.global.properties.AuthProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthProperties authProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        return uri.startsWith("/oauth2/")
+                || uri.startsWith("/login/oauth2/")
+                || uri.startsWith("/swagger-ui/")
+                || uri.startsWith("/v3/api-docs")
+                || uri.equals("/actuator/health")
+                || uri.equals("/api/v1/auth/refresh")
+                || uri.equals("/api/v1/auth/logout");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            String token = resolveToken(request);
+
+            if (StringUtils.hasText(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (AuthException e) {
+            SecurityContextHolder.clearContext();
+
+            ReasonDTO reason = e.getErrorReasonHttpStatus();
+
+            response.setStatus(reason.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("isSuccess", reason.getIsSuccess());
+            body.put("code", reason.getCode());
+            body.put("message", reason.getMessage());
+            body.put("result", null);
+
+            objectMapper.writeValue(response.getWriter(), body);
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return getCookieValue(request, authProperties.getAccessCookieName());
+    }
+
+    private String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,119 @@
+package com.example.ossdoc.global.security.jwt;
+
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.enums.UserRole;
+import com.example.ossdoc.global.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateAccessToken(User user) {
+        return Jwts.builder()
+                .issuer(jwtProperties.getIssuer())
+                .subject(String.valueOf(user.getId()))
+                .claim("email", user.getEmail())
+                .claim("role", user.getRole().name())
+                .claim("tokenType", "access")
+                .issuedAt(new java.util.Date())
+                .expiration(new java.util.Date(System.currentTimeMillis() + jwtProperties.getAccessExpirationMs()))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(User user) {
+        return Jwts.builder()
+                .issuer(jwtProperties.getIssuer())
+                .subject(String.valueOf(user.getId()))
+                .claim("tokenType", "refresh")
+                .issuedAt(new java.util.Date())
+                .expiration(new java.util.Date(System.currentTimeMillis() + jwtProperties.getRefreshExpirationMs()))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        String tokenType = claims.get("tokenType", String.class);
+        if (!"access".equals(tokenType)) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+
+        Long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+        UserRole role = UserRole.valueOf(claims.get("role", String.class));
+
+        AuthenticatedUser principal = AuthenticatedUser.builder()
+                .userId(userId)
+                .email(email)
+                .role(role)
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                accessToken,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+    }
+
+    public Long getUserIdFromRefreshToken(String refreshToken) {
+        Claims claims = parseClaims(refreshToken);
+
+        String tokenType = claims.get("tokenType", String.class);
+        if (!"refresh".equals(tokenType)) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public long getAccessTokenMaxAgeSeconds() {
+        return jwtProperties.getAccessExpirationMs() / 1000;
+    }
+
+    public long getRefreshTokenMaxAgeSeconds() {
+        return jwtProperties.getRefreshExpirationMs() / 1000;
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2User.java
@@ -1,0 +1,52 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OidcUser {
+
+    private final User user;
+    private final OidcUser oidcUser;
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return oidcUser.getClaims();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return oidcUser.getUserInfo();
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return oidcUser.getIdToken();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oidcUser.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUserService.java
@@ -1,0 +1,55 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.enums.AuthProvider;
+import com.example.ossdoc.domain.user.enums.UserRole;
+import com.example.ossdoc.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OidcUser loadUser(OidcUserRequest userRequest) {
+        OidcUser oidcUser = super.loadUser(userRequest);
+
+        String providerId = (String) oidcUser.getAttributes().get("sub");
+        String email = (String) oidcUser.getAttributes().get("email");
+        String name = (String) oidcUser.getAttributes().get("name");
+
+        if (providerId == null || email == null) {
+            throw new AuthException(AuthErrorCode.OAUTH2_LOGIN_FAILED);
+        }
+
+        User user = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, providerId)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .provider(AuthProvider.GOOGLE)
+                                .providerId(providerId)
+                                .email(email)
+                                .name(name)
+                                .role(UserRole.USER)
+                                .active(true)
+                                .build()
+                ));
+
+        if (!Boolean.TRUE.equals(user.getActive())) {
+            throw new AuthException(AuthErrorCode.INACTIVE_USER);
+        }
+
+        user.updateProfile(email, name);
+
+        return new CustomOAuth2User(user, oidcUser);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.domain.auth.service.AuthService;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.global.properties.AuthProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+    private final AuthProperties authProperties;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
+        User user = principal.getUser();
+
+        authService.issueLoginTokens(user, response);
+        clearAuthenticationAttributes(request);
+
+        getRedirectStrategy().sendRedirect(request, response, authProperties.getFrontendSuccessRedirectUri());
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/util/AuthUtil.java
+++ b/src/main/java/com/example/ossdoc/global/util/AuthUtil.java
@@ -1,0 +1,27 @@
+package com.example.ossdoc.global.util;
+
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthUtil {
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof AuthenticatedUser user) {
+            return user.getUserId();
+        }
+
+        throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+    }
+}


### PR DESCRIPTION
[#10 ] Spring 씨큐리티 적용 (구글 연동)

**Google OAuth2 로그인 후 JWT access/refresh 쿠키를 발급하고, JWT 필터로 보호 API 인증 구조를 적용**

### 주요 변경사항
SecurityConfig에 OAuth2 로그인, 예외 응답, JWT 필터 체인을 설정하고 Swagger/OAuth 경로를 허용

### 추가 보완사항
@AuthenticationPrincipal null 방어와 인증 예외 코드를 추가해 인증 누락 시 500 대신 예외 응답하도록 보완

### 인증 흐름
1. 사용자가 /oauth2/authorization/google 로 구글 로그인을 시작
2. 구글 인증 성공 후 CustomOidcUserService 가 사용자 정보를 조회·저장
3. OAuth2LoginSuccessHandler 가 access/refresh 토큰을 생성해 쿠키로 발급
4. 이후 API 요청 시 JwtAuthenticationFilter 가 헤더 또는 쿠키에서 access 토큰을 확인
5. JwtTokenProvider 가 토큰을 검증하고 AuthenticatedUser 를 생성해 인증 정보를 저장
6. 컨트롤러는 @AuthenticationPrincipal 로 인증 사용자를 받아 보호 API를 처리
7. access 토큰 만료 시 refresh 토큰으로 재발급하고, logout 시 refresh 토큰과 쿠키를 제거