### PR TITLE
feat: S3 기반 JSON 저장소 연동 및 경로 관리(#12)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,11 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
 
     implementation 'org.springframework:spring-webflux'
+
+    // AWS SDK v2 (S3)
+    implementation platform('software.amazon.awssdk:bom:2.25.60')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
@@ -1,32 +1,118 @@
-// domain/artifact/service/ArtifactService.java
 package com.example.ossdoc.domain.artifact.service;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.global.s3.exception.S3Exception;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+import com.example.ossdoc.global.s3.util.S3Util;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Artifact 저장 서비스.
+ *
+ * <p><b>저장 흐름</b>
+ * <pre>
+ *   1. JSON 직렬화  →  실패 시 S3Exception(S3_500_003)
+ *   2. S3 업로드    →  실패 시 S3Exception(S3_500_001)
+ *   3. DB 저장      →  Artifact.path = S3 HTTPS URL
+ * </pre>
+ *
+ * <p><b>S3 키 구조</b>
+ * <pre>
+ *   artifacts/
+ *   └── {runId}/
+ *       ├── job_manifest.json
+ *       ├── build_manifest.json
+ *       ├── facts.json
+ *       ├── graph_stats.json
+ *       └── llm/
+ *           ├── refined_rules.json
+ *           ├── scenario_specs.json
+ *           ├── subsystem_summaries.json
+ *           └── api_docs.json
+ * </pre>
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ArtifactService {
 
     private final ArtifactRepository artifactRepository;
+    private final S3Util             s3Util;
+    private final ObjectMapper       objectMapper;
 
+    /**
+     * JSON Artifact를 S3에 업로드하고 DB에 URL 경로를 저장한다.
+     *
+     * @param run           연관된 RepoRun
+     * @param kind          Artifact 종류 (ArtifactKind 열거형)
+     * @param schemaVersion JSON 스키마 버전 문자열 (예: "1.0")
+     * @param relativePath  S3 상의 상대 경로 (예: "llm/refined_rules.json")
+     *                      — runId 프리픽스는 자동으로 붙음
+     * @param content       저장할 JSON 본문
+     * @return              저장된 Artifact 엔티티 (path = S3 HTTPS URL)
+     * @throws S3Exception  직렬화 실패(S3_500_003) 또는 업로드 실패(S3_500_001) 시
+     */
     @Transactional
-    public Artifact saveJsonArtifact(RepoRun run, ArtifactKind kind, String schemaVersion, String path, JsonNode meta) {
+    public Artifact saveJsonArtifact(RepoRun run,
+                                     ArtifactKind kind,
+                                     String schemaVersion,
+                                     String relativePath,
+                                     JsonNode content) {
+
+        // 1. JSON 직렬화
+        String jsonBody = serialize(content);
+
+        // 2. S3 업로드  (키 = artifacts/{runId}/{relativePath})
+        String s3Key = buildS3Key(run.getRunId(), relativePath);
+        String s3Url = s3Util.uploadJson(s3Key, jsonBody);
+
+        log.info("[ArtifactService] S3 업로드 완료 — kind: {}, url: {}", kind, s3Url);
+
+        // 3. DB 저장 (path = S3 URL)
         Artifact artifact = new Artifact(
                 null,
                 run,
                 kind,
-                schemaVersion,        // 예: "0.1"
+                schemaVersion,
                 "application/json",
-                path,
-                meta
+                s3Url,
+                content
         );
+
         return artifactRepository.save(artifact);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * S3 객체 키 조립.
+     * buildS3Key("run_20260315_abc12345", "llm/refined_rules.json")
+     *   → "artifacts/run_20260315_abc12345/llm/refined_rules.json"
+     */
+    private String buildS3Key(String runId, String relativePath) {
+        String clean = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+        return String.format("artifacts/%s/%s", runId, clean);
+    }
+
+    /**
+     * JsonNode → JSON 문자열 변환.
+     * 실패 시 IllegalStateException 대신 프로젝트 공통 S3Exception 으로 변환한다.
+     */
+    private String serialize(JsonNode node) {
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            log.error("[ArtifactService] JSON 직렬화 실패 — {}", e.getMessage());
+            throw new S3Exception(S3ErrorCode.JSON_SERIALIZE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
@@ -97,7 +97,8 @@ public class BuildResolveService {
                                 .anyMatch(m -> m.getClassesDirs() != null && !m.getClassesDirs().isEmpty()));
 
         // Artifact 등록(너희 artifact 도메인에 이미 있으니 재사용)
-        artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST,"0.1", buildManifestPath.toString(), meta);
+        artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
+                "build_manifest.json", meta);
 
         return new BuildResolveResponse(runId, manifest.getBuildMode(), buildManifestPath.toString());
     }

--- a/src/main/java/com/example/ossdoc/domain/run/dto/RepoRunCreateResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/RepoRunCreateResponse.java
@@ -1,4 +1,3 @@
-// domain/run/dto/RepoRunCreateResponse.java
 package com.example.ossdoc.domain.run.dto;
 
 import com.example.ossdoc.domain.run.enums.RunStatus;
@@ -12,5 +11,4 @@ public class RepoRunCreateResponse {
     private RunStatus status;
     private String commitSha;
     private String workspaceRoot;
-    private String jobManifestPath;
 }

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -1,4 +1,3 @@
-// domain/run/service/RepoRunService.java
 package com.example.ossdoc.domain.run.service;
 
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
@@ -37,9 +36,8 @@ public class RepoRunService {
 
     @Transactional
     public RepoRunCreateResponse createRun(RepoRunCreateRequest req, Long userId) {
-        User owner= userRepository.findById(userId)
+        User owner = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-
 
         // 1) URL 파싱
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
@@ -54,25 +52,18 @@ public class RepoRunService {
         String commitSha = githubClient.resolveCommitSha(parsed.getOwner(), parsed.getRepo(), ref);
 
         // 4) runId / workspace 경로
-        String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "") + "_" + UUID.randomUUID().toString().substring(0, 8);
+        String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "")
+                + "_" + UUID.randomUUID().toString().substring(0, 8);
         Path wsRoot = workspaceManager.workspaceRoot(runId);
 
         // 5) zip 다운로드 → unzip
         Path zipPath = wsRoot.resolve("repo.zip");
         githubClient.downloadZip(parsed.getOwner(), parsed.getRepo(), commitSha, zipPath);
 
-        // GitHub zip은 보통 최상위 폴더가 "{repo}-{sha}" 형태로 한 번 감싸져 있음
         Path unzipRoot = wsRoot.resolve("repo");
         ZipUtils.unzip(zipPath, unzipRoot);
 
-        // 6) job_manifest.json 생성
-        Path manifestPath = workspaceManager.writeJobManifest(
-                wsRoot, runId, req.getRepoUrl(),
-                parsed.getOwner(), parsed.getRepo(),
-                ref, commitSha, unzipRoot
-        );
-
-        // 7) DB 저장 (RepoRun)
+        // 6) DB 저장 (RepoRun)
         RepoRun run = new RepoRun(
                 runId,
                 owner,
@@ -87,20 +78,20 @@ public class RepoRunService {
         );
         repoRunRepository.save(run);
 
-        // 8) DB 저장 (Artifact - job_manifest)
+        // 7) job_manifest Artifact → S3 + DB 저장 (로컬 파일 없이 meta 직접 구성)
         ObjectNode meta = objectMapper.createObjectNode();
         meta.put("ref", ref);
         meta.put("commitSha", commitSha);
         meta.put("generatedAt", OffsetDateTime.now().toString());
 
-        artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1", manifestPath.toString(), meta);
+        artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1",
+                "job_manifest.json", meta);
 
         return RepoRunCreateResponse.builder()
                 .runId(runId)
                 .status(run.getStatus())
                 .commitSha(commitSha)
                 .workspaceRoot(wsRoot.toString())
-                .jobManifestPath(manifestPath.toString())
                 .build();
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
@@ -1,85 +1,22 @@
-// domain/run/support/WorkspaceManager.java
 package com.example.ossdoc.domain.run.support;
 
-import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
-import com.example.ossdoc.domain.run.exception.RunException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.OffsetDateTime;
 
-@Slf4j
 @Component
-@RequiredArgsConstructor
 public class WorkspaceManager {
 
-    private final ObjectMapper objectMapper;
-
     // TODO: application.yml로 빼는 걸 추천 (ex. ossdoc.workspace.base-dir=/data/ossdoc)
-    // 모든 Run 작업이 저장되는 루트 경로
     private final String baseDir = "/data/ossdoc";
 
-    // 특정 Run의 최상위 작업 디렉토리 경로 반환
-    /**
-     이 디렉토리 안에: unzip된 소스,
-     artifacts,
-     facts.json,
-     graph.json,
-     build 결과,
-     전부 들어가게 됨
-     **/
+    /** 특정 Run의 최상위 작업 디렉토리 경로 반환 */
     public Path workspaceRoot(String runId) {
         return Path.of(baseDir, runId);
     }
 
-    // 분석 결과물이 저장될 폴더 경로 반환 (job_manifest.json, build_manifest.json, facts.json, graph_stats.json, rule_candidates.json, rendered diagrams)
+    /** 분석 결과물이 저장될 폴더 경로 반환 */
     public Path artifactsDir(Path workspaceRoot) {
         return workspaceRoot.resolve("artifacts");
-    }
-
-    // Run이 어떤 코드 스냅샷을 분석했는지 기록하는 공식 선언문 생성 (job_manifest.json)
-    public Path writeJobManifest(
-            Path workspaceRoot,
-            String runId,
-            String repoUrl,
-            String owner,
-            String repo,
-            String ref,
-            String commitSha,
-            Path unzipRoot
-    ) {
-        try {
-            Files.createDirectories(artifactsDir(workspaceRoot));
-            Path manifestPath = artifactsDir(workspaceRoot).resolve("job_manifest.json");
-
-            ObjectNode root = objectMapper.createObjectNode();
-            ObjectNode repoRun = root.putObject("repoRun");
-            repoRun.put("runId", runId);
-
-            ObjectNode source = repoRun.putObject("source");
-            source.put("type", "github");
-            source.put("url", repoUrl);
-            source.put("owner", owner);
-            source.put("repo", repo);
-            source.put("ref", ref);
-            source.put("commitSha", commitSha);
-
-            ObjectNode paths = repoRun.putObject("paths");
-            paths.put("workspaceRoot", workspaceRoot.toString());
-            paths.put("repoRoot", unzipRoot.toString());
-
-            repoRun.put("generatedAt", OffsetDateTime.now().toString());
-
-            Files.writeString(manifestPath, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(root));
-            return manifestPath;
-        } catch (Exception e) {
-            log.debug("manifest write fail error={}", e.getMessage());
-            throw new RunException(RunErrorCode.MANIFEST_WRITE_FAILED);
-        }
     }
 }

--- a/src/main/java/com/example/ossdoc/global/config/S3Config.java
+++ b/src/main/java/com/example/ossdoc/global/config/S3Config.java
@@ -1,0 +1,66 @@
+package com.example.ossdoc.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key:#{null}}")
+    private String accessKeyId;
+
+    @Value("${cloud.aws.credentials.secret-key:#{null}}")
+    private String secretAccessKey;
+
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket:ossdoc-artifact-storage}")
+    private String bucketName;
+
+    @Bean
+    public S3Client s3Client() {
+        Region awsRegion = Region.of(region);
+
+        // 우선순위: yml → 환경변수 → IAM Role(DefaultCredentialsProvider)
+        String keyId     = firstNonBlank(accessKeyId,     System.getenv("AWS_ACCESS_KEY_ID"));
+        String secretKey = firstNonBlank(secretAccessKey, System.getenv("AWS_SECRET_ACCESS_KEY"));
+
+        AwsCredentialsProvider credentialsProvider;
+        if (keyId != null && secretKey != null) {
+            credentialsProvider = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(keyId, secretKey));
+        } else {
+            credentialsProvider = DefaultCredentialsProvider.create();
+        }
+
+        log.info("S3Client initialized — region: {}, bucket: {}", awsRegion, bucketName);
+
+        return S3Client.builder()
+                .region(awsRegion)
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    /** S3 버킷 이름을 Bean으로 노출 — 다른 컴포넌트에서 @Qualifier 없이 주입 가능 */
+    @Bean(name = "s3BucketName")
+    public String s3BucketName() {
+        return bucketName;
+    }
+
+    private String firstNonBlank(String... candidates) {
+        for (String c : candidates) {
+            if (c != null && !c.isBlank()) return c.trim();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/s3/exception/S3Exception.java
+++ b/src/main/java/com/example/ossdoc/global/s3/exception/S3Exception.java
@@ -1,0 +1,11 @@
+package com.example.ossdoc.global.s3.exception;
+
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+
+public class S3Exception extends GeneralException {
+
+    public S3Exception(S3ErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/s3/exception/code/S3ErrorCode.java
+++ b/src/main/java/com/example/ossdoc/global/s3/exception/code/S3ErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.ossdoc.domain.run.exception.code;
+package com.example.ossdoc.global.s3.exception.code;
 
 import com.example.ossdoc.global.apiPayload.code.BaseCode;
 import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
@@ -8,11 +8,23 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum RunErrorCode implements BaseCode {
-    INVALID_REPO_URL(HttpStatus.BAD_REQUEST, "RUN_400_001", "Invalid GitHub repo URL."),
-    GITHUB_API_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_001", "Failed to resolve repo info from GitHub."),
-    DOWNLOAD_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_002", "Failed to download repository zip."),
-    UNZIP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_001", "Failed to unzip repository.");
+public enum S3ErrorCode implements BaseCode {
+
+    // 업로드 실패
+    UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_001", "S3 파일 업로드에 실패했습니다."),
+
+    // 삭제 실패
+    DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_002", "S3 파일 삭제에 실패했습니다."),
+
+    // JSON 직렬화 실패 (업로드 전처리 단계)
+    JSON_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_003", "Artifact JSON 직렬화에 실패했습니다."),
+
+    // 잘못된 S3 키/URL
+    INVALID_S3_KEY(HttpStatus.BAD_REQUEST,
+            "S3_400_001", "유효하지 않은 S3 경로입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ossdoc/global/s3/util/S3Util.java
+++ b/src/main/java/com/example/ossdoc/global/s3/util/S3Util.java
@@ -1,0 +1,137 @@
+package com.example.ossdoc.global.s3.util;
+
+import com.example.ossdoc.global.s3.exception.S3Exception;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * S3 업로드 / 삭제 헬퍼.
+ *
+ * <p>주요 사용처: ArtifactService — LLM이 생성한 JSON을 S3에 저장하고
+ * 반환된 URL을 Artifact.path 컬럼에 기록한다.
+ *
+ * <p>S3 키 규칙:
+ * <pre>
+ *   artifacts/{runId}/{relativePath}
+ *   예) artifacts/run_20260315_abc12345/llm/refined_rules.json
+ * </pre>
+ *
+ * <p>예외: 모든 S3 오류는 {@link S3Exception}으로 변환되어
+ * {@link com.example.ossdoc.global.apiPayload.exception.ExceptionAdvice}에서
+ * 공통 응답 포맷으로 처리된다.
+ */
+@Slf4j
+@Component
+public class S3Util {
+
+    private final S3Client s3Client;
+    private final String   bucketName;
+
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
+    private String region;
+
+    public S3Util(S3Client s3Client,
+                  @Qualifier("s3BucketName") String bucketName) {
+        this.s3Client   = s3Client;
+        this.bucketName = bucketName;
+    }
+
+    // ── Upload ────────────────────────────────────────────────────────────────
+
+    /**
+     * JSON 문자열을 S3에 업로드한다.
+     *
+     * @param key      S3 객체 키 (예: "artifacts/run_xxx/llm/refined_rules.json")
+     * @param jsonBody 업로드할 JSON 문자열
+     * @return         업로드된 객체의 Public HTTPS URL
+     * @throws S3Exception S3_500_001 — 업로드 중 AWS SDK 오류 발생 시
+     */
+    public String uploadJson(String key, String jsonBody) {
+        if (key == null || key.isBlank()) {
+            throw new S3Exception(S3ErrorCode.INVALID_S3_KEY);
+        }
+
+        try {
+            byte[] bytes = jsonBody.getBytes(StandardCharsets.UTF_8);
+
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType("application/json")
+                    .contentLength((long) bytes.length)
+                    .build();
+
+            PutObjectResponse response = s3Client.putObject(request, RequestBody.fromBytes(bytes));
+            log.info("S3 업로드 완료 — key: {}, eTag: {}", key, response.eTag());
+
+            return buildUrl(key);
+
+        } catch (SdkException e) {
+            log.error("S3 업로드 실패 — key: {}, 원인: {}", key, e.getMessage());
+            throw new S3Exception(S3ErrorCode.UPLOAD_FAILED);
+        }
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    /**
+     * S3 URL 또는 키로 객체를 삭제한다.
+     *
+     * @param s3UrlOrKey 전체 S3 URL 또는 키 문자열 모두 허용
+     * @throws S3Exception S3_500_002 — 삭제 중 AWS SDK 오류 발생 시
+     */
+    public void delete(String s3UrlOrKey) {
+        String key = extractKey(s3UrlOrKey);
+        if (key == null || key.isBlank()) {
+            log.warn("S3 삭제 건너뜀 — 키를 추출할 수 없습니다. 입력값: {}", s3UrlOrKey);
+            return;
+        }
+
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build());
+            log.info("S3 삭제 완료 — key: {}", key);
+
+        } catch (SdkException e) {
+            log.error("S3 삭제 실패 — key: {}, 원인: {}", key, e.getMessage());
+            throw new S3Exception(S3ErrorCode.DELETE_FAILED);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * S3 키로부터 HTTPS URL을 조립한다.
+     * 형식: https://{bucket}.s3.{region}.amazonaws.com/{key}
+     */
+    public String buildUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    /**
+     * S3 URL에서 키를 추출한다. 이미 키 형태이면 그대로 반환한다.
+     */
+    public String extractKey(String s3UrlOrKey) {
+        if (s3UrlOrKey == null || s3UrlOrKey.isBlank()) return null;
+
+        String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+        if (s3UrlOrKey.startsWith(prefix)) {
+            return s3UrlOrKey.substring(prefix.length());
+        }
+
+        return s3UrlOrKey;
+    }
+}


### PR DESCRIPTION
LLM 및 빌드 분석 결과로 생성되는 JSON 파일들을 서버 로컬 파일시스템 대신 AWS S3 버킷에 저장하고, 해당 S3 URL을 DB의 Artifact.path 컬럼에 기록하는 방식으로 전환.

기존 구조에서는 분석 결과 JSON을 서버 로컬(/data/ossdoc/{runId}/artifacts/)에 저장하고, 그 절대경로를 DB에 기록
다음과 같은 문제 발생
- 서버 재시작 또는 컨테이너 교체 시 로컬 파일 유실
- 멀티 인스턴스 환경에서 파일 공유 불가
- DB에 로컬 절대경로가 저장되어 환경이 바뀌면 경로가 무효화됨
- JSON 대용량 데이터를 DB에 직접 저장하지 않고 경로만 저장하여 DB를 가볍게 유지하려는 설계 의도와 맞지 않음

S3Config.java (신규)
S3Client Bean을 등록. 자격증명 우선순위는 application.yml → 환경변수(AWS_ACCESS_KEY_ID) → IAM Role 순서. 
버킷 이름은 s3BucketName Bean으로 별도 노출하여 다른 컴포넌트에서 @Qualifier로 주입할 수 있게 함.

S3Util.java (신규)
uploadJson(key, jsonBody) — JSON 문자열을 S3에 업로드하고 HTTPS URL을 반환.
delete(s3UrlOrKey) — S3 URL 또는 키로 객체를 삭제.
모든 AWS SDK 오류는 프로젝트 공통 예외 포맷(S3Exception)으로 변환하여 ExceptionAdvice에서 일관된 응답으로 처리됩니다.

S3ErrorCode.java / S3Exception.java (신규)
기존 프로젝트의 예외 처리 패턴(GeneralException → BaseCode → ExceptionAdvice)을 그대로 따름. 
S3 관련 오류를 공통 응답 포맷으로 통일.

ArtifactService.java (수정)
S3Util을 주입받아 JSON Artifact 저장 흐름을 다음과 같이 변경.
1. JsonNode 직렬화
2. S3 업로드 → 키: artifacts/{runId}/{relativePath}
3. DB 저장 → Artifact.path = S3 HTTPS URL

RepoRunService.java (수정)
기존에는 WorkspaceManager.writeJobManifest()를 통해 로컬에 job_manifest.json 파일을 생성한 뒤, 그 절대경로(manifestPath.toString())를 ArtifactService에 넘김.
S3 방식에서는 JsonNode를 메모리에서 직접 구성해 ArtifactService에 넘기면 자동으로 S3에 업로드되기 때문에, 로컬 파일 생성 단계가 불필요해졌다. 또한 절대경로를 그대로 S3 키에 붙이면 artifacts/run_xxx//data/ossdoc/.../job_manifest.json 같은 잘못된 키가 생성되는 문제도 함께 제거.
relativePath를 "job_manifest.json"으로 고정하여 S3 키가 artifacts/{runId}/job_manifest.json으로 정확히 생성.

WorkspaceManager.java (수정)
writeJobManifest() 메서드를 제거. 이 메서드가 하던 로컬 파일 생성 역할이 RepoRunService에서 ArtifactService를 통한 S3 업로드로 대체되었기 때문이다. ObjectMapper 의존성도 함께 제거되어 클래스가 단순.

RepoRunCreateResponse.java (수정)
jobManifestPath 필드를 제거. 
로컬 파일 경로를 응답으로 내려줄 이유가 사라짐. 파일은 S3에 있고 경로는 DB Artifact.path에서 조회하면 됩니다.

RunErrorCode.java (수정)
writeJobManifest() 제거로 더 이상 사용되지 않는 MANIFEST_WRITE_FAILED 에러 코드를 제거.

BuildResolveService.java (수정)
buildManifestPath.toString() — 즉 로컬 절대경로를 ArtifactService에 넘기던 부분을 "build_manifest.json" 고정 상대경로로 수정. BuildManifestWriter가 로컬에 파일을 쓰는 것은 빌드 실행 흐름상 유지하되, 그 경로를 S3 키로 오용하던 부분만 수정.

- 전체 동작 흐름 -  
 [POST /runs]
RepoRunService
  ├─ GitHub zip 다운로드 & 로컬 압축 해제
  ├─ RepoRun DB 저장 (status = QUEUED)
  └─ ArtifactService.saveJsonArtifact("job_manifest.json")
        ├─ JsonNode 직렬화
        ├─ S3 업로드 → artifacts/{runId}/job_manifest.json
        └─ Artifact DB 저장 (path = S3 URL)

[POST /build/resolve]
BuildResolveService
  ├─ 로컬에서 Gradle/Maven 빌드 실행
  ├─ build_manifest.json 로컬 생성 (빌드 실행에 필요)
  └─ ArtifactService.saveJsonArtifact("build_manifest.json")
        ├─ meta(JsonNode) 직렬화
        ├─ S3 업로드 → artifacts/{runId}/build_manifest.json
        └─ Artifact DB 저장 (path = S3 URL)

[POST /llm/refine]
LlmService
  ├─ Step 1: Claude API → refined_rules
  │     └─ ArtifactService → artifacts/{runId}/llm/refined_rules.json
  ├─ Step 2: Claude API → scenario_specs
  │     └─ ArtifactService → artifacts/{runId}/llm/scenario_specs.json
  ├─ Step 3: Claude API → subsystem_summaries
  │     └─ ArtifactService → artifacts/{runId}/llm/subsystem_summaries.json
  └─ Step 4: Claude API → api_docs
        └─ ArtifactService → artifacts/{runId}/llm/api_docs.json