### PR TITLE
Feat: facts.json 기반 GraphStore 적재 기능 구현(#14)

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/repository/ArtifactRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/repository/ArtifactRepository.java
@@ -1,4 +1,3 @@
-// domain/artifact/repository/ArtifactRepository.java
 package com.example.ossdoc.domain.artifact.repository;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
@@ -8,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
-    Optional<Artifact> findTopByRun_RunIdAndKindOrderByArtifactIdDesc(String runId, ArtifactKind kind);
+
+    Optional<Artifact> findTopByRun_RunIdAndKindOrderByCreatedAtDesc(String runId, ArtifactKind kind);
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/repository/ArtifactRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/repository/ArtifactRepository.java
@@ -2,7 +2,11 @@
 package com.example.ossdoc.domain.artifact.repository;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
+    Optional<Artifact> findTopByRun_RunIdAndKindOrderByArtifactIdDesc(String runId, ArtifactKind kind);
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactContentReader.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactContentReader.java
@@ -1,0 +1,8 @@
+package com.example.ossdoc.domain.artifact.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface ArtifactContentReader {
+    JsonNode readJson(Artifact artifact);
+}

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
@@ -1,43 +1,118 @@
-// domain/artifact/service/ArtifactService.java
 package com.example.ossdoc.domain.artifact.service;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.global.s3.exception.S3Exception;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+import com.example.ossdoc.global.s3.util.S3Util;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Artifact 저장 서비스.
+ *
+ * <p><b>저장 흐름</b>
+ * <pre>
+ *   1. JSON 직렬화  →  실패 시 S3Exception(S3_500_003)
+ *   2. S3 업로드    →  실패 시 S3Exception(S3_500_001)
+ *   3. DB 저장      →  Artifact.path = S3 HTTPS URL
+ * </pre>
+ *
+ * <p><b>S3 키 구조</b>
+ * <pre>
+ *   artifacts/
+ *   └── {runId}/
+ *       ├── job_manifest.json
+ *       ├── build_manifest.json
+ *       ├── facts.json
+ *       ├── graph_stats.json
+ *       └── llm/
+ *           ├── refined_rules.json
+ *           ├── scenario_specs.json
+ *           ├── subsystem_summaries.json
+ *           └── api_docs.json
+ * </pre>
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ArtifactService {
 
     private final ArtifactRepository artifactRepository;
+    private final S3Util             s3Util;
+    private final ObjectMapper       objectMapper;
 
+    /**
+     * JSON Artifact를 S3에 업로드하고 DB에 URL 경로를 저장한다.
+     *
+     * @param run           연관된 RepoRun
+     * @param kind          Artifact 종류 (ArtifactKind 열거형)
+     * @param schemaVersion JSON 스키마 버전 문자열 (예: "1.0")
+     * @param relativePath  S3 상의 상대 경로 (예: "llm/refined_rules.json")
+     *                      — runId 프리픽스는 자동으로 붙음
+     * @param content       저장할 JSON 본문
+     * @return              저장된 Artifact 엔티티 (path = S3 HTTPS URL)
+     * @throws S3Exception  직렬화 실패(S3_500_003) 또는 업로드 실패(S3_500_001) 시
+     */
     @Transactional
-    public Artifact saveJsonArtifact(RepoRun run, ArtifactKind kind, String schemaVersion, String path, JsonNode meta) {
+    public Artifact saveJsonArtifact(RepoRun run,
+                                     ArtifactKind kind,
+                                     String schemaVersion,
+                                     String relativePath,
+                                     JsonNode content) {
+
+        // 1. JSON 직렬화
+        String jsonBody = serialize(content);
+
+        // 2. S3 업로드  (키 = artifacts/{runId}/{relativePath})
+        String s3Key = buildS3Key(run.getRunId(), relativePath);
+        String s3Url = s3Util.uploadJson(s3Key, jsonBody);
+
+        log.info("[ArtifactService] S3 업로드 완료 — kind: {}, url: {}", kind, s3Url);
+
+        // 3. DB 저장 (path = S3 URL)
         Artifact artifact = new Artifact(
                 null,
                 run,
                 kind,
-                schemaVersion,        // 예: "0.1"
+                schemaVersion,
                 "application/json",
-                path,
-                meta
+                s3Url,
+                content
         );
+
         return artifactRepository.save(artifact);
     }
 
-    @Transactional(readOnly = true)
-    public Artifact getLatestArtifact(String runId, ArtifactKind kind) {
-        return artifactRepository.findTopByRun_RunIdAndKindOrderByArtifactIdDesc(runId, kind)
-                .orElse(null);
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * S3 객체 키 조립.
+     * buildS3Key("run_20260315_abc12345", "llm/refined_rules.json")
+     *   → "artifacts/run_20260315_abc12345/llm/refined_rules.json"
+     */
+    private String buildS3Key(String runId, String relativePath) {
+        String clean = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+        return String.format("artifacts/%s/%s", runId, clean);
     }
 
-    @Transactional(readOnly = true)
-    public Artifact getArtifact(Long artifactId) {
-        return artifactRepository.findById(artifactId).orElse(null);
+    /**
+     * JsonNode → JSON 문자열 변환.
+     * 실패 시 IllegalStateException 대신 프로젝트 공통 S3Exception 으로 변환한다.
+     */
+    private String serialize(JsonNode node) {
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            log.error("[ArtifactService] JSON 직렬화 실패 — {}", e.getMessage());
+            throw new S3Exception(S3ErrorCode.JSON_SERIALIZE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactService.java
@@ -29,4 +29,15 @@ public class ArtifactService {
         );
         return artifactRepository.save(artifact);
     }
+
+    @Transactional(readOnly = true)
+    public Artifact getLatestArtifact(String runId, ArtifactKind kind) {
+        return artifactRepository.findTopByRun_RunIdAndKindOrderByArtifactIdDesc(runId, kind)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public Artifact getArtifact(Long artifactId) {
+        return artifactRepository.findById(artifactId).orElse(null);
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/LocalArtifactContentReader.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/LocalArtifactContentReader.java
@@ -1,0 +1,34 @@
+package com.example.ossdoc.domain.artifact.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.graphstore.exception.GraphStoreException;
+import com.example.ossdoc.domain.graphstore.exception.code.GraphStoreErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+@RequiredArgsConstructor
+public class LocalArtifactContentReader implements ArtifactContentReader {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public JsonNode readJson(Artifact artifact) {
+        try {
+            Path path = Path.of(artifact.getPath());
+            if (!Files.exists(path)) {
+                throw new GraphStoreException(GraphStoreErrorCode.FACTS_ARTIFACT_NOT_FOUND);
+            }
+            return objectMapper.readTree(path.toFile());
+        } catch (GraphStoreException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GraphStoreException(GraphStoreErrorCode.FACTS_READ_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/dto/response/BuildResolveResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/build/dto/response/BuildResolveResponse.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 public class BuildResolveResponse {
     private String runId;
     private BuildMode buildMode;
-    private String buildManifestPath; // build_manifest.json 저장 경로
+    private String buildManifestPath; // build_manifest.json S3 URL
 }

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildDetector.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildDetector.java
@@ -1,29 +1,64 @@
 package com.example.ossdoc.domain.build.service;
 
-import com.example.ossdoc.domain.build.enums.BuildToolKind;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+/**
+ * 역할:
+ * 저장소 루트를 검사해 사용 가능한 빌드 도구(Gradle/Maven)를 감지한다.
+ *
+ * 책임:
+ * 1) 빌드 파일 존재 여부 판단
+ * 2) wrapper 존재 여부 판단
+ * 3) 감지 결과를 Detected 레코드로 반환
+ */
 @Component
 public class BuildDetector {
 
+    /**
+     * 역할:
+     * 저장소의 빌드 도구/wrapper 존재 상태를 계산한다.
+     *
+     * 책임:
+     * settings/build/pom/mvnw/gradlew 파일 존재 여부를 조합해 실행 분기 근거를 제공한다.
+     */
     public Detected detect(Path repoRoot) {
+        // Gradle 관련 빌드 파일 존재 여부
         boolean hasGradle = Files.exists(repoRoot.resolve("settings.gradle"))
                 || Files.exists(repoRoot.resolve("settings.gradle.kts"))
                 || Files.exists(repoRoot.resolve("build.gradle"))
                 || Files.exists(repoRoot.resolve("build.gradle.kts"));
 
+        // Maven 관련 빌드 파일 존재 여부
         boolean hasMaven = Files.exists(repoRoot.resolve("pom.xml"));
 
-        boolean gradleWrapper = Files.exists(repoRoot.resolve("gradlew")) || Files.exists(repoRoot.resolve("gradlew.bat"));
-        boolean mavenWrapper = Files.exists(repoRoot.resolve("mvnw")) || Files.exists(repoRoot.resolve("mvnw.cmd"));
+        // 각 도구의 wrapper 존재 여부 (실행 우선순위 판단에 사용)
+        boolean gradleWrapper = Files.exists(repoRoot.resolve("gradlew"))
+                || Files.exists(repoRoot.resolve("gradlew.bat"));
+        boolean mavenWrapper = Files.exists(repoRoot.resolve("mvnw"))
+                || Files.exists(repoRoot.resolve("mvnw.cmd"));
 
-        if (hasGradle) return new Detected(BuildToolKind.GRADLE, gradleWrapper);
-        if (hasMaven)  return new Detected(BuildToolKind.MAVEN, mavenWrapper);
-        return new Detected(BuildToolKind.NONE, false);
+        return new Detected(hasGradle, gradleWrapper, hasMaven, mavenWrapper);
     }
 
-    public record Detected(BuildToolKind tool, boolean wrapperExists) {}
+    public record Detected(
+            boolean hasGradle,
+            boolean gradleWrapperExists,
+            boolean hasMaven,
+            boolean mavenWrapperExists
+    ) {
+        /**
+         * 역할:
+         * 최소 1개 이상의 빌드 도구 존재 여부를 반환한다.
+         *
+         * 책임:
+         * 상위 오케스트레이터가 즉시 실패 처리할지 계속 진행할지 판단할 수 있도록 한다.
+         */
+        // 하나라도 있으면 빌드 도구가 존재하는 것으로 간주
+        public boolean hasAnyBuildTool() {
+            return hasGradle || hasMaven;
+        }
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
@@ -10,22 +10,50 @@ import com.example.ossdoc.domain.build.enums.BuildMode;
 import com.example.ossdoc.domain.build.enums.BuildToolKind;
 import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
-import com.example.ossdoc.domain.build.support.*;
+import com.example.ossdoc.domain.build.support.BuildManifestSelector;
+import com.example.ossdoc.domain.build.support.BuildManifestWriter;
+import com.example.ossdoc.domain.build.support.BuildToolchainSupport;
+import com.example.ossdoc.domain.build.support.GradleBuildSupport;
+import com.example.ossdoc.domain.build.support.GradleDumpParser;
+import com.example.ossdoc.domain.build.support.GradleInitScriptWriter;
+import com.example.ossdoc.domain.build.support.MavenBuildSupport;
+import com.example.ossdoc.domain.build.support.MavenJavaVersionResolver;
+import com.example.ossdoc.domain.build.support.PomModuleScanner;
+import com.example.ossdoc.domain.build.support.ProcessRunner;
+import com.example.ossdoc.domain.build.support.RepoRootResolver;
+import com.example.ossdoc.domain.build.support.SourceOnlyModuleScanner;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.global.config.BuildCommandProperties;
+import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.nio.file.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
+/**
+ * 역할:
+ * 빌드 리졸브 전체 흐름을 오케스트레이션한다.
+ *
+ * 책임:
+ * 1) Run/Workspace/Repo 유효성 검증
+ * 2) 빌드 도구 감지 후 Gradle/Maven 실행 분기
+ * 3) 빌드 매니페스트 산출물 저장 및 응답 반환
+ *
+ * 비책임:
+ * 세부 실행 정책(Gradle 재시도, dump 파싱, 결과 점수화)은 support 클래스로 위임한다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,31 +64,42 @@ public class BuildResolveService {
     private final RepoRootResolver repoRootResolver;
 
     private final BuildDetector buildDetector;
-    private final ProcessRunner processRunner;
-    private final GradleInitScriptWriter gradleInitScriptWriter;
     private final BuildManifestWriter buildManifestWriter;
     private final SourceOnlyModuleScanner sourceOnlyModuleScanner;
     private final PomModuleScanner pomModuleScanner;
     private final MavenBuildSupport mavenBuildSupport;
+    private final MavenJavaVersionResolver mavenJavaVersionResolver;
+    private final BuildCommandProperties buildCommandProperties;
+    private final BuildToolchainSupport buildToolchainSupport;
+    private final BuildManifestSelector buildManifestSelector;
+    private final GradleBuildSupport gradleBuildSupport;
+    private final GradleInitScriptWriter gradleInitScriptWriter;
+    private final GradleDumpParser gradleDumpParser;
 
-    private final ObjectMapper objectMapper;
-
+    /**
+     * 역할:
+     * Build Resolve 유스케이스의 단일 진입점.
+     *
+     * 책임:
+     * 1) 경로/도구 상태 검증
+     * 2) Gradle/Maven 단일 혹은 경쟁 실행
+     * 3) build_manifest 생성/저장 후 API 응답 생성
+     */
     public BuildResolveResponse resolve(String runId) {
         RepoRun run = repoRunRepository.findById(runId)
                 .orElseThrow(() -> new BuildException(BuildErrorCode.RUN_NOT_FOUND));
 
         Path workspaceRoot = Path.of(run.getWorkspaceRoot());
         if (!Files.exists(workspaceRoot)) {
-            log.debug("workspeaceRoot={}", workspaceRoot.toString());
+            log.debug("workspeaceRoot={}", workspaceRoot);
             throw new BuildException(BuildErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        // 너희 run에서 repo를 어디에 풀어두는지에 맞춰 여기만 맞추면 됨
         Path repoRoot = workspaceRoot.resolve("repo");
         Path actualRepoRoot = repoRootResolver.resolveActualRoot(repoRoot);
 
         if (!Files.exists(actualRepoRoot)) {
-            log.debug("actualRepoRoot={}", actualRepoRoot.toString());
+            log.debug("actualRepoRoot={}", actualRepoRoot);
             throw new BuildException(BuildErrorCode.REPO_ROOT_NOT_FOUND);
         }
 
@@ -69,10 +108,10 @@ public class BuildResolveService {
 
         BuildDetector.Detected detected = buildDetector.detect(actualRepoRoot);
 
-        BuildManifest manifest = switch (detected.tool()) {
-            case GRADLE -> resolveGradle(runId, actualRepoRoot, detected.wrapperExists(), tmpDir);
-            case MAVEN -> resolveMaven(runId, actualRepoRoot, detected.wrapperExists(), tmpDir);
-            case NONE -> BuildManifest.builder()
+        BuildManifest manifest;
+        if (!detected.hasAnyBuildTool()) {
+            // 빌드 도구 자체가 없으면 즉시 FAILED
+            manifest = BuildManifest.builder()
                     .runId(runId)
                     .detectedAt(OffsetDateTime.now())
                     .buildTool(BuildToolKind.NONE)
@@ -83,45 +122,78 @@ public class BuildResolveService {
                             .message(BuildErrorCode.BUILD_TOOL_NOT_FOUND.getMessage())
                             .build()))
                     .build();
-        };
+        } else if (detected.hasGradle() && detected.hasMaven()) {
+            // 혼합 프로젝트(Gradle+Maven)는 둘 다 실행 후 더 좋은 결과를 선택한다.
+            log.info("[BUILD] Both Gradle and Maven detected. Running competitive resolve. repoRoot={}", actualRepoRoot);
+            BuildManifest gradleManifest = resolveGradle(
+                    runId,
+                    actualRepoRoot,
+                    workspaceRoot,
+                    detected.gradleWrapperExists(),
+                    tmpDir.resolve("gradle")
+            );
+            BuildManifest mavenManifest = resolveMaven(
+                    runId,
+                    actualRepoRoot,
+                    workspaceRoot,
+                    detected.mavenWrapperExists(),
+                    tmpDir.resolve("maven")
+            );
+            manifest = buildManifestSelector.selectBetter(gradleManifest, mavenManifest);
+            log.info(
+                    "[BUILD] Competitive resolve selected tool={} mode={} (gradleMode={}, mavenMode={})",
+                    manifest.getBuildTool(),
+                    manifest.getBuildMode(),
+                    gradleManifest.getBuildMode(),
+                    mavenManifest.getBuildMode()
+            );
+        } else if (detected.hasGradle()) {
+            manifest = resolveGradle(runId, actualRepoRoot, workspaceRoot, detected.gradleWrapperExists(), tmpDir.resolve("gradle"));
+        } else {
+            manifest = resolveMaven(runId, actualRepoRoot, workspaceRoot, detected.mavenWrapperExists(), tmpDir.resolve("maven"));
+        }
 
-        Path buildManifestPath = buildManifestWriter.write(artifactsDir, manifest);
+        JsonNode manifestJson = buildManifestWriter.toJson(manifest);
+        buildManifestWriter.write(artifactsDir, manifestJson);
+        Artifact savedManifest = artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
+                "build_manifest.json", manifestJson);
 
-        JsonNode meta = objectMapper.createObjectNode()
-                .put("buildTool", manifest.getBuildTool().name())
-                .put("buildMode", manifest.getBuildMode().name())
-                .put("moduleCount", manifest.getModules().size())
-                .put("failureCount", manifest.getFailures().size())
-                .put("hasClassesDirs",
-                        manifest.getModules().stream()
-                                .anyMatch(m -> m.getClassesDirs() != null && !m.getClassesDirs().isEmpty()));
-
-        // Artifact 등록(너희 artifact 도메인에 이미 있으니 재사용)
-        artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST,"0.1", buildManifestPath.toString(), meta);
-
-        return new BuildResolveResponse(runId, manifest.getBuildMode(), buildManifestPath.toString());
+        return new BuildResolveResponse(runId, manifest.getBuildMode(), savedManifest.getPath());
     }
 
-    private BuildManifest resolveGradle(String runId, Path repoRoot, boolean wrapperUsed, Path tmpDir) {
+    /**
+     * 역할:
+     * Gradle 기반 빌드/리졸브를 수행한다.
+     *
+     * 책임:
+     * 1) ossdocDump 실행 후 모듈 메타데이터 수집
+     * 2) classes 컴파일 결과를 반영해 BuildMode 결정
+     * 3) 실패 시 SOURCE_ONLY 폴백 정보를 failures에 기록
+     */
+    private BuildManifest resolveGradle(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildModuleManifest> modules = new ArrayList<>();
         List<BuildFailure> failures = new ArrayList<>();
 
-        // 1) 덤프(모듈/소스루트/classesDirs/classpath) — 빌드가 깨져도 성공하는 경우가 많아서 핵심
         Path init = gradleInitScriptWriter.write(tmpDir);
 
         List<String> dumpCmd = List.of(
-                selectGradleCmd(repoRoot),
+                gradleBuildSupport.selectGradleCmd(repoRoot),
                 "-I", init.toString(),
                 "ossdocDump",
                 "-q",
                 "--no-daemon"
         );
 
-        ProcessRunner.Result dump = processRunner.run(repoRoot, dumpCmd, Duration.ofMinutes(10));
+        ProcessRunner.Result dump = gradleBuildSupport.runWithJavaFallback(
+                repoRoot,
+                workspaceRoot,
+                dumpCmd,
+                Duration.ofMinutes(10),
+                "dump"
+        );
         if (dump.getExitCode() == 0) {
-            modules.addAll(parseGradleDump(dump.getOutput(), failures));
+            modules.addAll(gradleDumpParser.parse(repoRoot, dump.getOutput(), failures));
 
-            // dump는 성공했는데 실제 모듈 추출 결과가 없으면 SOURCE_ONLY 폴백
             if (modules.isEmpty()) {
                 failures.add(BuildFailure.builder()
                         .code("SOURCE_ONLY")
@@ -138,20 +210,24 @@ public class BuildResolveService {
                     .logHint(hint(dump))
                     .build());
 
-            // dump 실패해도 AST가 돌 수 있게 source-only 폴백
             modules.addAll(sourceOnlyModuleScanner.scan(repoRoot));
         }
 
-        // 2) 컴파일 시도(성공률 우선: 테스트/체크 스킵)
         List<String> compileCmd = List.of(
-                selectGradleCmd(repoRoot),
+                gradleBuildSupport.selectGradleCmd(repoRoot),
                 "classes",
                 "-x", "test",
                 "-x", "check",
                 "--no-daemon"
         );
 
-        ProcessRunner.Result compile = processRunner.run(repoRoot, compileCmd, Duration.ofMinutes(20));
+        ProcessRunner.Result compile = gradleBuildSupport.runWithJavaFallback(
+                repoRoot,
+                workspaceRoot,
+                compileCmd,
+                Duration.ofMinutes(20),
+                "compile"
+        );
 
         BuildMode mode = decideBuildMode(modules, compile);
         if (compile.getExitCode() != 0 && mode != BuildMode.FAILED) {
@@ -173,6 +249,14 @@ public class BuildResolveService {
                 .build();
     }
 
+    /**
+     * 역할:
+     * Maven 실행 불가/예외 상황에서 source-only 결과를 생성한다.
+     *
+     * 책임:
+     * 1) 소스 루트 스캔 결과만으로 최소 매니페스트 구성
+     * 2) 실패 원인을 BuildFailure로 명시
+     */
     private BuildManifest resolveMavenSourceOnly(String runId, Path repoRoot, boolean wrapperUsed, String reason, String logHint) {
         List<BuildModuleManifest> modules = sourceOnlyModuleScanner.scan(repoRoot);
 
@@ -196,11 +280,98 @@ public class BuildResolveService {
                 .build();
     }
 
-    private String selectGradleCmd(Path repoRoot) {
-        // Windows 개발 환경이면 gradlew.bat 우선
-        if (Files.exists(repoRoot.resolve("gradlew.bat"))) return "gradlew.bat";
-        if (Files.exists(repoRoot.resolve("gradlew"))) return "./gradlew";
-        return "gradle";
+    /**
+     * 역할:
+     * Maven 실행 시 JAVA_HOME 후보를 순차 적용해 재시도한다.
+     *
+     * 책임:
+     * 1) 1순위 JDK로 실행
+     * 2) 호환성 에러 감지 시 후보 JDK 순차 재시도
+     * 3) 필요 시 현재 런타임 JVM으로 baseline 폴백
+     */
+    private ProcessRunner.Result runMavenWithJavaFallback(Path mavenLocalRepoPath,
+                                                          MavenJavaSelection selection,
+                                                          String stage,
+                                                          Function<Map<String, String>, ProcessRunner.Result> runner) {
+        List<String> candidates = selection.javaHomes();
+
+        ProcessRunner.Result first;
+        String selectedJavaHome = null;
+        if (candidates.isEmpty()) {
+            first = runner.apply(Map.of());
+        } else {
+            selectedJavaHome = candidates.get(0);
+            first = runner.apply(buildToolchainSupport.buildEnvironment(Map.of(), selectedJavaHome));
+            log.info(
+                    "[BUILD] Maven {} initial JAVA_HOME={} (requiredJava={}, repoLocal={})",
+                    stage,
+                    selectedJavaHome,
+                    selection.requiredJavaMajor().orElse(null),
+                    mavenLocalRepoPath
+            );
+        }
+
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        Optional<String> compatibilityReason = buildToolchainSupport.detectJavaCompatibilityReason(BuildToolKind.MAVEN, first);
+        if (compatibilityReason.isEmpty()) {
+            if (selectedJavaHome != null && !buildToolchainSupport.isCurrentRuntimeJavaHome(selectedJavaHome)) {
+                ProcessRunner.Result baseline = runner.apply(Map.of());
+                if (baseline.getExitCode() == 0) {
+                    log.info("[BUILD] Maven {} fallback to current runtime JVM succeeded", stage);
+                    return baseline;
+                }
+            }
+            return first;
+        }
+        log.info("[BUILD] Maven {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
+
+        ProcessRunner.Result last = first;
+        for (String javaHome : candidates) {
+            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
+                continue;
+            }
+            log.info("[BUILD] Maven {} retry with JAVA_HOME={}", stage, javaHome);
+            ProcessRunner.Result retry = runner.apply(buildToolchainSupport.buildEnvironment(Map.of(), javaHome));
+            if (retry.getExitCode() == 0) {
+                return retry;
+            }
+            last = retry;
+        }
+
+        return last;
+    }
+
+    private MavenJavaSelection resolveMavenJavaSelection(Path repoRoot) {
+        Optional<Integer> requiredJavaMajor = mavenJavaVersionResolver.resolveRequiredJavaMajor(repoRoot);
+        List<String> javaHomes = buildToolchainSupport.resolveJavaHomeCandidatesForMaven(requiredJavaMajor);
+        return new MavenJavaSelection(requiredJavaMajor, javaHomes);
+    }
+
+    /**
+     * 역할:
+     * 격리 실행 모드에서 Run 전용 Maven local repository 경로를 준비한다.
+     *
+     * 책임:
+     * 1) 디렉터리 생성 보장
+     * 2) 생성 실패 시 경고 로그 후 null 반환
+     */
+    private Path resolveMavenLocalRepoPath(Path workspaceRoot) {
+        if (!buildCommandProperties.isIsolatedExecution()) {
+            return null;
+        }
+        Path mavenLocalRepo = workspaceRoot.resolve(buildCommandProperties.getMavenLocalRepoDir())
+                .toAbsolutePath()
+                .normalize();
+        try {
+            Files.createDirectories(mavenLocalRepo);
+            return mavenLocalRepo;
+        } catch (IOException e) {
+            log.warn("[BUILD] Failed to create Maven local repository path. path={}", mavenLocalRepo, e);
+            return null;
+        }
     }
 
     private BuildMode decideBuildMode(List<BuildModuleManifest> modules, ProcessRunner.Result compile) {
@@ -220,68 +391,24 @@ public class BuildResolveService {
         return base.substring(0, Math.min(600, base.length()));
     }
 
-    private List<BuildModuleManifest> parseGradleDump(String output, List<BuildFailure> failures) {
-        Pattern p = Pattern.compile("^OSS_DOC_DUMP=(\\{.*\\})$", Pattern.MULTILINE);
-        Matcher m = p.matcher(output);
-
-        List<BuildModuleManifest> modules = new ArrayList<>();
-        while (m.find()) {
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> map = objectMapper.readValue(m.group(1), Map.class);
-
-                List<String> sourceRoots = (List<String>) map.getOrDefault("sourceRoots", List.of());
-                List<String> testRoots = (List<String>) map.getOrDefault("testRoots", List.of());
-                List<String> resourceRoots = (List<String>) map.getOrDefault("resourceRoots", List.of());
-                List<String> classesDirs = (List<String>) map.getOrDefault("classesDirs", List.of());
-                List<String> compileClasspath = (List<String>) map.getOrDefault("compileClasspath", List.of());
-                List<String> runtimeClasspath = (List<String>) map.getOrDefault("runtimeClasspath", List.of());
-
-                /**
-                 * OK → classesDirs까지 있음 → ASM 기대 가능
-                 * PARTIAL → sourceRoots는 있음 → AST 가능
-                 * FAILED → 실질 정보 없음
-                 */
-                String status;
-                if (!classesDirs.isEmpty()) {
-                    status = "OK";
-                } else if (!sourceRoots.isEmpty() || !testRoots.isEmpty() || !resourceRoots.isEmpty()) {
-                    status = "PARTIAL";
-                } else {
-                    status = "FAILED";
-                }
-
-                modules.add(BuildModuleManifest.builder()
-                        .moduleId((String) map.getOrDefault("projectPath", ""))
-                        .name((String) map.getOrDefault("name", ""))
-                        .sourceRoots(sourceRoots)
-                        .testRoots(testRoots)
-                        .resourceRoots(resourceRoots)
-                        .classesDirs(classesDirs)
-                        .compileClasspath(compileClasspath)
-                        .runtimeClasspath(runtimeClasspath)
-                        .status(status)
-                        .build());
-
-            } catch (Exception e) {
-                failures.add(BuildFailure.builder()
-                        .code(BuildErrorCode.GRADLE_DUMP_FAILED.getCode())
-                        .message("Failed to parse OSS_DOC_DUMP - " + e.getMessage())
-                        .build());
-            }
-        }
-        return modules;
-    }
-
-    private BuildManifest resolveMaven(String runId, Path repoRoot, boolean wrapperUsed, Path tmpDir) {
+    /**
+     * 역할:
+     * Maven 기반 빌드/리졸브를 수행한다.
+     *
+     * 책임:
+     * 1) 모듈 스캔 + classpath 생성
+     * 2) compile 수행 후 BuildMode 결정
+     * 3) 실패 시 SOURCE_ONLY로 안전 폴백
+     */
+    private BuildManifest resolveMaven(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildFailure> failures = new ArrayList<>();
         List<BuildModuleManifest> modules = new ArrayList<>();
 
         try {
-            // 1) 모듈 루트 파악
+            Files.createDirectories(tmpDir);
+
             List<Path> moduleRoots = pomModuleScanner.scanModuleRoots(repoRoot);
 
-            // 모듈 루트조차 못 찾으면 SOURCE_ONLY 폴백
             if (moduleRoots.isEmpty()) {
                 return resolveMavenSourceOnly(
                         runId,
@@ -292,13 +419,19 @@ public class BuildResolveService {
                 );
             }
 
-            // 2) classpath 확보 시도
             Path classpathFile = tmpDir.resolve("maven-classpath.txt");
-            ProcessRunner.Result cpResult = mavenBuildSupport.buildClasspath(repoRoot, classpathFile);
+            Path mavenLocalRepoPath = resolveMavenLocalRepoPath(workspaceRoot);
+            MavenJavaSelection mavenJavaSelection = resolveMavenJavaSelection(repoRoot);
+            ProcessRunner.Result cpResult = runMavenWithJavaFallback(
+                    mavenLocalRepoPath,
+                    mavenJavaSelection,
+                    "classpath",
+                    env -> mavenBuildSupport.buildClasspath(repoRoot, classpathFile, mavenLocalRepoPath, env)
+            );
 
             List<String> classpath = List.of();
             if (cpResult.getExitCode() == 0) {
-                classpath = mavenBuildSupport.readClasspathFile(classpathFile);
+                classpath = mavenBuildSupport.readClasspathFile(repoRoot, classpathFile);
             } else {
                 failures.add(BuildFailure.builder()
                         .code("MAVEN_CLASSPATH_FAILED")
@@ -307,15 +440,17 @@ public class BuildResolveService {
                         .build());
             }
 
-            // 3) 컴파일 시도
-            ProcessRunner.Result compileResult = mavenBuildSupport.compile(repoRoot);
+            ProcessRunner.Result compileResult = runMavenWithJavaFallback(
+                    mavenLocalRepoPath,
+                    mavenJavaSelection,
+                    "compile",
+                    env -> mavenBuildSupport.compile(repoRoot, mavenLocalRepoPath, env)
+            );
 
-            // 4) 모듈별 manifest 생성
             for (Path moduleRoot : moduleRoots) {
                 modules.add(mavenBuildSupport.toModuleManifest(repoRoot, moduleRoot, classpath));
             }
 
-            // 모듈 manifest 자체가 비면 SOURCE_ONLY 폴백
             if (modules.isEmpty()) {
                 return resolveMavenSourceOnly(
                         runId,
@@ -326,12 +461,8 @@ public class BuildResolveService {
                 );
             }
 
-            // 5) buildMode 결정
             BuildMode mode = decideBuildMode(modules, compileResult);
 
-            // 6) compile 실패 시:
-            //    이미 만든 modules가 있으면 그걸 유지하고 SOURCE_ONLY로 반환
-            //    (scanner로 다시 덮어쓰지 않음)
             if (compileResult.getExitCode() != 0) {
                 failures.add(BuildFailure.builder()
                         .code("MAVEN_COMPILE_FAILED")
@@ -350,7 +481,6 @@ public class BuildResolveService {
                         .build();
             }
 
-            // 7) 성공 케이스
             return BuildManifest.builder()
                     .runId(runId)
                     .detectedAt(OffsetDateTime.now())
@@ -370,5 +500,8 @@ public class BuildResolveService {
                     e.getMessage()
             );
         }
+    }
+
+    private record MavenJavaSelection(Optional<Integer> requiredJavaMajor, List<String> javaHomes) {
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestSelector.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestSelector.java
@@ -1,0 +1,100 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.build.enums.BuildMode;
+import org.springframework.stereotype.Component;
+
+/**
+ * 역할:
+ * Gradle/Maven 빌드 결과 중 더 품질이 높은 매니페스트를 선택한다.
+ *
+ * 책임:
+ * 1) BuildMode 우선 비교(FULL > COMPILE_ONLY > SOURCE_ONLY > FAILED)
+ * 2) 동점 시 classesDirs/모듈 수/실패 수 순으로 비교
+ * 3) 완전 동점 시 기존 정책(Gradle 우선) 유지
+ */
+@Component
+public class BuildManifestSelector {
+
+    /**
+     * 역할:
+     * 두 매니페스트 중 최종 채택 대상을 반환한다.
+     *
+     * 책임:
+     * 내부 품질 점수 비교 결과를 정책에 맞게 해석해 반환한다.
+     */
+    public BuildManifest selectBetter(BuildManifest gradleManifest, BuildManifest mavenManifest) {
+        // 점수 비교 결과가 0 이상이면 left(Gradle) 선택: 동률 시 기존 우선순위 유지
+        int comparison = compareQuality(gradleManifest, mavenManifest);
+        return comparison >= 0 ? gradleManifest : mavenManifest;
+    }
+
+    private int compareQuality(BuildManifest left, BuildManifest right) {
+        // 1순위: buildMode
+        int modeComparison = Integer.compare(buildModeScore(left.getBuildMode()), buildModeScore(right.getBuildMode()));
+        if (modeComparison != 0) {
+            return modeComparison;
+        }
+
+        // 2순위: classesDirs 확보량(바이트코드 분석 가능성)
+        int leftClasses = classesDirCount(left);
+        int rightClasses = classesDirCount(right);
+        int classesComparison = Integer.compare(leftClasses, rightClasses);
+        if (classesComparison != 0) {
+            return classesComparison;
+        }
+
+        // 3순위: 모듈 수
+        int leftModules = moduleCount(left);
+        int rightModules = moduleCount(right);
+        int moduleComparison = Integer.compare(leftModules, rightModules);
+        if (moduleComparison != 0) {
+            return moduleComparison;
+        }
+
+        // 4순위: 실패 수(적을수록 우수)
+        int leftFailureCount = failureCount(left);
+        int rightFailureCount = failureCount(right);
+        int failureComparison = Integer.compare(rightFailureCount, leftFailureCount);
+        if (failureComparison != 0) {
+            return failureComparison;
+        }
+
+        // 동률이면 기존 우선순위(Gradle 우선)를 유지한다.
+        return 0;
+    }
+
+    private int buildModeScore(BuildMode mode) {
+        if (mode == null) return 0;
+        return switch (mode) {
+            case FULL -> 4;
+            case COMPILE_ONLY -> 3;
+            case SOURCE_ONLY -> 2;
+            case FAILED -> 1;
+        };
+    }
+
+    private int classesDirCount(BuildManifest manifest) {
+        if (manifest == null || manifest.getModules() == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (BuildModuleManifest module : manifest.getModules()) {
+            if (module == null || module.getClassesDirs() == null) {
+                continue;
+            }
+            count += module.getClassesDirs().size();
+        }
+        return count;
+    }
+
+    private int moduleCount(BuildManifest manifest) {
+        return manifest == null || manifest.getModules() == null ? 0 : manifest.getModules().size();
+    }
+
+    private int failureCount(BuildManifest manifest) {
+        return manifest == null || manifest.getFailures() == null ? 0 : manifest.getFailures().size();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestWriter.java
@@ -3,6 +3,7 @@ package com.example.ossdoc.domain.build.support;
 import com.example.ossdoc.domain.build.dto.json.BuildManifest;
 import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +19,20 @@ public class BuildManifestWriter {
 
     private final ObjectMapper objectMapper;
 
-    public Path write(Path artifactsDir, BuildManifest manifest) {
+    public JsonNode toJson(BuildManifest manifest) {
+        try {
+            return objectMapper.valueToTree(manifest);
+        } catch (Exception e) {
+            log.debug("BuildManifestWriter error={}", e);
+            throw new BuildException(BuildErrorCode.BUILD_MANIFEST_WRITE_FAILED);
+        }
+    }
+
+    public Path write(Path artifactsDir, JsonNode buildManifest) {
         try {
             Files.createDirectories(artifactsDir);
             Path out = artifactsDir.resolve("build_manifest.json");
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), manifest);
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), buildManifest);
             return out;
         } catch (Exception e) {
             log.debug("BuildManifestWriter error={}", e);

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildPathNormalizer.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildPathNormalizer.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.build.support;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BuildPathNormalizer {
+
+    public List<String> toAbsolutePaths(Path baseDir, List<String> rawPaths) {
+        if (rawPaths == null || rawPaths.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> normalized = new ArrayList<>();
+        for (String rawPath : rawPaths) {
+            String resolved = toAbsolutePath(baseDir, rawPath);
+            if (resolved != null) {
+                normalized.add(resolved);
+            }
+        }
+        return normalized;
+    }
+
+    public String toAbsolutePath(Path baseDir, String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+
+        try {
+            Path path = Path.of(rawPath.trim());
+            Path resolved = path.isAbsolute() ? path : baseDir.resolve(path);
+            return normalize(resolved);
+        } catch (InvalidPathException e) {
+            return rawPath.trim().replace("\\", "/");
+        }
+    }
+
+    public String normalize(Path path) {
+        return path.toAbsolutePath().normalize().toString().replace("\\", "/");
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildToolchainSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildToolchainSupport.java
@@ -1,0 +1,433 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.enums.BuildToolKind;
+import com.example.ossdoc.global.config.BuildCommandProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 역할:
+ * 빌드 실행에 필요한 JDK 선택/호환성 판단 규칙을 제공한다.
+ *
+ * 책임:
+ * 1) 설정된 JAVA_HOME 후보 로드 및 버전 파싱
+ * 2) Gradle/Maven별 우선순위에 따라 후보 정렬
+ * 3) 빌드 로그에서 Java 호환성 실패 신호 감지
+ * 4) JAVA_HOME/PATH 실행 환경 맵 구성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuildToolchainSupport {
+
+    private final BuildCommandProperties buildCommandProperties;
+
+    /**
+     * 역할:
+     * Gradle 실행용 JAVA_HOME 후보 목록을 우선순위대로 반환한다.
+     *
+     * 책임:
+     * gradle-wrapper 버전을 참고해 호환성이 높은 JDK가 먼저 오도록 정렬한다.
+     */
+    public List<String> resolveJavaHomeCandidatesForGradle(Path repoRoot) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        Optional<GradleVersion> gradleVersion = parseGradleVersionFromWrapper(repoRoot);
+        if (gradleVersion.isPresent()) {
+            GradleVersion version = gradleVersion.get();
+            int preferredJava = preferredJavaMajor(version);
+
+            candidates.sort((left, right) -> {
+                int tierCompare = Integer.compare(
+                        compatibilityTier(version, right.major()),
+                        compatibilityTier(version, left.major())
+                );
+                if (tierCompare != 0) {
+                    return tierCompare;
+                }
+
+                int leftDistance = Math.abs(left.major() - preferredJava);
+                int rightDistance = Math.abs(right.major() - preferredJava);
+                int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                if (distanceCompare != 0) {
+                    return distanceCompare;
+                }
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+        return toJavaHomePaths(candidates);
+    }
+
+    /**
+     * 역할:
+     * Maven 실행용 JAVA_HOME 후보 목록을 우선순위대로 반환한다.
+     *
+     * 책임:
+     * pom 분석으로 얻은 requiredJava를 기준으로 적합한 JDK를 앞쪽에 배치한다.
+     */
+    public List<String> resolveJavaHomeCandidatesForMaven(Optional<Integer> requiredJavaMajor) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        if (requiredJavaMajor.isPresent()) {
+            int requiredMajor = requiredJavaMajor.get();
+            candidates.sort((left, right) -> {
+                boolean leftAdequate = left.major() >= requiredMajor;
+                boolean rightAdequate = right.major() >= requiredMajor;
+
+                if (leftAdequate != rightAdequate) {
+                    return Boolean.compare(rightAdequate, leftAdequate);
+                }
+
+                if (leftAdequate) {
+                    int leftDistance = Math.abs(left.major() - requiredMajor);
+                    int rightDistance = Math.abs(right.major() - requiredMajor);
+                    int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                    if (distanceCompare != 0) {
+                        return distanceCompare;
+                    }
+                    return Integer.compare(left.major(), right.major());
+                }
+
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+
+        return toJavaHomePaths(candidates);
+    }
+
+    /**
+     * 역할:
+     * 실행 로그에서 Java 버전 불일치/호환성 문제 신호를 탐지한다.
+     *
+     * 책임:
+     * 공통 신호 + Gradle 전용 + Maven 전용 문구를 종합해 재시도 여부 판단 근거를 제공한다.
+     */
+    public Optional<String> detectJavaCompatibilityReason(BuildToolKind buildToolKind, ProcessRunner.Result result) {
+        String text = ((result.getOutput() == null ? "" : result.getOutput()) + "\n"
+                + (result.getError() == null ? "" : result.getError())).toLowerCase(Locale.ROOT);
+
+        List<String> commonSignals = List.of(
+                "unsupported class file major version",
+                "unsupported major.minor version",
+                "has been compiled by a more recent version",
+                "could not determine java version"
+        );
+        for (String signal : commonSignals) {
+            if (text.contains(signal)) {
+                return Optional.of(signal);
+            }
+        }
+
+        if (buildToolKind == BuildToolKind.GRADLE) {
+            // Gradle toolchain/JDK 미스매치에서 자주 나오는 문구를 재시도 신호로 사용
+            List<String> gradleSignals = List.of(
+                    "this version of gradle supports java",
+                    "minimum supported gradle version",
+                    "cannot find a java installation on your machine matching",
+                    "toolchain download repositories have not been configured",
+                    "no matching toolchains found for requested specification"
+            );
+            for (String signal : gradleSignals) {
+                if (text.contains(signal)) {
+                    return Optional.of(signal);
+                }
+            }
+            return Optional.empty();
+        }
+
+        if (buildToolKind == BuildToolKind.MAVEN) {
+            List<String> mavenSignals = List.of(
+                    "invalid target release",
+                    "invalid source release",
+                    "release version",
+                    "source option",
+                    "target option",
+                    "no toolchain found for type jdk",
+                    "cannot find matching toolchain definitions for the following toolchain types",
+                    "error: source release",
+                    "error: target release"
+            );
+            for (String signal : mavenSignals) {
+                if (!text.contains(signal)) {
+                    continue;
+                }
+
+                if ("release version".equals(signal) && !text.contains("not supported")) {
+                    continue;
+                }
+                if (("source option".equals(signal) || "target option".equals(signal))
+                        && !text.contains("is no longer supported")) {
+                    continue;
+                }
+                return Optional.of(signal);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * 역할:
+     * 전달된 JAVA_HOME이 현재 런타임 JVM 경로와 동일한지 판단한다.
+     *
+     * 책임:
+     * JAVA_HOME/System java.home 기준으로 baseline 폴백 필요 여부를 지원한다.
+     */
+    public boolean isCurrentRuntimeJavaHome(String javaHome) {
+        String normalized = normalizePathString(javaHome);
+        if (normalized == null) {
+            return false;
+        }
+        String currentJavaHome = normalizePathString(System.getenv("JAVA_HOME"));
+        String currentRuntimeHome = normalizePathString(System.getProperty("java.home"));
+        return normalized.equalsIgnoreCase(currentJavaHome) || normalized.equalsIgnoreCase(currentRuntimeHome);
+    }
+
+    /**
+     * 역할:
+     * 특정 JAVA_HOME으로 프로세스를 실행하기 위한 환경변수 맵을 구성한다.
+     *
+     * 책임:
+     * JAVA_HOME 설정과 함께 PATH/Path에 해당 JDK bin을 우선 주입한다.
+     */
+    public Map<String, String> buildEnvironment(Map<String, String> baseEnvironment, String javaHome) {
+        Map<String, String> env = new HashMap<>(baseEnvironment);
+        env.put("JAVA_HOME", javaHome);
+
+        String binPath = javaHome + File.separator + "bin";
+        String currentPath = Optional.ofNullable(System.getenv("PATH")).orElse("");
+        String mergedPath = currentPath.isBlank() ? binPath : binPath + File.pathSeparator + currentPath;
+
+        env.put("PATH", mergedPath);
+        env.put("Path", mergedPath);
+        return env;
+    }
+
+    private List<JavaHomeCandidate> loadConfiguredJavaHomeCandidates() {
+        List<String> configured = buildCommandProperties.getJavaHomes();
+        if (configured == null || configured.isEmpty()) {
+            return List.of();
+        }
+
+        List<JavaHomeCandidate> candidates = new ArrayList<>();
+        for (String candidate : configured) {
+            String normalized = normalizePathString(candidate);
+            if (normalized == null) {
+                continue;
+            }
+            Path javaHomePath = Path.of(normalized);
+            if (!Files.exists(javaHomePath) || !Files.isDirectory(javaHomePath)) {
+                continue;
+            }
+
+            Integer javaMajor = parseJavaMajorFromHome(javaHomePath);
+            if (javaMajor == null) {
+                continue;
+            }
+            candidates.add(new JavaHomeCandidate(normalized, javaMajor));
+        }
+        return candidates;
+    }
+
+    private List<String> toJavaHomePaths(List<JavaHomeCandidate> candidates) {
+        List<String> result = new ArrayList<>();
+        for (JavaHomeCandidate candidate : candidates) {
+            result.add(candidate.path());
+        }
+        return result;
+    }
+
+    private Optional<GradleVersion> parseGradleVersionFromWrapper(Path repoRoot) {
+        Path wrapperProperties = repoRoot.resolve("gradle").resolve("wrapper").resolve("gradle-wrapper.properties");
+        if (!Files.exists(wrapperProperties)) {
+            return Optional.empty();
+        }
+
+        Pattern distributionPattern = Pattern.compile("gradle-([0-9]+(?:\\.[0-9]+){0,2})-(?:bin|all)\\.zip");
+        try {
+            for (String line : Files.readAllLines(wrapperProperties, StandardCharsets.UTF_8)) {
+                String trimmed = line == null ? "" : line.trim();
+                if (!trimmed.startsWith("distributionUrl=")) {
+                    continue;
+                }
+                Matcher matcher = distributionPattern.matcher(trimmed);
+                if (!matcher.find()) {
+                    return Optional.empty();
+                }
+
+                String rawVersion = matcher.group(1);
+                String[] parts = rawVersion.split("\\.");
+                int major = parseIntOrZero(parts, 0);
+                int minor = parseIntOrZero(parts, 1);
+                int patch = parseIntOrZero(parts, 2);
+
+                if (major <= 0) {
+                    return Optional.empty();
+                }
+                return Optional.of(new GradleVersion(major, minor, patch));
+            }
+        } catch (Exception e) {
+            log.debug("[BUILD] Failed to parse gradle wrapper version. repoRoot={}", repoRoot, e);
+        }
+        return Optional.empty();
+    }
+
+    private int parseIntOrZero(String[] parts, int index) {
+        if (parts == null || index >= parts.length) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(parts[index]);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Integer parseJavaMajorFromHome(Path javaHome) {
+        Path releaseFile = javaHome.resolve("release");
+        if (Files.exists(releaseFile)) {
+            try {
+                for (String line : Files.readAllLines(releaseFile, StandardCharsets.UTF_8)) {
+                    String trimmed = line == null ? "" : line.trim();
+                    if (!trimmed.startsWith("JAVA_VERSION=")) {
+                        continue;
+                    }
+                    int firstQuote = trimmed.indexOf('"');
+                    int lastQuote = trimmed.lastIndexOf('"');
+                    if (firstQuote >= 0 && lastQuote > firstQuote) {
+                        String versionString = trimmed.substring(firstQuote + 1, lastQuote);
+                        Integer parsed = toMajorVersion(versionString);
+                        if (parsed != null) {
+                            return parsed;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("[BUILD] Failed to read JDK release file. javaHome={}", javaHome, e);
+            }
+        }
+
+        String fallback = javaHome.toString();
+        Matcher matcher = Pattern.compile("(?:jdk|java)[-_]?([0-9]{1,2})", Pattern.CASE_INSENSITIVE).matcher(fallback);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer toMajorVersion(String rawVersion) {
+        if (rawVersion == null || rawVersion.isBlank()) {
+            return null;
+        }
+
+        String version = rawVersion.trim();
+        if (version.startsWith("1.")) {
+            String[] parts = version.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        int dot = version.indexOf('.');
+        String majorPart = dot >= 0 ? version.substring(0, dot) : version;
+        try {
+            return Integer.parseInt(majorPart);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private int preferredJavaMajor(GradleVersion version) {
+        if (version.major() <= 6) {
+            return 11;
+        }
+        if (version.major() == 7) {
+            return version.minor() < 3 ? 11 : 17;
+        }
+        if (version.major() == 8) {
+            return version.minor() < 5 ? 17 : 21;
+        }
+        return 21;
+    }
+
+    private int compatibilityTier(GradleVersion version, int javaMajor) {
+        if (version.major() <= 6) {
+            if (javaMajor <= 11) return 4;
+            if (javaMajor <= 16) return 3;
+            return 1;
+        }
+
+        if (version.major() == 7) {
+            if (version.minor() < 3) {
+                if (javaMajor <= 11) return 4;
+                if (javaMajor <= 16) return 3;
+                if (javaMajor == 17) return 2;
+                return 1;
+            }
+            if (javaMajor <= 17) return 4;
+            if (javaMajor <= 20) return 3;
+            return 1;
+        }
+
+        if (version.major() == 8) {
+            if (version.minor() < 5) {
+                if (javaMajor <= 17) return 4;
+                if (javaMajor <= 20) return 3;
+                return 2;
+            }
+            if (javaMajor <= 21) return 4;
+            if (javaMajor <= 23) return 3;
+            return 2;
+        }
+
+        if (javaMajor >= 21) return 4;
+        if (javaMajor >= 17) return 3;
+        return 2;
+    }
+
+    private String normalizePathString(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+        try {
+            return Path.of(rawPath.trim()).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return rawPath.trim();
+        }
+    }
+
+    private record JavaHomeCandidate(String path, int major) {
+    }
+
+    private record GradleVersion(int major, int minor, int patch) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleBuildSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleBuildSupport.java
@@ -1,0 +1,200 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.enums.BuildToolKind;
+import com.example.ossdoc.global.config.BuildCommandProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 역할:
+ * Gradle 실행 전략(명령 선택, 재시도, wrapper 폴백)을 담당한다.
+ *
+ * 책임:
+ * 1) wrapper 우선/절대경로 기반 명령 결정
+ * 2) JAVA_HOME 후보 재시도 실행
+ * 3) wrapper 부트스트랩 실패 시 시스템 gradle 1회 폴백
+ * 4) 격리 실행 환경(GRADLE_USER_HOME) 구성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GradleBuildSupport {
+
+    private final ProcessRunner processRunner;
+    private final BuildCommandProperties buildCommandProperties;
+    private final BuildToolchainSupport buildToolchainSupport;
+
+    /**
+     * 역할:
+     * 현재 저장소에서 사용할 Gradle 실행 명령을 결정한다.
+     *
+     * 책임:
+     * gradlew(.bat) 존재 시 절대경로 wrapper를 우선 사용하고, 없으면 시스템 gradle을 사용한다.
+     */
+    public String selectGradleCmd(Path repoRoot) {
+        // wrapper는 절대경로로 호출해 ProcessBuilder 경로 탐색 이슈를 줄인다.
+        Path gradlewBat = repoRoot.resolve("gradlew.bat");
+        if (Files.exists(gradlewBat)) return gradlewBat.toAbsolutePath().normalize().toString();
+
+        Path gradlew = repoRoot.resolve("gradlew");
+        if (Files.exists(gradlew)) return gradlew.toAbsolutePath().normalize().toString();
+
+        return buildCommandProperties.getGradleCommand();
+    }
+
+    /**
+     * 역할:
+     * Gradle 명령을 실행하고 Java 호환성 문제 시 후보 JDK로 재시도한다.
+     *
+     * 책임:
+     * 1) 1순위 JAVA_HOME 실행
+     * 2) 호환성 신호 감지 시 순차 재시도
+     * 3) 필요 시 현재 런타임 JVM baseline 폴백
+     */
+    public ProcessRunner.Result runWithJavaFallback(Path repoRoot,
+                                                    Path workspaceRoot,
+                                                    List<String> command,
+                                                    Duration timeout,
+                                                    String stage) {
+        Map<String, String> baseEnvironment = resolveGradleBaseEnvironment(workspaceRoot);
+        List<String> candidates = buildToolchainSupport.resolveJavaHomeCandidatesForGradle(repoRoot);
+
+        ProcessRunner.Result first;
+        String selectedJavaHome = null;
+        if (candidates.isEmpty()) {
+            first = runGradleCommand(repoRoot, command, timeout, baseEnvironment);
+        } else {
+            selectedJavaHome = candidates.get(0);
+            first = runGradleCommand(
+                    repoRoot,
+                    command,
+                    timeout,
+                    buildToolchainSupport.buildEnvironment(baseEnvironment, selectedJavaHome)
+            );
+            log.info("[BUILD] Gradle {} initial JAVA_HOME={} (version-aware selection)", stage, selectedJavaHome);
+        }
+
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        Optional<String> compatibilityReason = buildToolchainSupport.detectJavaCompatibilityReason(BuildToolKind.GRADLE, first);
+        if (compatibilityReason.isEmpty()) {
+            if (selectedJavaHome != null && !buildToolchainSupport.isCurrentRuntimeJavaHome(selectedJavaHome)) {
+                ProcessRunner.Result baseline = runGradleCommand(repoRoot, command, timeout, baseEnvironment);
+                if (baseline.getExitCode() == 0) {
+                    log.info("[BUILD] Gradle {} fallback to current runtime JVM succeeded", stage);
+                    return baseline;
+                }
+            }
+            return first;
+        }
+        log.info("[BUILD] Gradle {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
+
+        ProcessRunner.Result last = first;
+        for (String javaHome : candidates) {
+            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
+                continue;
+            }
+
+            log.info("[BUILD] Gradle {} retry with JAVA_HOME={}", stage, javaHome);
+            ProcessRunner.Result retry = runGradleCommand(
+                    repoRoot,
+                    command,
+                    timeout,
+                    buildToolchainSupport.buildEnvironment(baseEnvironment, javaHome)
+            );
+            if (retry.getExitCode() == 0) {
+                return retry;
+            }
+            last = retry;
+        }
+
+        return last;
+    }
+
+    private ProcessRunner.Result runGradleCommand(Path repoRoot,
+                                                  List<String> command,
+                                                  Duration timeout,
+                                                  Map<String, String> environmentOverrides) {
+        ProcessRunner.Result first = processRunner.run(repoRoot, command, timeout, environmentOverrides);
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        if (command == null || command.isEmpty()) {
+            return first;
+        }
+
+        String primaryCommand = command.get(0);
+        if (!isGradleWrapperCommand(primaryCommand) || !isWrapperBootstrapFailure(first)) {
+            return first;
+        }
+
+        // wrapper 부트스트랩 실패(파일 탐색/실행 실패 등)면 시스템 gradle로 1회 폴백
+        String fallbackCommand = buildCommandProperties.getGradleCommand();
+        if (fallbackCommand == null || fallbackCommand.isBlank() || fallbackCommand.equals(primaryCommand)) {
+            return first;
+        }
+
+        List<String> fallback = new ArrayList<>(command);
+        fallback.set(0, fallbackCommand);
+
+        log.warn("[BUILD] Gradle wrapper command failed to bootstrap. fallbackCommand={}", fallbackCommand);
+        ProcessRunner.Result fallbackResult = processRunner.run(repoRoot, fallback, timeout, environmentOverrides);
+        if (fallbackResult.getExitCode() == 0) {
+            log.info("[BUILD] Gradle fallback command succeeded. command={}", fallbackCommand);
+        }
+        return fallbackResult;
+    }
+
+    private boolean isGradleWrapperCommand(String command) {
+        String normalized = command == null ? "" : command.replace("\\", "/").toLowerCase(Locale.ROOT);
+        return normalized.endsWith("/gradlew")
+                || normalized.endsWith("/gradlew.bat")
+                || normalized.equals("gradlew")
+                || normalized.equals("gradlew.bat")
+                || normalized.equals("./gradlew");
+    }
+
+    private boolean isWrapperBootstrapFailure(ProcessRunner.Result result) {
+        String joined = ((result.getError() == null ? "" : result.getError()) + "\n"
+                + (result.getOutput() == null ? "" : result.getOutput())).toLowerCase(Locale.ROOT);
+
+        return joined.contains("cannot run program")
+                || joined.contains("createprocess error=2")
+                || joined.contains("is not recognized as an internal or external command")
+                || joined.contains("command not found")
+                || joined.contains("no such file or directory");
+    }
+
+    private Map<String, String> resolveGradleBaseEnvironment(Path workspaceRoot) {
+        Map<String, String> env = new HashMap<>();
+        if (!buildCommandProperties.isIsolatedExecution()) {
+            return env;
+        }
+
+        Path gradleUserHome = workspaceRoot.resolve(buildCommandProperties.getGradleUserHomeDir())
+                .toAbsolutePath()
+                .normalize();
+        try {
+            Files.createDirectories(gradleUserHome);
+            env.put("GRADLE_USER_HOME", gradleUserHome.toString());
+        } catch (IOException e) {
+            log.warn("[BUILD] Failed to create GRADLE_USER_HOME directory. path={}", gradleUserHome, e);
+        }
+        return env;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleDumpParser.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleDumpParser.java
@@ -1,0 +1,103 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.dto.json.BuildFailure;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 역할:
+ * Gradle init script(ossdocDump) 출력 문자열을 모듈 매니페스트로 변환한다.
+ *
+ * 책임:
+ * 1) OSS_DOC_DUMP JSON 라인 추출
+ * 2) source/test/resource/classes/classpath 경로 정규화
+ * 3) 모듈 상태(OK/PARTIAL/FAILED) 판정
+ * 4) 파싱 실패를 BuildFailure로 누적
+ */
+@Component
+@RequiredArgsConstructor
+public class GradleDumpParser {
+
+    private final ObjectMapper objectMapper;
+    private final BuildPathNormalizer buildPathNormalizer;
+
+    /**
+     * 역할:
+     * dump 출력 전체를 파싱해 BuildModuleManifest 목록으로 반환한다.
+     *
+     * 책임:
+     * 유효한 dump 라인을 모두 읽어 모듈 정보를 생성하고, 예외는 failures에 기록한다.
+     */
+    public List<BuildModuleManifest> parse(Path repoRoot, String output, List<BuildFailure> failures) {
+        Pattern p = Pattern.compile("^OSS_DOC_DUMP=(\\{.*\\})$", Pattern.MULTILINE);
+        Matcher m = p.matcher(output);
+
+        List<BuildModuleManifest> modules = new ArrayList<>();
+        while (m.find()) {
+            try {
+                Map<String, Object> map = objectMapper.readValue(m.group(1), Map.class);
+
+                List<String> sourceRoots = readPathList(map, "sourceRoots", repoRoot);
+                List<String> testRoots = readPathList(map, "testRoots", repoRoot);
+                List<String> resourceRoots = readPathList(map, "resourceRoots", repoRoot);
+                List<String> classesDirs = readPathList(map, "classesDirs", repoRoot);
+                List<String> compileClasspath = readPathList(map, "compileClasspath", repoRoot);
+                List<String> runtimeClasspath = readPathList(map, "runtimeClasspath", repoRoot);
+
+                String status;
+                if (!classesDirs.isEmpty()) {
+                    status = "OK";
+                } else if (!sourceRoots.isEmpty() || !testRoots.isEmpty() || !resourceRoots.isEmpty()) {
+                    status = "PARTIAL";
+                } else {
+                    status = "FAILED";
+                }
+
+                modules.add(BuildModuleManifest.builder()
+                        .moduleId((String) map.getOrDefault("projectPath", ""))
+                        .name((String) map.getOrDefault("name", ""))
+                        .sourceRoots(sourceRoots)
+                        .testRoots(testRoots)
+                        .resourceRoots(resourceRoots)
+                        .classesDirs(classesDirs)
+                        .compileClasspath(compileClasspath)
+                        .runtimeClasspath(runtimeClasspath)
+                        .status(status)
+                        .build());
+
+            } catch (Exception e) {
+                failures.add(BuildFailure.builder()
+                        .code(BuildErrorCode.GRADLE_DUMP_FAILED.getCode())
+                        .message("Failed to parse OSS_DOC_DUMP - " + e.getMessage())
+                        .build());
+            }
+        }
+        return modules;
+    }
+
+    private List<String> readPathList(Map<String, Object> map, String key, Path repoRoot) {
+        Object rawValue = map.get(key);
+        if (!(rawValue instanceof List<?> values)) {
+            return List.of();
+        }
+
+        List<String> pathValues = new ArrayList<>();
+        for (Object value : values) {
+            if (value instanceof String path && !path.isBlank()) {
+                pathValues.add(path);
+            }
+        }
+
+        return buildPathNormalizer.toAbsolutePaths(repoRoot, pathValues);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriter.java
@@ -34,10 +34,10 @@ public class GradleInitScriptWriter {
                       if (hasJava && prj.hasProperty("sourceSets")) {
                         def main = prj.sourceSets.main
                         def test = prj.sourceSets.test
-                        result.sourceRoots = main.java.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.testRoots = test.java.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.resourceRoots = main.resources.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.classesDirs = main.output.classesDirs.files.collect { prj.rootProject.relativePath(it) }
+                        result.sourceRoots = main.java.srcDirs.collect { it.absolutePath }
+                        result.testRoots = test.java.srcDirs.collect { it.absolutePath }
+                        result.resourceRoots = main.resources.srcDirs.collect { it.absolutePath }
+                        result.classesDirs = main.output.classesDirs.files.collect { it.absolutePath }
 
                         try { result.compileClasspath = main.compileClasspath.files.collect { it.absolutePath } } catch (ignored) { result.compileClasspath = [] }
                         try { result.runtimeClasspath = main.runtimeClasspath.files.collect { it.absolutePath } } catch (ignored) { result.runtimeClasspath = [] }

--- a/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
@@ -11,7 +11,19 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
+/**
+ * 역할:
+ * Maven 실행/출력 해석을 담당하는 실행 지원 컴포넌트.
+ *
+ * 책임:
+ * 1) compile/classpath 명령 실행
+ * 2) wrapper 실패 시 시스템 mvn 폴백
+ * 3) 모듈 매니페스트 및 classpath 파일 파싱 보조
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -19,45 +31,71 @@ public class MavenBuildSupport {
 
     private final ProcessRunner processRunner;
     private final BuildCommandProperties buildCommandProperties;
+    private final BuildPathNormalizer buildPathNormalizer;
 
     /**
-     * Maven 컴파일 실행
-     * - 테스트는 스킵하고 compile까지만 가볍게 수행
+     * 역할:
+     * 테스트를 제외한 Maven 컴파일(test-compile)을 수행한다.
+     *
+     * 책임:
+     * mavenLocalRepoPath와 환경변수를 반영해 실행 결과를 반환한다.
      */
-    public ProcessRunner.Result compile(Path repoRoot) {
-        log.info("mvn path={}", repoRoot);
-        List<String> cmd = List.of(
-                selectMavenCmd(repoRoot),
-                "-q",
-                "-DskipTests",
-                "test-compile"
-        );
+    public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath) {
+        return compile(repoRoot, mavenLocalRepoPath, null);
+    }
+
+    /**
+     * 역할:
+     * Maven 컴파일 실행의 내부 진입점.
+     *
+     * 책임:
+     * 실행 인자 조립 및 runMavenCommand 위임을 담당한다.
+     */
+    public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath, Map<String, String> environmentOverrides) {
+        List<String> args = new ArrayList<>();
+        args.add("-q");
+        args.add("-DskipTests");
+        // 격리 실행 모드에서는 Run 전용 로컬 저장소를 사용해 의존성 충돌을 줄인다.
+        appendMavenLocalRepoOption(args, mavenLocalRepoPath);
+        args.add("test-compile");
 
         log.info("[BUILD] Maven compile start. repoRoot={}", repoRoot);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(20));
+        return runMavenCommand(repoRoot, args, Duration.ofMinutes(20), environmentOverrides);
     }
 
     /**
-     * dependency:build-classpath 로 classpath 파일 생성
+     * 역할:
+     * dependency:build-classpath를 실행해 classpath 파일을 생성한다.
+     *
+     * 책임:
+     * build 단계에서 타입 해석에 필요한 의존성 경로 확보를 지원한다.
      */
-    public ProcessRunner.Result buildClasspath(Path repoRoot, Path outputFile) {
-        List<String> cmd = List.of(
-                selectMavenCmd(repoRoot),
-                "-q",
-                "-DskipTests",
-                "dependency:build-classpath",
-                "-Dmdep.outputFile=" + outputFile.toString()
-        );
+    public ProcessRunner.Result buildClasspath(Path repoRoot, Path outputFile, Path mavenLocalRepoPath) {
+        return buildClasspath(repoRoot, outputFile, mavenLocalRepoPath, null);
+    }
+
+    public ProcessRunner.Result buildClasspath(Path repoRoot,
+                                               Path outputFile,
+                                               Path mavenLocalRepoPath,
+                                               Map<String, String> environmentOverrides) {
+        List<String> args = new ArrayList<>();
+        args.add("-q");
+        args.add("-DskipTests");
+        // classpath 산출도 compile과 동일하게 격리 저장소를 사용한다.
+        appendMavenLocalRepoOption(args, mavenLocalRepoPath);
+        args.add("dependency:build-classpath");
+        args.add("-Dmdep.outputFile=" + outputFile);
 
         log.info("[BUILD] Maven classpath build start. repoRoot={}, output={}", repoRoot, outputFile);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(10));
+        return runMavenCommand(repoRoot, args, Duration.ofMinutes(10), environmentOverrides);
     }
 
     /**
-     * 모듈 루트 기준으로 BuildModuleManifest를 생성
-     * - sourceRoots/testRoots/resourceRoots
-     * - classesDirs
-     * - compileClasspath/runtimeClasspath
+     * 역할:
+     * Maven 모듈 루트 경로를 BuildModuleManifest로 변환한다.
+     *
+     * 책임:
+     * source/test/resource/classes/classpath 정보를 표준 DTO로 매핑한다.
      */
     public BuildModuleManifest toModuleManifest(Path repoRoot, Path moduleRoot, List<String> classpath) {
         List<String> sourceRoots = new ArrayList<>();
@@ -73,6 +111,7 @@ public class MavenBuildSupport {
         String moduleId = toModuleId(repoRoot, moduleRoot);
         String name = moduleRoot.getFileName() != null ? moduleRoot.getFileName().toString() : moduleId;
 
+        // classpath/runtimeClasspath은 절대경로로 정규화해 후속 분석 단계에서 OS 의존성을 줄인다.
         return BuildModuleManifest.builder()
                 .moduleId(moduleId)
                 .name(name)
@@ -80,14 +119,21 @@ public class MavenBuildSupport {
                 .testRoots(testRoots)
                 .resourceRoots(resourceRoots)
                 .classesDirs(classesDirs)
-                .compileClasspath(classpath)
-                .runtimeClasspath(classpath)
+                .compileClasspath(buildPathNormalizer.toAbsolutePaths(repoRoot, classpath))
+                .runtimeClasspath(buildPathNormalizer.toAbsolutePaths(repoRoot, classpath))
                 .status(classesDirs.isEmpty() ? "PARTIAL" : "OK")
                 .failReason(null)
                 .build();
     }
 
-    public List<String> readClasspathFile(Path outputFile) {
+    /**
+     * 역할:
+     * Maven classpath 출력 파일을 읽어 경로 목록으로 반환한다.
+     *
+     * 책임:
+     * OS path separator 분리 + 절대경로 정규화 + 예외 안전 처리.
+     */
+    public List<String> readClasspathFile(Path repoRoot, Path outputFile) {
         try {
             if (!Files.exists(outputFile)) {
                 return List.of();
@@ -102,7 +148,11 @@ public class MavenBuildSupport {
             List<String> result = new ArrayList<>();
             for (String entry : entries) {
                 if (!entry.isBlank()) {
-                    result.add(entry.trim());
+                    // 상대경로/절대경로 혼재를 방지하기 위해 한 번 더 절대경로로 통일한다.
+                    String normalized = buildPathNormalizer.toAbsolutePath(repoRoot, entry);
+                    if (normalized != null) {
+                        result.add(normalized);
+                    }
                 }
             }
             return result;
@@ -112,9 +162,65 @@ public class MavenBuildSupport {
         }
     }
 
+    private ProcessRunner.Result runMavenCommand(Path repoRoot,
+                                                 List<String> args,
+                                                 Duration timeout,
+                                                 Map<String, String> environmentOverrides) {
+        String primaryCommand = selectMavenCmd(repoRoot);
+        List<String> primary = new ArrayList<>();
+        primary.add(primaryCommand);
+        primary.addAll(args);
+
+        ProcessRunner.Result first = processRunner.run(repoRoot, primary, timeout, environmentOverrides);
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        if (!isWrapperCommand(primaryCommand) || !isWrapperBootstrapFailure(first)) {
+            return first;
+        }
+
+        // wrapper 실행 자체가 실패하면 시스템 mvn 명령으로 1회 폴백한다.
+        String fallbackCommand = buildCommandProperties.getMavenCommand();
+        if (fallbackCommand == null || fallbackCommand.isBlank() || Objects.equals(primaryCommand, fallbackCommand)) {
+            return first;
+        }
+
+        List<String> fallback = new ArrayList<>();
+        fallback.add(fallbackCommand);
+        fallback.addAll(args);
+
+        log.warn("[BUILD] Maven wrapper command failed to bootstrap. fallbackCommand={}", fallbackCommand);
+        ProcessRunner.Result fallbackResult = processRunner.run(repoRoot, fallback, timeout, environmentOverrides);
+        if (fallbackResult.getExitCode() == 0) {
+            log.info("[BUILD] Maven fallback command succeeded. command={}", fallbackCommand);
+        }
+        return fallbackResult;
+    }
+
+    private boolean isWrapperCommand(String command) {
+        String normalized = command == null ? "" : command.replace("\\", "/").toLowerCase(Locale.ROOT);
+        return normalized.endsWith("/mvnw")
+                || normalized.endsWith("/mvnw.cmd")
+                || normalized.equals("mvnw")
+                || normalized.equals("mvnw.cmd")
+                || normalized.equals("./mvnw");
+    }
+
+    private boolean isWrapperBootstrapFailure(ProcessRunner.Result result) {
+        String joined = ((result.getError() == null ? "" : result.getError()) + "\n"
+                + (result.getOutput() == null ? "" : result.getOutput())).toLowerCase(Locale.ROOT);
+
+        return joined.contains("cannot run program")
+                || joined.contains("createprocess error=2")
+                || joined.contains("is not recognized as an internal or external command")
+                || joined.contains("command not found")
+                || joined.contains("no such file or directory");
+    }
+
     private void addIfExists(List<String> target, Path path) {
         if (Files.exists(path) && Files.isDirectory(path)) {
-            target.add(path.toString());
+            target.add(buildPathNormalizer.normalize(path));
         }
     }
 
@@ -126,9 +232,26 @@ public class MavenBuildSupport {
     }
 
     private String selectMavenCmd(Path repoRoot) {
-        if (Files.exists(repoRoot.resolve("mvnw.cmd"))) return "mvnw.cmd";
-        if (Files.exists(repoRoot.resolve("mvnw"))) return "./mvnw";
+        Path mvnwCmd = repoRoot.resolve("mvnw.cmd");
+        if (Files.exists(mvnwCmd)) {
+            // wrapper는 절대경로로 호출해 ProcessBuilder 경로 탐색 이슈를 줄인다.
+            return mvnwCmd.toAbsolutePath().normalize().toString();
+        }
+
+        Path mvnw = repoRoot.resolve("mvnw");
+        if (Files.exists(mvnw)) {
+            // Windows/Unix 공통으로 wrapper 절대경로 우선
+            return mvnw.toAbsolutePath().normalize().toString();
+        }
+
         return buildCommandProperties.getMavenCommand();
     }
 
+    private void appendMavenLocalRepoOption(List<String> command, Path mavenLocalRepoPath) {
+        if (mavenLocalRepoPath == null) {
+            return;
+        }
+        // -Dmaven.repo.local 옵션으로 Run별 캐시 경로를 강제한다.
+        command.add("-Dmaven.repo.local=" + buildPathNormalizer.normalize(mavenLocalRepoPath));
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/build/support/MavenJavaVersionResolver.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/MavenJavaVersionResolver.java
@@ -1,0 +1,361 @@
+package com.example.ossdoc.domain.build.support;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class MavenJavaVersionResolver {
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("^\\$\\{([^}]+)}$");
+
+    public Optional<Integer> resolveRequiredJavaMajor(Path repoRoot) {
+        Path rootPom = repoRoot.resolve("pom.xml");
+        if (!Files.exists(rootPom)) {
+            return Optional.empty();
+        }
+
+        List<PomModel> lineage = collectPomLineage(rootPom);
+        if (lineage.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> mergedProperties = mergeProperties(lineage);
+
+        for (int i = lineage.size() - 1; i >= 0; i--) {
+            PomModel model = lineage.get(i);
+
+            Optional<Integer> pluginVersion = parseMajor(model.compilerRelease(), mergedProperties)
+                    .or(() -> parseMajor(model.compilerSource(), mergedProperties))
+                    .or(() -> parseMajor(model.compilerTarget(), mergedProperties));
+            if (pluginVersion.isPresent()) {
+                return pluginVersion;
+            }
+
+            Optional<Integer> propertyVersion = parseMajor(model.mavenCompilerRelease(), mergedProperties)
+                    .or(() -> parseMajor(model.mavenCompilerSource(), mergedProperties))
+                    .or(() -> parseMajor(model.mavenCompilerTarget(), mergedProperties))
+                    .or(() -> parseMajor(model.javaVersion(), mergedProperties))
+                    .or(() -> parseMajor(model.jdkVersion(), mergedProperties));
+            if (propertyVersion.isPresent()) {
+                return propertyVersion;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private List<PomModel> collectPomLineage(Path rootPom) {
+        List<PomModel> chain = new ArrayList<>();
+        Set<Path> visited = new HashSet<>();
+
+        Path current = rootPom.toAbsolutePath().normalize();
+        while (Files.exists(current) && visited.add(current)) {
+            Optional<PomModel> modelOptional = readPomModel(current);
+            if (modelOptional.isEmpty()) {
+                break;
+            }
+
+            PomModel model = modelOptional.get();
+            chain.add(model);
+
+            Optional<Path> parent = resolveParentPomPath(current, model);
+            if (parent.isEmpty()) {
+                break;
+            }
+            current = parent.get();
+        }
+
+        Collections.reverse(chain);
+        return chain;
+    }
+
+    private Optional<Path> resolveParentPomPath(Path currentPom, PomModel model) {
+        if (!model.hasParent()) {
+            return Optional.empty();
+        }
+
+        String relativePath = model.parentRelativePath();
+        if (relativePath == null) {
+            relativePath = "../pom.xml";
+        }
+        if (relativePath.isBlank()) {
+            return Optional.empty();
+        }
+
+        Path resolved = currentPom.getParent().resolve(relativePath).normalize();
+        if (Files.exists(resolved)) {
+            return Optional.of(resolved);
+        }
+        return Optional.empty();
+    }
+
+    private Map<String, String> mergeProperties(List<PomModel> lineage) {
+        Map<String, String> merged = new HashMap<>();
+        for (PomModel model : lineage) {
+            for (Map.Entry<String, String> entry : model.properties().entrySet()) {
+                String value = resolvePlaceholders(entry.getValue(), merged);
+                merged.put(entry.getKey(), value);
+            }
+        }
+        return merged;
+    }
+
+    private Optional<PomModel> readPomModel(Path pomPath) {
+        try (InputStream in = Files.newInputStream(pomPath)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(false);
+            safeSet(factory, "http://apache.org/xml/features/disallow-doctype-decl", true);
+            safeSet(factory, "http://xml.org/sax/features/external-general-entities", false);
+            safeSet(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+            safeSet(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setExpandEntityReferences(false);
+            factory.setXIncludeAware(false);
+
+            Document document = factory.newDocumentBuilder().parse(in);
+            Element project = document.getDocumentElement();
+            if (project == null) {
+                return Optional.empty();
+            }
+
+            Map<String, String> properties = readProperties(project);
+            String compilerRelease = findCompilerPluginConfig(project, "release").orElse(null);
+            String compilerSource = findCompilerPluginConfig(project, "source").orElse(null);
+            String compilerTarget = findCompilerPluginConfig(project, "target").orElse(null);
+
+            String mavenCompilerRelease = properties.get("maven.compiler.release");
+            String mavenCompilerSource = properties.get("maven.compiler.source");
+            String mavenCompilerTarget = properties.get("maven.compiler.target");
+            String javaVersion = properties.get("java.version");
+            String jdkVersion = properties.get("jdk.version");
+
+            Element parentElement = directChild(project, "parent");
+            boolean hasParent = parentElement != null;
+            String parentRelativePath = null;
+            if (hasParent) {
+                Element relativePathElement = directChild(parentElement, "relativePath");
+                parentRelativePath = relativePathElement == null ? null : text(relativePathElement);
+            }
+
+            return Optional.of(new PomModel(
+                    pomPath,
+                    properties,
+                    compilerRelease,
+                    compilerSource,
+                    compilerTarget,
+                    mavenCompilerRelease,
+                    mavenCompilerSource,
+                    mavenCompilerTarget,
+                    javaVersion,
+                    jdkVersion,
+                    hasParent,
+                    parentRelativePath
+            ));
+        } catch (Exception e) {
+            log.debug("[BUILD] Failed to parse pom for Java version detection. pom={}", pomPath, e);
+            return Optional.empty();
+        }
+    }
+
+    private void safeSet(DocumentBuilderFactory factory, String feature, boolean value) {
+        try {
+            factory.setFeature(feature, value);
+        } catch (Exception ignored) {
+            // Keep best-effort hardening without failing build analysis.
+        }
+    }
+
+    private Map<String, String> readProperties(Element project) {
+        Map<String, String> properties = new HashMap<>();
+        Element propertiesElement = directChild(project, "properties");
+        if (propertiesElement == null) {
+            return properties;
+        }
+
+        NodeList children = propertiesElement.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            String key = node.getNodeName();
+            String value = text((Element) node);
+            if (key != null && !key.isBlank() && value != null && !value.isBlank()) {
+                properties.put(key.trim(), value.trim());
+            }
+        }
+        return properties;
+    }
+
+    private Optional<String> findCompilerPluginConfig(Element project, String key) {
+        Element build = directChild(project, "build");
+        if (build == null) {
+            return Optional.empty();
+        }
+
+        Optional<String> fromPlugins = findCompilerPluginConfigInContainer(directChild(build, "plugins"), key);
+        if (fromPlugins.isPresent()) {
+            return fromPlugins;
+        }
+
+        Element pluginManagement = directChild(build, "pluginManagement");
+        if (pluginManagement == null) {
+            return Optional.empty();
+        }
+        return findCompilerPluginConfigInContainer(directChild(pluginManagement, "plugins"), key);
+    }
+
+    private Optional<String> findCompilerPluginConfigInContainer(Element pluginsContainer, String key) {
+        if (pluginsContainer == null) {
+            return Optional.empty();
+        }
+
+        for (Element plugin : directChildren(pluginsContainer, "plugin")) {
+            String artifactId = text(directChild(plugin, "artifactId"));
+            if (!"maven-compiler-plugin".equals(artifactId)) {
+                continue;
+            }
+            Element configuration = directChild(plugin, "configuration");
+            if (configuration == null) {
+                return Optional.empty();
+            }
+            Element target = directChild(configuration, key);
+            return Optional.ofNullable(text(target));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Integer> parseMajor(String expression, Map<String, String> properties) {
+        if (expression == null || expression.isBlank()) {
+            return Optional.empty();
+        }
+
+        String resolved = resolvePlaceholders(expression, properties);
+        if (resolved == null || resolved.isBlank()) {
+            return Optional.empty();
+        }
+
+        Integer major = parseMajorVersion(resolved);
+        return Optional.ofNullable(major);
+    }
+
+    private String resolvePlaceholders(String raw, Map<String, String> properties) {
+        String current = raw == null ? "" : raw.trim();
+        for (int i = 0; i < 8; i++) {
+            Matcher matcher = PLACEHOLDER_PATTERN.matcher(current);
+            if (!matcher.matches()) {
+                return current;
+            }
+
+            String key = matcher.group(1) == null ? "" : matcher.group(1).trim();
+            if (key.isBlank()) {
+                return current;
+            }
+
+            String replacement = properties.get(key);
+            if (replacement == null || replacement.isBlank()) {
+                return current;
+            }
+            current = replacement.trim();
+        }
+        return current;
+    }
+
+    private Integer parseMajorVersion(String value) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.isBlank()) {
+            return null;
+        }
+
+        if (trimmed.startsWith("1.")) {
+            String[] parts = trimmed.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        int dot = trimmed.indexOf('.');
+        String majorPart = dot >= 0 ? trimmed.substring(0, dot) : trimmed;
+        try {
+            return Integer.parseInt(majorPart);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Element directChild(Element parent, String childName) {
+        if (parent == null || childName == null) {
+            return null;
+        }
+
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (childName.equals(node.getNodeName())) {
+                return (Element) node;
+            }
+        }
+        return null;
+    }
+
+    private List<Element> directChildren(Element parent, String childName) {
+        List<Element> elements = new ArrayList<>();
+        if (parent == null || childName == null) {
+            return elements;
+        }
+
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (childName.equals(node.getNodeName())) {
+                elements.add((Element) node);
+            }
+        }
+        return elements;
+    }
+
+    private String text(Element element) {
+        if (element == null) {
+            return null;
+        }
+        String value = element.getTextContent();
+        return value == null ? null : value.trim();
+    }
+
+    private record PomModel(Path path,
+                            Map<String, String> properties,
+                            String compilerRelease,
+                            String compilerSource,
+                            String compilerTarget,
+                            String mavenCompilerRelease,
+                            String mavenCompilerSource,
+                            String mavenCompilerTarget,
+                            String javaVersion,
+                            String jdkVersion,
+                            boolean hasParent,
+                            String parentRelativePath) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/ProcessRunner.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/ProcessRunner.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -15,10 +16,17 @@ import java.util.concurrent.TimeUnit;
 public class ProcessRunner {
 
     public Result run(Path workingDir, List<String> command, Duration timeout) {
+        return run(workingDir, command, timeout, null);
+    }
+
+    public Result run(Path workingDir, List<String> command, Duration timeout, Map<String, String> environmentOverrides) {
         try {
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(workingDir.toFile());
             pb.redirectErrorStream(true);
+            if (environmentOverrides != null && !environmentOverrides.isEmpty()) {
+                pb.environment().putAll(environmentOverrides);
+            }
 
             Process p = pb.start();
 

--- a/src/main/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScanner.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScanner.java
@@ -1,6 +1,7 @@
 package com.example.ossdoc.domain.build.support;
 
 import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,10 @@ import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SourceOnlyModuleScanner {
+
+    private final BuildPathNormalizer buildPathNormalizer;
 
     /**
      * SOURCE_ONLY 폴백용 스캐너
@@ -82,7 +86,7 @@ public class SourceOnlyModuleScanner {
     private void addIfExists(List<String> target, Path moduleRoot, String relativePath) {
         Path candidate = moduleRoot.resolve(relativePath);
         if (Files.exists(candidate) && Files.isDirectory(candidate)) {
-            target.add(candidate.toString());
+            target.add(buildPathNormalizer.normalize(candidate));
         }
     }
 

--- a/src/main/java/com/example/ossdoc/domain/extraction/controller/ExtractionController.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/controller/ExtractionController.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.domain.extraction.controller;
+
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+import com.example.ossdoc.domain.extraction.facade.FactsExtractionFacade;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/extraction")
+public class ExtractionController {
+
+    private final FactsExtractionFacade factsExtractionFacade;
+
+    @PostMapping("/extract")
+    public ApiResponse<FactsExtractResponse> extract(@Valid @RequestBody FactsExtractRequest request) {
+        FactsExtractResponse response = factsExtractionFacade.extract(request);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractedFacts.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractedFacts.java
@@ -1,0 +1,213 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+import com.example.ossdoc.domain.extraction.enums.ChunkStatus;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * extractor 내부에서만 쓰는 중간 집계 객체.
+ *
+ * 새 파이프라인의 기본 반환형은 ChunkResult지만,
+ * 테스트/로컬 유틸에서 aggregate 자체가 필요할 수 있어 보조로 유지한다.
+ */
+public record ExtractedFacts(
+        Map<String, EvidenceFact> evidence,
+        SymbolTable symbols,
+        RelationTable relations,
+        ObservationTable observations,
+        StatsMeta stats,
+        List<String> warnings,
+        List<String> errors
+) {
+
+    public ExtractedFacts {
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        errors = errors == null ? List.of() : List.copyOf(errors);
+    }
+
+    public static ExtractedFacts empty() {
+        return new ExtractedFacts(
+                Map.of(),
+                SymbolTable.builder()
+                        .modules(List.of())
+                        .packages(List.of())
+                        .types(List.of())
+                        .constructors(List.of())
+                        .methods(List.of())
+                        .fields(List.of())
+                        .build(),
+                RelationTable.builder()
+                        .contains(List.of())
+                        .extendsRelations(List.of())
+                        .implementsRelations(List.of())
+                        .overrides(List.of())
+                        .calls(List.of())
+                        .accessesField(List.of())
+                        .fieldType(List.of())
+                        .paramType(List.of())
+                        .returnType(List.of())
+                        .throwsType(List.of())
+                        .annotatedBy(List.of())
+                        .build(),
+                ObservationTable.builder()
+                        .diInjectionSites(List.of())
+                        .diProviders(List.of())
+                        .spiProviders(List.of())
+                        .eventPublish(List.of())
+                        .eventSubscribe(List.of())
+                        .reflectionUses(List.of())
+                        .configWiring(List.of())
+                        .build(),
+                StatsMeta.builder().build(),
+                List.of(),
+                List.of()
+        );
+    }
+
+    public ChunkResult toChunkResult(ChunkDescriptor descriptor, ChunkStatus status) {
+        return ChunkResult.builder()
+                .descriptor(descriptor)
+                .status(status)
+                .evidence(evidence)
+                .symbols(mergeSymbolLists())
+                .relations(mergeRelationLists())
+                .observations(mergeObservationLists())
+                .stats(stats)
+                .warnings(warnings)
+                .errors(errors)
+                .build();
+    }
+
+    public ExtractedFacts merge(ExtractedFacts other) {
+        if (other == null) {
+            return this;
+        }
+
+        Map<String, EvidenceFact> mergedEvidence = new LinkedHashMap<>();
+        mergedEvidence.putAll(this.evidence);
+        mergedEvidence.putAll(other.evidence);
+
+        return new ExtractedFacts(
+                mergedEvidence,
+                SymbolTable.builder()
+                        .modules(mergeLists(this.symbols.modules(), other.symbols.modules()))
+                        .packages(mergeLists(this.symbols.packages(), other.symbols.packages()))
+                        .types(mergeLists(this.symbols.types(), other.symbols.types()))
+                        .constructors(mergeLists(this.symbols.constructors(), other.symbols.constructors()))
+                        .methods(mergeLists(this.symbols.methods(), other.symbols.methods()))
+                        .fields(mergeLists(this.symbols.fields(), other.symbols.fields()))
+                        .build(),
+                RelationTable.builder()
+                        .contains(mergeLists(this.relations.contains(), other.relations.contains()))
+                        .extendsRelations(mergeLists(this.relations.extendsRelations(), other.relations.extendsRelations()))
+                        .implementsRelations(mergeLists(this.relations.implementsRelations(), other.relations.implementsRelations()))
+                        .overrides(mergeLists(this.relations.overrides(), other.relations.overrides()))
+                        .calls(mergeLists(this.relations.calls(), other.relations.calls()))
+                        .accessesField(mergeLists(this.relations.accessesField(), other.relations.accessesField()))
+                        .fieldType(mergeLists(this.relations.fieldType(), other.relations.fieldType()))
+                        .paramType(mergeLists(this.relations.paramType(), other.relations.paramType()))
+                        .returnType(mergeLists(this.relations.returnType(), other.relations.returnType()))
+                        .throwsType(mergeLists(this.relations.throwsType(), other.relations.throwsType()))
+                        .annotatedBy(mergeLists(this.relations.annotatedBy(), other.relations.annotatedBy()))
+                        .build(),
+                ObservationTable.builder()
+                        .diInjectionSites(mergeLists(this.observations.diInjectionSites(), other.observations.diInjectionSites()))
+                        .diProviders(mergeLists(this.observations.diProviders(), other.observations.diProviders()))
+                        .spiProviders(mergeLists(this.observations.spiProviders(), other.observations.spiProviders()))
+                        .eventPublish(mergeLists(this.observations.eventPublish(), other.observations.eventPublish()))
+                        .eventSubscribe(mergeLists(this.observations.eventSubscribe(), other.observations.eventSubscribe()))
+                        .reflectionUses(mergeLists(this.observations.reflectionUses(), other.observations.reflectionUses()))
+                        .configWiring(mergeLists(this.observations.configWiring(), other.observations.configWiring()))
+                        .build(),
+                StatsMeta.builder()
+                        .filesScanned(this.stats.filesScanned() + other.stats.filesScanned())
+                        .filesParsed(this.stats.filesParsed() + other.stats.filesParsed())
+                        .filesSkipped(this.stats.filesSkipped() + other.stats.filesSkipped())
+                        .astFilesScanned(this.stats.astFilesScanned() + other.stats.astFilesScanned())
+                        .classFilesScanned(this.stats.classFilesScanned() + other.stats.classFilesScanned())
+                        .astFilesParsed(this.stats.astFilesParsed() + other.stats.astFilesParsed())
+                        .classFilesParsed(this.stats.classFilesParsed() + other.stats.classFilesParsed())
+                        .chunksTotal(this.stats.chunksTotal() + other.stats.chunksTotal())
+                        .chunksSucceeded(this.stats.chunksSucceeded() + other.stats.chunksSucceeded())
+                        .chunksFailed(this.stats.chunksFailed() + other.stats.chunksFailed())
+                        .chunksPartial(this.stats.chunksPartial() + other.stats.chunksPartial())
+                        .types(this.stats.types() + other.stats.types())
+                        .constructors(this.stats.constructors() + other.stats.constructors())
+                        .methods(this.stats.methods() + other.stats.methods())
+                        .fields(this.stats.fields() + other.stats.fields())
+                        .edgeCandidates(this.stats.edgeCandidates() + other.stats.edgeCandidates())
+                        .relations(this.stats.relations() + other.stats.relations())
+                        .observations(this.stats.observations() + other.stats.observations())
+                        .evidence(this.stats.evidence() + other.stats.evidence())
+                        .unresolvedTypeRefs(this.stats.unresolvedTypeRefs() + other.stats.unresolvedTypeRefs())
+                        .errors(this.stats.errors() + other.stats.errors())
+                        .build(),
+                mergeLists(this.warnings, other.warnings),
+                mergeLists(this.errors, other.errors)
+        );
+    }
+
+    private List<SymbolFact> mergeSymbolLists() {
+        List<SymbolFact> merged = new ArrayList<>();
+        merged.addAll(symbols.modules());
+        merged.addAll(symbols.packages());
+        merged.addAll(symbols.types());
+        merged.addAll(symbols.constructors());
+        merged.addAll(symbols.methods());
+        merged.addAll(symbols.fields());
+        return List.copyOf(merged);
+    }
+
+    private List<RelationFact> mergeRelationLists() {
+        List<RelationFact> merged = new ArrayList<>();
+        merged.addAll(relations.contains());
+        merged.addAll(relations.extendsRelations());
+        merged.addAll(relations.implementsRelations());
+        merged.addAll(relations.overrides());
+        merged.addAll(relations.calls());
+        merged.addAll(relations.accessesField());
+        merged.addAll(relations.fieldType());
+        merged.addAll(relations.paramType());
+        merged.addAll(relations.returnType());
+        merged.addAll(relations.throwsType());
+        merged.addAll(relations.annotatedBy());
+        return List.copyOf(merged);
+    }
+
+    private List<ObservationFact> mergeObservationLists() {
+        List<ObservationFact> merged = new ArrayList<>();
+        merged.addAll(observations.diInjectionSites());
+        merged.addAll(observations.diProviders());
+        merged.addAll(observations.spiProviders());
+        merged.addAll(observations.eventPublish());
+        merged.addAll(observations.eventSubscribe());
+        merged.addAll(observations.reflectionUses());
+        merged.addAll(observations.configWiring());
+        return List.copyOf(merged);
+    }
+
+    private static <T> List<T> mergeLists(List<T> left, List<T> right) {
+        List<T> merged = new ArrayList<>();
+        if (left != null) {
+            merged.addAll(left);
+        }
+        if (right != null) {
+            merged.addAll(right);
+        }
+        return List.copyOf(merged);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionContext.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionContext.java
@@ -1,0 +1,103 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+import lombok.Builder;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * chunk 단위 extractor 입력 컨텍스트.
+ *
+ * 전제:
+ * - repoRoot / rootPath / files / classpath는 preflight + chunk planner에서 이미 정규화된 값이다.
+ * - extractor는 include/exclude glob으로 다시 전체 디렉터리를 순회하지 않고,
+ *   planner가 확정한 files 목록만 처리한다.
+ */
+@Builder
+public record ExtractionContext(
+        Path repoRoot,
+        ChunkDescriptor chunk,
+        String module,
+        Path rootPath,
+        List<Path> files,
+        List<Path> astLookupRoots,
+        List<Path> compileClasspathEntries,
+        List<Path> runtimeClasspathEntries,
+        boolean includeObservations
+) {
+
+    public ExtractionContext {
+        repoRoot = Objects.requireNonNull(repoRoot, "repoRoot must not be null").normalize();
+        chunk = Objects.requireNonNull(chunk, "chunk must not be null");
+        module = normalizeModule(module == null || module.isBlank() ? chunk.module() : module);
+        rootPath = Objects.requireNonNull(rootPath, "rootPath must not be null").normalize();
+        files = sanitizePaths(files);
+        astLookupRoots = sanitizePaths(astLookupRoots);
+        compileClasspathEntries = sanitizePaths(compileClasspathEntries);
+        runtimeClasspathEntries = sanitizePaths(runtimeClasspathEntries);
+    }
+
+    public ChunkKind chunkKind() {
+        return chunk.kind();
+    }
+
+    public String chunkId() {
+        return chunk.chunkId();
+    }
+
+    public boolean isAstChunk() {
+        return chunkKind() == ChunkKind.AST;
+    }
+
+    public boolean isAsmChunk() {
+        return chunkKind() == ChunkKind.ASM;
+    }
+
+    public boolean hasFiles() {
+        return !files.isEmpty();
+    }
+
+    public List<Path> classpathEntries() {
+        return compileClasspathEntries;
+    }
+
+    public String rootPathString() {
+        return RepoPathUtils.toRepoRelative(repoRoot, rootPath);
+    }
+
+    public String sourceRootString() {
+        return isAstChunk() ? rootPathString() : null;
+    }
+
+    public String bytecodeRootString() {
+        return isAsmChunk() ? rootPathString() : null;
+    }
+
+    private static String normalizeModule(String module) {
+        if (module == null || module.isBlank()) {
+            return "root";
+        }
+        return module;
+    }
+
+    private static List<Path> sanitizePaths(List<Path> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Path> normalized = new LinkedHashSet<>();
+        for (Path path : paths) {
+            if (path == null) {
+                continue;
+            }
+            normalized.add(path.normalize());
+        }
+        return List.copyOf(normalized);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionFacadeContext.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionFacadeContext.java
@@ -1,0 +1,53 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.extraction.dto.model.BuildMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkingPolicy;
+import com.example.ossdoc.domain.extraction.dto.model.JobMeta;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightResult;
+import lombok.Builder;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * facade가 extraction 전체 흐름 동안 유지하는 정규화 컨텍스트.
+ *
+ * facade는 runId -> 경로/manifest 로딩 -> preflight -> chunk planning -> merge -> compose/write 까지의
+ * 상위 orchestration만 담당하고, 각 단계의 세부 구현은 support/extractor/composer/writer에 위임한다.
+ */
+@Builder
+public record ExtractionFacadeContext(
+        FactsExtractRequest request,
+        String runId,
+
+        OffsetDateTime startedAt,
+        OffsetDateTime finishedAt,
+
+        Path workspaceRoot,
+        Path repoRoot,
+        Path artifactsRoot,
+        Path buildManifestPath,
+
+        BuildManifest buildManifest,
+        ExtractionPreflightResult preflightResult,
+        ChunkingPolicy chunkingPolicy,
+
+        JobMeta jobMeta,
+        BuildMeta buildMeta,
+
+        Map<String, String> engineVersions
+) {
+    public ExtractionFacadeContext {
+        engineVersions = engineVersions == null
+                ? Map.of()
+                : Map.copyOf(new LinkedHashMap<>(engineVersions));
+    }
+
+    public boolean hasPreflight() {
+        return preflightResult != null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionSink.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/ExtractionSink.java
@@ -1,0 +1,345 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.ChunkStatus;
+import com.example.ossdoc.domain.extraction.enums.ObservationKind;
+import com.example.ossdoc.domain.extraction.enums.RelationKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+import com.example.ossdoc.domain.extraction.service.support.merge.StatsAccumulator;
+import com.example.ossdoc.domain.extraction.service.support.util.WarningCollector;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * extractor 내부의 mutable collector.
+ * 최종 반환 직전에 ChunkResult immutable 객체로 변환한다.
+ */
+public class ExtractionSink {
+
+    private final ChunkKind chunkKind;
+
+    private final Map<String, EvidenceFact> evidence = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> modules = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> packages = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> types = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> constructors = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> methods = new LinkedHashMap<>();
+    private final Map<String, SymbolFact> fields = new LinkedHashMap<>();
+
+    private final Map<String, RelationFact> contains = new LinkedHashMap<>();
+    private final Map<String, RelationFact> extendsRelations = new LinkedHashMap<>();
+    private final Map<String, RelationFact> implementsRelations = new LinkedHashMap<>();
+    private final Map<String, RelationFact> overrides = new LinkedHashMap<>();
+    private final Map<String, RelationFact> calls = new LinkedHashMap<>();
+    private final Map<String, RelationFact> accessesField = new LinkedHashMap<>();
+    private final Map<String, RelationFact> fieldType = new LinkedHashMap<>();
+    private final Map<String, RelationFact> paramType = new LinkedHashMap<>();
+    private final Map<String, RelationFact> returnType = new LinkedHashMap<>();
+    private final Map<String, RelationFact> throwsType = new LinkedHashMap<>();
+    private final Map<String, RelationFact> annotatedBy = new LinkedHashMap<>();
+
+    private final Map<String, ObservationFact> diInjectionSites = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> diProviders = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> spiProviders = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> eventPublish = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> eventSubscribe = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> reflectionUses = new LinkedHashMap<>();
+    private final Map<String, ObservationFact> configWiring = new LinkedHashMap<>();
+
+    private final StatsAccumulator stats = new StatsAccumulator();
+    private final WarningCollector warnings = new WarningCollector();
+    private final WarningCollector errors = new WarningCollector();
+
+    public ExtractionSink(ChunkKind chunkKind) {
+        this.chunkKind = chunkKind;
+    }
+
+    public void addWarning(String warning) {
+        warnings.add(warning);
+    }
+
+    public void addWarnings(List<String> items) {
+        warnings.addAll(items);
+    }
+
+    public void addError(String error) {
+        errors.add(error);
+        stats.recordError();
+    }
+
+    public void recordFileScanned() {
+        stats.recordScannedFileKind(chunkKind);
+    }
+
+    public void recordFileParsed() {
+        stats.recordParsedFileKind(chunkKind);
+    }
+
+    public void recordFileSkipped() {
+        stats.recordFileSkipped();
+    }
+
+    public void recordError() {
+        stats.recordError();
+    }
+
+    public void recordUnresolvedTypeRef() {
+        stats.recordUnresolvedTypeRef();
+    }
+
+    public void addEvidence(EvidenceFact fact) {
+        if (fact == null || fact.id() == null || fact.id().isBlank()) {
+            return;
+        }
+        if (!evidence.containsKey(fact.id())) {
+            evidence.put(fact.id(), fact);
+            stats.recordEvidence();
+        }
+    }
+
+    public void addSymbol(SymbolFact fact) {
+        if (fact == null || fact.symbol() == null || fact.symbol().isBlank() || fact.kind() == null) {
+            return;
+        }
+
+        Map<String, SymbolFact> bucket = symbolBucket(fact.kind());
+        if (!bucket.containsKey(fact.symbol())) {
+            bucket.put(fact.symbol(), fact);
+            stats.recordSymbol(fact);
+        }
+    }
+
+    public void addRelation(RelationFact fact) {
+        if (fact == null || fact.kind() == null || fact.srcSymbol() == null || fact.srcSymbol().isBlank()) {
+            return;
+        }
+
+        Map<String, RelationFact> bucket = relationBucket(fact.kind());
+        String key = relationKey(fact);
+        if (!bucket.containsKey(key)) {
+            bucket.put(key, fact);
+            stats.recordRelation();
+        }
+    }
+
+    public void addObservation(ObservationFact fact) {
+        if (fact == null || fact.kind() == null) {
+            return;
+        }
+
+        Map<String, ObservationFact> bucket = observationBucket(fact.kind());
+        String key = observationKey(fact);
+        if (!bucket.containsKey(key)) {
+            bucket.put(key, fact);
+            stats.recordObservation();
+        }
+    }
+
+    public ChunkResult toChunkResult(ChunkDescriptor descriptor) {
+        StatsMeta snapshot = stats.snapshot();
+        List<String> errorList = errors.snapshot();
+
+        boolean hasProducedFacts = !evidence.isEmpty()
+                || !modules.isEmpty()
+                || !packages.isEmpty()
+                || !types.isEmpty()
+                || !constructors.isEmpty()
+                || !methods.isEmpty()
+                || !fields.isEmpty()
+                || !contains.isEmpty()
+                || !extendsRelations.isEmpty()
+                || !implementsRelations.isEmpty()
+                || !overrides.isEmpty()
+                || !calls.isEmpty()
+                || !accessesField.isEmpty()
+                || !fieldType.isEmpty()
+                || !paramType.isEmpty()
+                || !returnType.isEmpty()
+                || !throwsType.isEmpty()
+                || !annotatedBy.isEmpty()
+                || !diInjectionSites.isEmpty()
+                || !diProviders.isEmpty()
+                || !spiProviders.isEmpty()
+                || !eventPublish.isEmpty()
+                || !eventSubscribe.isEmpty()
+                || !reflectionUses.isEmpty()
+                || !configWiring.isEmpty();
+
+        ChunkStatus status;
+        if (errorList.isEmpty()) {
+            status = ChunkStatus.SUCCEEDED;
+        } else if (hasProducedFacts || snapshot.filesParsed() > 0) {
+            status = ChunkStatus.PARTIAL;
+        } else {
+            status = ChunkStatus.FAILED;
+        }
+
+        return ChunkResult.builder()
+                .descriptor(descriptor)
+                .status(status)
+                .evidence(Map.copyOf(evidence))
+                .symbols(allSymbols())
+                .relations(allRelations())
+                .observations(allObservations())
+                .stats(snapshot)
+                .warnings(warnings.snapshot())
+                .errors(errorList)
+                .build();
+    }
+
+    public ExtractedFacts toExtractedFacts() {
+        return new ExtractedFacts(
+                Map.copyOf(evidence),
+                SymbolTable.builder()
+                        .modules(List.copyOf(modules.values()))
+                        .packages(List.copyOf(packages.values()))
+                        .types(List.copyOf(types.values()))
+                        .constructors(List.copyOf(constructors.values()))
+                        .methods(List.copyOf(methods.values()))
+                        .fields(List.copyOf(fields.values()))
+                        .build(),
+                RelationTable.builder()
+                        .contains(List.copyOf(contains.values()))
+                        .extendsRelations(List.copyOf(extendsRelations.values()))
+                        .implementsRelations(List.copyOf(implementsRelations.values()))
+                        .overrides(List.copyOf(overrides.values()))
+                        .calls(List.copyOf(calls.values()))
+                        .accessesField(List.copyOf(accessesField.values()))
+                        .fieldType(List.copyOf(fieldType.values()))
+                        .paramType(List.copyOf(paramType.values()))
+                        .returnType(List.copyOf(returnType.values()))
+                        .throwsType(List.copyOf(throwsType.values()))
+                        .annotatedBy(List.copyOf(annotatedBy.values()))
+                        .build(),
+                ObservationTable.builder()
+                        .diInjectionSites(List.copyOf(diInjectionSites.values()))
+                        .diProviders(List.copyOf(diProviders.values()))
+                        .spiProviders(List.copyOf(spiProviders.values()))
+                        .eventPublish(List.copyOf(eventPublish.values()))
+                        .eventSubscribe(List.copyOf(eventSubscribe.values()))
+                        .reflectionUses(List.copyOf(reflectionUses.values()))
+                        .configWiring(List.copyOf(configWiring.values()))
+                        .build(),
+                stats.snapshot(),
+                warnings.snapshot(),
+                errors.snapshot()
+        );
+    }
+
+    private List<SymbolFact> allSymbols() {
+        List<SymbolFact> items = new ArrayList<>();
+        items.addAll(modules.values());
+        items.addAll(packages.values());
+        items.addAll(types.values());
+        items.addAll(constructors.values());
+        items.addAll(methods.values());
+        items.addAll(fields.values());
+        return List.copyOf(items);
+    }
+
+    private List<RelationFact> allRelations() {
+        List<RelationFact> items = new ArrayList<>();
+        items.addAll(contains.values());
+        items.addAll(extendsRelations.values());
+        items.addAll(implementsRelations.values());
+        items.addAll(overrides.values());
+        items.addAll(calls.values());
+        items.addAll(accessesField.values());
+        items.addAll(fieldType.values());
+        items.addAll(paramType.values());
+        items.addAll(returnType.values());
+        items.addAll(throwsType.values());
+        items.addAll(annotatedBy.values());
+        return List.copyOf(items);
+    }
+
+    private List<ObservationFact> allObservations() {
+        List<ObservationFact> items = new ArrayList<>();
+        items.addAll(diInjectionSites.values());
+        items.addAll(diProviders.values());
+        items.addAll(spiProviders.values());
+        items.addAll(eventPublish.values());
+        items.addAll(eventSubscribe.values());
+        items.addAll(reflectionUses.values());
+        items.addAll(configWiring.values());
+        return List.copyOf(items);
+    }
+
+    private Map<String, SymbolFact> symbolBucket(SymbolFactKind kind) {
+        return switch (kind) {
+            case MODULE -> modules;
+            case PACKAGE -> packages;
+            case TYPE -> types;
+            case CONSTRUCTOR -> constructors;
+            case METHOD -> methods;
+            case FIELD -> fields;
+        };
+    }
+
+    private Map<String, RelationFact> relationBucket(RelationKind kind) {
+        return switch (kind) {
+            case CONTAINS -> contains;
+            case EXTENDS -> extendsRelations;
+            case IMPLEMENTS -> implementsRelations;
+            case OVERRIDES -> overrides;
+            case CALLS -> calls;
+            case ACCESSES_FIELD -> accessesField;
+            case FIELD_TYPE -> fieldType;
+            case PARAM_TYPE -> paramType;
+            case RETURN_TYPE -> returnType;
+            case THROWS_TYPE -> throwsType;
+            case ANNOTATED_BY -> annotatedBy;
+        };
+    }
+
+    private Map<String, ObservationFact> observationBucket(ObservationKind kind) {
+        return switch (kind) {
+            case DI_INJECTION_SITE -> diInjectionSites;
+            case DI_PROVIDER -> diProviders;
+            case SPI_PROVIDER -> spiProviders;
+            case EVENT_PUBLISH -> eventPublish;
+            case EVENT_SUBSCRIBE -> eventSubscribe;
+            case REFLECTION_USE -> reflectionUses;
+            case CONFIG_WIRING -> configWiring;
+        };
+    }
+
+    private String relationKey(RelationFact fact) {
+        return String.join("|",
+                fact.kind().code(),
+                nullSafe(fact.srcSymbol()),
+                nullSafe(fact.dstSymbol()),
+                nullSafe(fact.dstRawRef()),
+                nullSafe(fact.origin() == null ? null : fact.origin().code())
+        );
+    }
+
+    private String observationKey(ObservationFact fact) {
+        return String.join("|",
+                fact.kind().code(),
+                nullSafe(fact.siteSymbol()),
+                nullSafe(fact.targetSymbol()),
+                nullSafe(fact.serviceInterfaceSymbol()),
+                nullSafe(fact.targetTypeRef() == null ? null : fact.targetTypeRef().raw()),
+                nullSafe(fact.note())
+        );
+    }
+
+    private String nullSafe(String value) {
+        return Objects.toString(value, "");
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/FactsCompositionContext.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/FactsCompositionContext.java
@@ -1,0 +1,86 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.extraction.dto.model.BuildMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionAggregate;
+import com.example.ossdoc.domain.extraction.dto.model.JobMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+import com.example.ossdoc.domain.extraction.enums.BytecodeAvailability;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * composer가 FactsDocument를 만들기 위해 필요한 상위 컨텍스트.
+ *
+ * extractor/merge 단계는 이미 끝났고,
+ * composer는 facade/service가 넘겨준 aggregate를 facts.json 형태로만 정리한다.
+ */
+public record FactsCompositionContext(
+        String schemaVersion,
+        JobMeta job,
+        BuildMeta build,
+        ExtractionMode mode,
+        BytecodeAvailability bytecodeAvailability,
+        OffsetDateTime startedAt,
+        OffsetDateTime finishedAt,
+        Map<String, String> engineVersions,
+        List<String> warnings,
+        List<String> scannedModules,
+        List<String> scannedSourceRoots,
+        List<String> scannedBytecodeRoots,
+        boolean includeObservations,
+        ExtractionAggregate aggregate
+) {
+    public FactsCompositionContext {
+        engineVersions = engineVersions == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(engineVersions));
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        scannedModules = scannedModules == null ? List.of() : List.copyOf(scannedModules);
+        scannedSourceRoots = scannedSourceRoots == null ? List.of() : List.copyOf(scannedSourceRoots);
+        scannedBytecodeRoots = scannedBytecodeRoots == null ? List.of() : List.copyOf(scannedBytecodeRoots);
+        aggregate = aggregate == null ? emptyAggregate() : aggregate;
+    }
+
+    private static ExtractionAggregate emptyAggregate() {
+        return ExtractionAggregate.builder()
+                .evidence(Map.of())
+                .symbols(SymbolTable.builder()
+                        .modules(List.of())
+                        .packages(List.of())
+                        .types(List.of())
+                        .constructors(List.of())
+                        .methods(List.of())
+                        .fields(List.of())
+                        .build())
+                .relations(RelationTable.builder()
+                        .contains(List.of())
+                        .extendsRelations(List.of())
+                        .implementsRelations(List.of())
+                        .overrides(List.of())
+                        .calls(List.of())
+                        .accessesField(List.of())
+                        .fieldType(List.of())
+                        .paramType(List.of())
+                        .returnType(List.of())
+                        .throwsType(List.of())
+                        .annotatedBy(List.of())
+                        .build())
+                .observations(ObservationTable.builder()
+                        .diInjectionSites(List.of())
+                        .diProviders(List.of())
+                        .spiProviders(List.of())
+                        .eventPublish(List.of())
+                        .eventSubscribe(List.of())
+                        .reflectionUses(List.of())
+                        .configWiring(List.of())
+                        .build())
+                .stats(StatsMeta.builder().build())
+                .warnings(List.of())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/context/FactsWriteContext.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/context/FactsWriteContext.java
@@ -1,0 +1,30 @@
+package com.example.ossdoc.domain.extraction.dto.context;
+
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * writer 입력 컨텍스트
+ *
+ * writer는 composer가 완성한 FactsDocument를 받아 S3에 업로드하고
+ * 추가 warning을 extraction warning과 합쳐 최종 응답을 만든다.
+ */
+public record FactsWriteContext(
+        String runId,
+        Path artifactsRoot,
+        FactsDocument document,
+        List<String> additionalWarnings
+) {
+    public FactsWriteContext {
+        Objects.requireNonNull(runId, "runId must not be null");
+        if (runId.isBlank()) {
+            throw new IllegalArgumentException("runId must not be blank");
+        }
+        Objects.requireNonNull(artifactsRoot, "artifactsRoot must not be null");
+        Objects.requireNonNull(document, "document must not be null");
+        additionalWarnings = additionalWarnings == null ? List.of() : List.copyOf(additionalWarnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/BuildMeta.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/BuildMeta.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 빌드 단계 결과 요약
+ *
+ * status 는 빌드 결과 상태(success/failed/partial/skipped/unknown),
+ * mode 는 빌드 수행 형태(FULL / COMPILE_ONLY / SOURCE_ONLY / FAILED 등)를 담는다.
+ *
+ * build 도메인 enum이 확정되면 그 enum을 직접 재사용하거나
+ * mapper에서 문자열로 변환해 넣는 것을 권장한다.
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BuildMeta(
+        @JsonProperty("status")
+        String status,
+
+        @JsonProperty("mode")
+        String mode,
+
+        @JsonProperty("tool")
+        String tool,
+
+        @JsonProperty("java_version_used")
+        String javaVersionUsed,
+
+        @JsonProperty("classpath_fingerprint")
+        String classpathFingerprint,
+
+        @JsonProperty("modules")
+        List<String> modules,
+
+        @JsonProperty("bytecode_roots")
+        List<String> bytecodeRoots,
+
+        @JsonProperty("classpath_entries")
+        List<String> classpathEntries
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkDescriptor.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkDescriptor.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * worker에 전달되는 청크 작업 단위
+ */
+@Builder
+public record ChunkDescriptor(
+        String chunkId,
+        ChunkKind kind,
+        String module,
+        String rootPath,
+        List<String> files,
+        long totalBytes,
+        int fileCount
+) {
+    public ChunkDescriptor {
+        files = files == null ? List.of() : List.copyOf(files);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkResult.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkResult.java
@@ -1,0 +1,32 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.ChunkStatus;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 청크 1건 처리 결과
+ */
+@Builder
+public record ChunkResult(
+        ChunkDescriptor descriptor,
+        ChunkStatus status,
+        Map<String, EvidenceFact> evidence,
+        List<SymbolFact> symbols,
+        List<RelationFact> relations,
+        List<ObservationFact> observations,
+        StatsMeta stats,
+        List<String> warnings,
+        List<String> errors
+) {
+    public ChunkResult {
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+        symbols = symbols == null ? List.of() : List.copyOf(symbols);
+        relations = relations == null ? List.of() : List.copyOf(relations);
+        observations = observations == null ? List.of() : List.copyOf(observations);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        errors = errors == null ? List.of() : List.copyOf(errors);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkingPolicy.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ChunkingPolicy.java
@@ -1,0 +1,39 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import lombok.Builder;
+
+/**
+ * 병렬 청크 분할 / worker pool 정책
+ */
+@Builder
+public record ChunkingPolicy(
+        int astMaxFiles,
+        long astMaxBytes,
+        int asmMaxFiles,
+        long asmMaxBytes,
+        int workerCount
+) {
+    public ChunkingPolicy {
+        if (astMaxFiles <= 0) {
+            throw new IllegalArgumentException("astMaxFiles must be greater than 0");
+        }
+        if (astMaxBytes <= 0) {
+            throw new IllegalArgumentException("astMaxBytes must be greater than 0");
+        }
+        if (asmMaxFiles <= 0) {
+            throw new IllegalArgumentException("asmMaxFiles must be greater than 0");
+        }
+        if (asmMaxBytes <= 0) {
+            throw new IllegalArgumentException("asmMaxBytes must be greater than 0");
+        }
+        if (workerCount <= 0) {
+            throw new IllegalArgumentException("workerCount must be greater than 0");
+        }
+    }
+
+    public static ChunkingPolicy standard() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        int workers = Math.max(1, Math.min(processors, 8));
+        return new ChunkingPolicy(30, 1_500_000L, 100, 3_000_000L, workers);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/EvidenceFact.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/EvidenceFact.java
@@ -1,0 +1,46 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.EvidenceKind;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * 코드 위치 기반 근거
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EvidenceFact(
+        @JsonProperty("id")
+        String id,
+
+        @JsonProperty("type")
+        EvidenceKind type,
+
+        /**
+         * repo 상대경로 권장
+         */
+        @JsonProperty("path")
+        String path,
+
+        @JsonProperty("span")
+        SourceSpan span,
+
+        /**
+         * 관련 심볼이 있으면 연결
+         */
+        @JsonProperty("symbol")
+        String symbol,
+
+        @JsonProperty("snippet")
+        String snippet,
+
+        @JsonProperty("hash")
+        String hash,
+
+        @JsonProperty("attrs")
+        Map<String, Object> attrs
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ExtractionAggregate.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ExtractionAggregate.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * composer 직전 최종 집계 결과
+ */
+@Builder
+public record ExtractionAggregate(
+        Map<String, EvidenceFact> evidence,
+        SymbolTable symbols,
+        RelationTable relations,
+        ObservationTable observations,
+        StatsMeta stats,
+        List<String> warnings
+) {
+    public ExtractionAggregate {
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ExtractionMeta.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ExtractionMeta.java
@@ -1,0 +1,49 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.BytecodeAvailability;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 추출 단계 메타
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ExtractionMeta(
+        @JsonProperty("mode")
+        ExtractionMode mode,
+
+        @JsonProperty("bytecode_availability")
+        BytecodeAvailability bytecodeAvailability,
+
+        @JsonProperty("started_at")
+        OffsetDateTime startedAt,
+
+        @JsonProperty("finished_at")
+        OffsetDateTime finishedAt,
+
+        @JsonProperty("warnings")
+        List<String> warnings,
+
+        @JsonProperty("scanned_modules")
+        List<String> scannedModules,
+
+        @JsonProperty("scanned_source_roots")
+        List<String> scannedSourceRoots,
+
+        @JsonProperty("scanned_bytecode_roots")
+        List<String> scannedBytecodeRoots,
+
+        /**
+         * 예: {"ast":"javaparser-3.28.0", "bytecode":"asm-9.7"}
+         */
+        @JsonProperty("engine_versions")
+        Map<String, String> engineVersions
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/FactsDocument.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/FactsDocument.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * facts.json 최상위 루트
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FactsDocument(
+        @JsonProperty("schema_version")
+        String schemaVersion,
+
+        @JsonProperty("job")
+        JobMeta job,
+
+        @JsonProperty("build")
+        BuildMeta build,
+
+        @JsonProperty("extraction")
+        ExtractionMeta extraction,
+
+        @JsonProperty("stats")
+        StatsMeta stats,
+
+        /**
+         * evidence_id -> EvidenceFact
+         */
+        @JsonProperty("evidence")
+        Map<String, EvidenceFact> evidence,
+
+        @JsonProperty("symbols")
+        SymbolTable symbols,
+
+        @JsonProperty("relations")
+        RelationTable relations,
+
+        @JsonProperty("observations")
+        ObservationTable observations
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/JobMeta.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/JobMeta.java
@@ -1,0 +1,22 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * 어떤 job / repo / commit에 대해 facts를 생성했는지 나타내는 재현성 메타
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record JobMeta(
+        @JsonProperty("job_id")
+        String jobId,
+
+        @JsonProperty("repo_url")
+        String repoUrl,
+
+        @JsonProperty("commit_sha")
+        String commitSha
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ModuleMergeResult.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ModuleMergeResult.java
@@ -1,0 +1,32 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.MergeStage;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * module 단위 병합 결과
+ */
+@Builder
+public record ModuleMergeResult(
+        String module,
+        MergeStage stage,
+        List<RootMergeResult> roots,
+        Map<String, EvidenceFact> evidence,
+        List<SymbolFact> symbols,
+        List<RelationFact> relations,
+        List<ObservationFact> observations,
+        StatsMeta stats,
+        List<String> warnings
+) {
+    public ModuleMergeResult {
+        roots = roots == null ? List.of() : List.copyOf(roots);
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+        symbols = symbols == null ? List.of() : List.copyOf(symbols);
+        relations = relations == null ? List.of() : List.copyOf(relations);
+        observations = observations == null ? List.of() : List.copyOf(observations);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ObservationFact.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ObservationFact.java
@@ -1,0 +1,57 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.FactOriginKind;
+import com.example.ossdoc.domain.extraction.enums.ObservationKind;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DI/SPI/Reflection/Event 같은 비정적 연결의 관측 사실
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ObservationFact(
+        @JsonProperty("kind")
+        ObservationKind kind,
+
+        /**
+         * 관측된 위치의 심볼
+         */
+        @JsonProperty("site_symbol")
+        String siteSymbol,
+
+        /**
+         * 대상이 내부 심볼로 해석되면 채움
+         */
+        @JsonProperty("target_symbol")
+        String targetSymbol,
+
+        /**
+         * 대상이 타입 참조로만 존재하는 경우
+         */
+        @JsonProperty("target_type_ref")
+        TypeRef targetTypeRef,
+
+        /**
+         * SPI 같이 서비스 인터페이스 심볼이 따로 있을 때 사용
+         */
+        @JsonProperty("service_interface_symbol")
+        String serviceInterfaceSymbol,
+
+        @JsonProperty("note")
+        String note,
+
+        @JsonProperty("evidence_ids")
+        List<String> evidenceIds,
+
+        @JsonProperty("origin")
+        FactOriginKind origin,
+
+        @JsonProperty("attrs")
+        Map<String, Object> attrs
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ObservationTable.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/ObservationTable.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * observation bucket 테이블
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ObservationTable(
+        @JsonProperty("di_injection_sites")
+        List<ObservationFact> diInjectionSites,
+
+        @JsonProperty("di_providers")
+        List<ObservationFact> diProviders,
+
+        @JsonProperty("spi_providers")
+        List<ObservationFact> spiProviders,
+
+        @JsonProperty("event_publish")
+        List<ObservationFact> eventPublish,
+
+        @JsonProperty("event_subscribe")
+        List<ObservationFact> eventSubscribe,
+
+        @JsonProperty("reflection_uses")
+        List<ObservationFact> reflectionUses,
+
+        @JsonProperty("config_wiring")
+        List<ObservationFact> configWiring
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationFact.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationFact.java
@@ -1,0 +1,56 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.FactOriginKind;
+import com.example.ossdoc.domain.extraction.enums.RelationKind;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Graph Builder가 바로 먹을 수 있는 관계 후보 한 건
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RelationFact(
+        @JsonProperty("kind")
+        RelationKind kind,
+
+        @JsonProperty("src_symbol")
+        String srcSymbol,
+
+        @JsonProperty("dst_symbol")
+        String dstSymbol,
+
+        @JsonProperty("dst_raw_ref")
+        String dstRawRef,
+
+        @JsonProperty("evidence_ids")
+        List<String> evidenceIds,
+
+        @JsonProperty("resolution")
+        RelationResolution resolution,
+
+        @JsonProperty("origin")
+        FactOriginKind origin,
+
+        @JsonProperty("confidence_hint")
+        Double confidenceHint,
+
+        @JsonProperty("attrs")
+        Map<String, Object> attrs
+) {
+    public RelationFact {
+        boolean hasDstSymbol = dstSymbol != null && !dstSymbol.isBlank();
+        boolean hasDstRaw = dstRawRef != null && !dstRawRef.isBlank();
+
+        if (!hasDstSymbol && !hasDstRaw) {
+            throw new IllegalArgumentException("Either dstSymbol or dstRawRef must be provided.");
+        }
+        if (hasDstSymbol && hasDstRaw) {
+            throw new IllegalArgumentException("Only one of dstSymbol or dstRawRef should be provided.");
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationResolution.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationResolution.java
@@ -1,0 +1,20 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.ResolutionStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * relation 해석 상태
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RelationResolution(
+        @JsonProperty("status")
+        ResolutionStatus status,
+
+        @JsonProperty("reason")
+        String reason
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationTable.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RelationTable.java
@@ -1,0 +1,48 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 관계 후보를 종류별 bucket으로 나눈 테이블
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RelationTable(
+        @JsonProperty("contains")
+        List<RelationFact> contains,
+
+        @JsonProperty("extends")
+        List<RelationFact> extendsRelations,
+
+        @JsonProperty("implements")
+        List<RelationFact> implementsRelations,
+
+        @JsonProperty("overrides")
+        List<RelationFact> overrides,
+
+        @JsonProperty("calls")
+        List<RelationFact> calls,
+
+        @JsonProperty("accesses_field")
+        List<RelationFact> accessesField,
+
+        @JsonProperty("field_type")
+        List<RelationFact> fieldType,
+
+        @JsonProperty("param_type")
+        List<RelationFact> paramType,
+
+        @JsonProperty("return_type")
+        List<RelationFact> returnType,
+
+        @JsonProperty("throws_type")
+        List<RelationFact> throwsType,
+
+        @JsonProperty("annotated_by")
+        List<RelationFact> annotatedBy
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RootMergeResult.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/RootMergeResult.java
@@ -1,0 +1,35 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.MergeStage;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * sourceRoot / bytecodeRoot 단위 병합 결과
+ */
+@Builder
+public record RootMergeResult(
+        String module,
+        String rootPath,
+        ChunkKind kind,
+        MergeStage stage,
+        List<ChunkResult> chunkResults,
+        Map<String, EvidenceFact> evidence,
+        List<SymbolFact> symbols,
+        List<RelationFact> relations,
+        List<ObservationFact> observations,
+        StatsMeta stats,
+        List<String> warnings
+) {
+    public RootMergeResult {
+        chunkResults = chunkResults == null ? List.of() : List.copyOf(chunkResults);
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+        symbols = symbols == null ? List.of() : List.copyOf(symbols);
+        relations = relations == null ? List.of() : List.copyOf(relations);
+        observations = observations == null ? List.of() : List.copyOf(observations);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SignatureFact.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SignatureFact.java
@@ -1,0 +1,39 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 메서드/생성자/필드 시그니처 표준 구조
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SignatureFact(
+        /**
+         * 메서드/생성자 파라미터 타입들
+         */
+        @JsonProperty("params")
+        List<TypeRef> params,
+
+        /**
+         * 메서드 반환 타입
+         */
+        @JsonProperty("returns")
+        TypeRef returns,
+
+        /**
+         * throws 선언 타입들
+         */
+        @JsonProperty("throws")
+        List<TypeRef> throwsTypes,
+
+        /**
+         * 필드 타입
+         */
+        @JsonProperty("field_type")
+        TypeRef fieldType
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SourceSpan.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SourceSpan.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * 소스 코드 위치(라인/컬럼 범위)
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SourceSpan(
+        @JsonProperty("start_line")
+        Integer startLine,
+
+        @JsonProperty("start_col")
+        Integer startCol,
+
+        @JsonProperty("end_line")
+        Integer endLine,
+
+        @JsonProperty("end_col")
+        Integer endCol
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/StatsMeta.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/StatsMeta.java
@@ -1,0 +1,76 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * facts 추출 통계
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record StatsMeta(
+        @JsonProperty("files_scanned")
+        long filesScanned,
+
+        @JsonProperty("files_parsed")
+        long filesParsed,
+
+        @JsonProperty("files_skipped")
+        long filesSkipped,
+
+        @JsonProperty("ast_files_scanned")
+        long astFilesScanned,
+
+        @JsonProperty("class_files_scanned")
+        long classFilesScanned,
+
+        @JsonProperty("ast_files_parsed")
+        long astFilesParsed,
+
+        @JsonProperty("class_files_parsed")
+        long classFilesParsed,
+
+        @JsonProperty("chunks_total")
+        long chunksTotal,
+
+        @JsonProperty("chunks_succeeded")
+        long chunksSucceeded,
+
+        @JsonProperty("chunks_failed")
+        long chunksFailed,
+
+        @JsonProperty("chunks_partial")
+        long chunksPartial,
+
+        @JsonProperty("types")
+        long types,
+
+        @JsonProperty("constructors")
+        long constructors,
+
+        @JsonProperty("methods")
+        long methods,
+
+        @JsonProperty("fields")
+        long fields,
+
+        @JsonProperty("edges_candidates")
+        long edgeCandidates,
+
+        @JsonProperty("relations")
+        long relations,
+
+        @JsonProperty("observations")
+        long observations,
+
+        @JsonProperty("evidence")
+        long evidence,
+
+        @JsonProperty("unresolved_type_refs")
+        long unresolvedTypeRefs,
+
+        @JsonProperty("errors")
+        long errors
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SymbolFact.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SymbolFact.java
@@ -1,0 +1,127 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.example.ossdoc.domain.extraction.enums.AccessLevel;
+import com.example.ossdoc.domain.extraction.enums.ModifierKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolOriginKind;
+import com.example.ossdoc.domain.extraction.enums.TypeKind;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 심볼(타입/메서드/필드 등) 원시 사실
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SymbolFact(
+        @JsonProperty("symbol")
+        String symbol,
+
+        @JsonProperty("kind")
+        SymbolFactKind kind,
+
+        @JsonProperty("type_kind")
+        TypeKind typeKind,
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("qualified_name")
+        String qualifiedName,
+
+        /**
+         * method / constructor / field의 owner type
+         */
+        @JsonProperty("owner_type_symbol")
+        String ownerTypeSymbol,
+
+        /**
+         * type의 package symbol
+         */
+        @JsonProperty("package_symbol")
+        String packageSymbol,
+
+        /**
+         * 추출 시점의 모듈 이름
+         */
+        @JsonProperty("module")
+        String module,
+
+        /**
+         * AST 관점 source root
+         */
+        @JsonProperty("source_root")
+        String sourceRoot,
+
+        /**
+         * ASM 관점 bytecode root
+         */
+        @JsonProperty("bytecode_root")
+        String bytecodeRoot,
+
+        /**
+         * 중첩 타입이면 바깥 타입 심볼
+         */
+        @JsonProperty("nested_in")
+        String nestedIn,
+
+        @JsonProperty("access")
+        AccessLevel access,
+
+        @JsonProperty("modifiers")
+        Set<ModifierKind> modifiers,
+
+        @JsonProperty("origin")
+        SymbolOriginKind origin,
+
+        @JsonProperty("annotations")
+        List<TypeRef> annotations,
+
+        @JsonProperty("evidence_ids")
+        List<String> evidenceIds,
+
+        @JsonProperty("attrs")
+        Map<String, Object> attrs,
+
+        /**
+         * method/constructor/field signature
+         */
+        @JsonProperty("signature")
+        SignatureFact signature,
+
+        /**
+         * TYPE 심볼용 부가 정보
+         */
+        @JsonProperty("super_type_ref")
+        TypeRef superTypeRef,
+
+        @JsonProperty("interface_type_refs")
+        List<TypeRef> interfaceTypeRefs,
+
+        @JsonProperty("source_file")
+        String sourceFile,
+
+        /**
+         * bytecode 관점 부가 정보
+         */
+        @JsonProperty("is_bridge")
+        Boolean isBridge,
+
+        @JsonProperty("is_synthetic")
+        Boolean isSynthetic,
+
+        @JsonProperty("bytecode_descriptor")
+        String bytecodeDescriptor,
+
+        /**
+         * 같은 파일/클래스 내의 local call 후보
+         */
+        @JsonProperty("local_calls")
+        List<String> localCalls
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SymbolTable.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/SymbolTable.java
@@ -1,0 +1,33 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 심볼을 종류별 bucket으로 나눈 테이블
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SymbolTable(
+        @JsonProperty("modules")
+        List<SymbolFact> modules,
+
+        @JsonProperty("packages")
+        List<SymbolFact> packages,
+
+        @JsonProperty("types")
+        List<SymbolFact> types,
+
+        @JsonProperty("constructors")
+        List<SymbolFact> constructors,
+
+        @JsonProperty("methods")
+        List<SymbolFact> methods,
+
+        @JsonProperty("fields")
+        List<SymbolFact> fields
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/model/TypeRef.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/model/TypeRef.java
@@ -1,0 +1,50 @@
+package com.example.ossdoc.domain.extraction.dto.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 타입 참조 표준 구조
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TypeRef(
+        /**
+         * 가능한 표준화된 이름(FQN 권장)
+         * 예: java.util.List
+         */
+        @JsonProperty("raw")
+        String raw,
+
+        /**
+         * 제네릭 인자들
+         */
+        @JsonProperty("args")
+        List<TypeRef> args,
+
+        /**
+         * 배열 차원 (int[][] -> 2)
+         */
+        @JsonProperty("array_dim")
+        Integer arrayDim,
+
+        @JsonProperty("primitive")
+        Boolean primitive,
+
+        /**
+         * 해결 여부 힌트
+         */
+        @JsonProperty("unresolved")
+        Boolean unresolved,
+
+        /**
+         * AST 기준 원문 타입 표현
+         * 예: List<String>
+         */
+        @JsonProperty("source_text")
+        String sourceText
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/request/FactsExtractRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/request/FactsExtractRequest.java
@@ -1,0 +1,67 @@
+package com.example.ossdoc.domain.extraction.dto.request;
+
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * facts 추출 요청 입력
+ */
+@Builder
+public record FactsExtractRequest(
+        @NotBlank
+        String runId,
+
+        /**
+         * null이면 service가 build 정보 등을 보고 자동 결정
+         */
+        ExtractionMode mode,
+
+        /**
+         * observation 추출 포함 여부
+         */
+        boolean includeObservations,
+
+        /**
+         * test source / test bytecode 포함 여부
+         */
+        boolean includeTests,
+
+        /**
+         * 일부 파일 실패 시 즉시 중단할지 여부
+         */
+        boolean failFast,
+
+        /**
+         * 특정 모듈만 대상으로 제한하고 싶을 때(옵션)
+         * 예: ["root", "module-a", "module-b"]
+         */
+        List<String> targetModules,
+
+        /**
+         * 특정 경로만 스캔하고 싶을 때(옵션)
+         * 예: ["src/main/java", "module-a/src/main/java"]
+         */
+        List<String> includeGlobs,
+
+        /**
+         * 제외할 경로 패턴(옵션)
+         * 예: ["##/generated/##", "##/build/##"]
+         */
+        List<String> excludeGlobs
+) {
+    public FactsExtractRequest {
+        targetModules = filterBlanks(targetModules);
+        includeGlobs  = filterBlanks(includeGlobs);
+        excludeGlobs  = filterBlanks(excludeGlobs);
+    }
+
+    private static List<String> filterBlanks(List<String> values) {
+        if (values == null) return List.of();
+        return values.stream()
+                .filter(v -> v != null && !v.isBlank())
+                .toList();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/dto/response/FactsExtractResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/dto/response/FactsExtractResponse.java
@@ -1,0 +1,29 @@
+package com.example.ossdoc.domain.extraction.dto.response;
+
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.enums.BytecodeAvailability;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 추출 결과 요약 응답
+ */
+@Builder
+public record FactsExtractResponse(
+        String runId,
+        ExtractionMode mode,
+        BytecodeAvailability bytecodeAvailability,
+
+        String schemaVersion,
+
+        List<String> scannedModules,
+        StatsMeta stats,
+        List<String> warnings
+) {
+    public FactsExtractResponse {
+        scannedModules = scannedModules == null ? List.of() : List.copyOf(scannedModules);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/AccessLevel.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/AccessLevel.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 접근 제어자
+ */
+public enum AccessLevel {
+    PUBLIC("public"),
+    PROTECTED("protected"),
+    PACKAGE("package"),
+    PRIVATE("private");
+
+    private final String code;
+
+    AccessLevel(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/BuildStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/BuildStatus.java
@@ -1,0 +1,27 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 빌드 상태
+ * BuildStatus, BuildToolKind는 extraction에서 새로 만들지 말고,
+ * 지금은 String 유지 후 build 도메인 enum이 확정되면 그걸 참조하거나 매핑하자.
+ */
+public enum BuildStatus {
+    SUCCESS("success"),
+    FAILED("failed"),
+    PARTIAL("partial"),
+    SKIPPED("skipped"),
+    UNKNOWN("unknown");
+
+    private final String code;
+
+    BuildStatus(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/BytecodeAvailability.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/BytecodeAvailability.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * extraction 시작 전 bytecode 사용 가능 상태
+ */
+public enum BytecodeAvailability {
+    FULL("full"),
+    PARTIAL("partial"),
+    NONE("none");
+
+    private final String code;
+
+    BytecodeAvailability(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ChunkKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ChunkKind.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 병렬 추출 청크 종류
+ *
+ * AST : .java 소스 기반 청크
+ * ASM : .class 바이트코드 기반 청크
+ */
+public enum ChunkKind {
+    AST("ast"),
+    ASM("asm");
+
+    private final String code;
+
+    ChunkKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ChunkStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ChunkStatus.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 청크 실행 상태
+ */
+public enum ChunkStatus {
+    PENDING("pending"),
+    RUNNING("running"),
+    SUCCEEDED("succeeded"),
+    FAILED("failed"),
+    PARTIAL("partial");
+
+    private final String code;
+
+    ChunkStatus(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/EvidenceKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/EvidenceKind.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * evidence 종류
+ */
+public enum EvidenceKind {
+    AST("AST"),
+    BYTECODE("BYTECODE"),
+    RESOURCE("RESOURCE"),
+    README("README"),
+    TEST("TEST");
+
+    private final String code;
+
+    EvidenceKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ExtractionMode.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ExtractionMode.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * facts 추출 모드
+ */
+public enum ExtractionMode {
+    AST_ONLY("ast-only"),
+    AST_PLUS_BYTECODE("ast+bytecode"),
+    AST_PLUS_PARTIAL_BYTECODE("ast+partial-bytecode");
+
+    private final String code;
+
+    ExtractionMode(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/FactOriginKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/FactOriginKind.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * relation / observation 등의 출처
+ */
+public enum FactOriginKind {
+    AST("AST"),
+    BYTECODE("BYTECODE"),
+    MERGED("MERGED"),
+    OBSERVED("OBSERVED"),
+    RESOURCE("RESOURCE");
+
+    private final String code;
+
+    FactOriginKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/MergeStage.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/MergeStage.java
@@ -1,0 +1,29 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 병렬 추출 결과 병합 단계
+ *
+ * CHUNK  : worker local 결과
+ * ROOT   : sourceRoot / bytecodeRoot 단위 결과
+ * MODULE : module 단위 결과
+ * FINAL  : 최종 composer 입력 결과
+ */
+public enum MergeStage {
+    CHUNK("chunk"),
+    ROOT("root"),
+    MODULE("module"),
+    FINAL("final");
+
+    private final String code;
+
+    MergeStage(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ModifierKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ModifierKind.java
@@ -1,0 +1,39 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 자바 수정자.
+ *
+ * <p>{@code DEFAULT}, {@code SEALED}, {@code NON_SEALED}은 현재 extractor에서 매핑하지 않으나,
+ * Java 17+ sealed class 지원 시 필요하므로 유지한다.
+ * <ul>
+ *   <li>{@code DEFAULT} — 인터페이스 default 메서드 수정자</li>
+ *   <li>{@code SEALED} — 상속 허용 타입을 제한하는 sealed class/interface 수정자</li>
+ *   <li>{@code NON_SEALED} — sealed 계층에서 하위 클래스의 상속 제한을 해제하는 수정자</li>
+ * </ul>
+ */
+public enum ModifierKind {
+    STATIC("static"),
+    FINAL("final"),
+    ABSTRACT("abstract"),
+    SYNCHRONIZED("synchronized"),
+    NATIVE("native"),
+    STRICTFP("strictfp"),
+    TRANSIENT("transient"),
+    VOLATILE("volatile"),
+    DEFAULT("default"),
+    SEALED("sealed"),
+    NON_SEALED("non-sealed");
+
+    private final String code;
+
+    ModifierKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ObservationKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ObservationKind.java
@@ -1,0 +1,27 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 비정적 연결을 위한 관측 사실 종류
+ */
+public enum ObservationKind {
+    DI_INJECTION_SITE("di_injection_site"),
+    DI_PROVIDER("di_provider"),
+    SPI_PROVIDER("spi_provider"),
+    EVENT_PUBLISH("event_publish"),
+    EVENT_SUBSCRIBE("event_subscribe"),
+    REFLECTION_USE("reflection_use"),
+    CONFIG_WIRING("config_wiring");
+
+    private final String code;
+
+    ObservationKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/RelationKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/RelationKind.java
@@ -1,0 +1,31 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Graph Builder가 바로 먹을 수 있는 관계 후보 종류
+ */
+public enum RelationKind {
+    CONTAINS("contains"),
+    EXTENDS("extends"),
+    IMPLEMENTS("implements"),
+    OVERRIDES("overrides"),
+    CALLS("calls"),
+    ACCESSES_FIELD("accesses_field"),
+    FIELD_TYPE("field_type"),
+    PARAM_TYPE("param_type"),
+    RETURN_TYPE("return_type"),
+    THROWS_TYPE("throws_type"),
+    ANNOTATED_BY("annotated_by");
+
+    private final String code;
+
+    RelationKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/ResolutionStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/ResolutionStatus.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 참조 해석 상태
+ */
+public enum ResolutionStatus {
+    RESOLVED("resolved"),
+    PARTIAL("partial"),
+    UNRESOLVED("unresolved");
+
+    private final String code;
+
+    ResolutionStatus(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/SymbolFactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/SymbolFactKind.java
@@ -1,0 +1,27 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 심볼의 최상위 분류
+ * 세부 타입 종류(class/interface/enum/record/annotation)는 TypeKind로 분리
+ */
+public enum SymbolFactKind {
+    MODULE("module"),
+    PACKAGE("package"),
+    TYPE("type"),
+    METHOD("method"),
+    FIELD("field"),
+    CONSTRUCTOR("constructor");
+
+    private final String code;
+
+    SymbolFactKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/SymbolOriginKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/SymbolOriginKind.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * symbol 자체의 생성 출처
+ */
+public enum SymbolOriginKind {
+    SOURCE("source"),
+    BYTECODE("bytecode"),
+    GENERATED("generated"),
+    MERGED("merged");
+
+    private final String code;
+
+    SymbolOriginKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/enums/TypeKind.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/enums/TypeKind.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.extraction.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * TYPE 심볼의 세부 종류
+ */
+public enum TypeKind {
+    CLASS("class"),
+    INTERFACE("interface"),
+    ENUM("enum"),
+    RECORD("record"),
+    ANNOTATION("annotation");
+
+    private final String code;
+
+    TypeKind(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/exception/ExtractionErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/exception/ExtractionErrorCode.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.extraction.exception;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExtractionErrorCode implements BaseCode {
+
+    EXTRACTION_FAIL_FAST_ABORTED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTRACTION_500_002", "failFast 설정으로 추출이 중단되었습니다."),
+    EXTRACTION_ORCHESTRATION_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTRACTION_500_003", "추출 병렬 처리 중 인터럽트가 발생했습니다."),
+    EXTRACTION_ORCHESTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTRACTION_500_004", "추출 병렬 처리 중 예기치 못한 오류가 발생했습니다."),
+
+    EXTRACTION_PREFLIGHT_FAILED(HttpStatus.BAD_REQUEST, "EXTRACTION_400_003", "추출 사전 점검에 실패했습니다."),
+
+    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTRACTION_404_001", "워크스페이스를 찾을 수 없습니다."),
+    RUN_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTRACTION_404_002", "Run을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(status)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/exception/ExtractionException.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/exception/ExtractionException.java
@@ -1,0 +1,22 @@
+package com.example.ossdoc.domain.extraction.exception;
+
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class ExtractionException extends GeneralException {
+
+    public ExtractionException(ExtractionErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ExtractionException(ExtractionErrorCode errorCode, String detailMessage) {
+        super(errorCode, detailMessage);
+    }
+
+    public ExtractionException(ExtractionErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public ExtractionException(ExtractionErrorCode errorCode, String detailMessage, Throwable cause) {
+        super(errorCode, detailMessage, cause);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/facade/DefaultFactsExtractionFacade.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/facade/DefaultFactsExtractionFacade.java
@@ -1,0 +1,700 @@
+package com.example.ossdoc.domain.extraction.facade;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionFacadeContext;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.extraction.dto.model.BuildMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkingPolicy;
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionAggregate;
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+import com.example.ossdoc.domain.extraction.dto.model.JobMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ModuleMergeResult;
+import com.example.ossdoc.domain.extraction.dto.model.RootMergeResult;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+import com.example.ossdoc.domain.extraction.enums.BuildStatus;
+import com.example.ossdoc.domain.extraction.enums.ChunkStatus;
+import com.example.ossdoc.domain.extraction.exception.ExtractionErrorCode;
+import com.example.ossdoc.domain.extraction.exception.ExtractionException;
+import com.example.ossdoc.domain.extraction.service.composer.FactsComposer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsCompositionContext;
+import com.example.ossdoc.domain.extraction.service.extractor.ChunkFactsExtractionCoordinator;
+import com.example.ossdoc.domain.build.support.RepoRootResolver;
+import com.example.ossdoc.domain.extraction.service.support.preflight.BuildManifestLoader;
+import com.example.ossdoc.domain.extraction.service.support.planning.ChunkPlanner;
+import com.example.ossdoc.domain.extraction.service.support.util.ExtractionClock;
+import com.example.ossdoc.domain.extraction.service.support.merge.ExtractionMergeSupport;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightChecker;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightResult;
+import com.example.ossdoc.domain.extraction.service.support.util.FactsSchema;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+import com.example.ossdoc.domain.extraction.service.support.util.WarningCollector;
+import com.example.ossdoc.domain.extraction.dto.context.FactsWriteContext;
+import com.example.ossdoc.domain.extraction.service.writer.FactsWriter;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultFactsExtractionFacade implements FactsExtractionFacade {
+
+
+    private final ObjectMapper objectMapper;
+    private final ExtractionClock extractionClock;
+    private final ExtractionPreflightChecker extractionPreflightChecker;
+    private final ChunkPlanner chunkPlanner;
+    private final ChunkFactsExtractionCoordinator chunkFactsExtractionCoordinator;
+    private final ExtractionMergeSupport extractionMergeSupport;
+    private final FactsComposer factsComposer;
+    private final FactsWriter factsWriter;
+    private final RepoRunRepository repoRunRepository;
+    private final RepoRootResolver repoRootResolver;
+    private final BuildManifestLoader buildManifestLoader;
+
+    @Override
+    public FactsExtractResponse extract(FactsExtractRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        OffsetDateTime startedAt = extractionClock.now();
+        WarningCollector warnings = new WarningCollector();
+
+        ExtractionFacadeContext prepared = prepareFacadeContext(request, startedAt, warnings);
+        log.info("[EXTRACTION] Phase 1 완료 — 컨텍스트 준비 (runId={}, repoRoot={})", prepared.runId(), prepared.repoRoot());
+
+        ExtractionPreflightResult preflightResult = extractionPreflightChecker.check(
+                request,
+                prepared.buildManifest(),
+                prepared.repoRoot()
+        );
+        warnings.addAll(preflightResult.warnings());
+        log.info("[EXTRACTION] Phase 2 완료 — Preflight 검사 (mode={}, bytecodeAvailability={})",
+                preflightResult.resolvedMode(),
+                preflightResult.bytecodeAvailability() == null ? "N/A" : preflightResult.bytecodeAvailability().availability());
+
+        ExtractionFacadeContext facadeContext = ExtractionFacadeContext.builder()
+                .request(prepared.request())
+                .runId(prepared.runId())
+                .startedAt(prepared.startedAt())
+                .finishedAt(prepared.finishedAt())
+                .workspaceRoot(prepared.workspaceRoot())
+                .repoRoot(prepared.repoRoot())
+                .artifactsRoot(prepared.artifactsRoot())
+                .buildManifestPath(prepared.buildManifestPath())
+                .buildManifest(prepared.buildManifest())
+                .preflightResult(preflightResult)
+                .chunkingPolicy(prepared.chunkingPolicy())
+                .jobMeta(prepared.jobMeta())
+                .buildMeta(buildBuildMeta(prepared.buildManifest(), preflightResult, prepared.repoRoot()))
+                .engineVersions(prepared.engineVersions())
+                .build();
+
+        ensureProceedable(facadeContext, warnings);
+
+        ChunkingPolicy chunkingPolicy = facadeContext.chunkingPolicy() == null
+                ? ChunkingPolicy.standard()
+                : facadeContext.chunkingPolicy();
+
+        List<ChunkDescriptor> chunks = chunkPlanner.plan(
+                request,
+                preflightResult,
+                facadeContext.repoRoot(),
+                chunkingPolicy
+        );
+
+        log.info("[EXTRACTION] Phase 3 완료 — 청크 계획 (chunks={})", chunks.size());
+
+        if (chunks.isEmpty()) {
+            warnings.add("No extraction chunks were planned; resulting facts.json will be structurally valid but empty");
+        }
+
+        List<ChunkResult> chunkResults = executeChunksInParallel(
+                request,
+                preflightResult,
+                facadeContext.repoRoot(),
+                chunks,
+                chunkingPolicy,
+                warnings
+        );
+
+        long successCount = chunkResults.stream().filter(r -> r.status() == ChunkStatus.SUCCEEDED).count();
+        long failedCount = chunkResults.stream().filter(r -> r.status() == ChunkStatus.FAILED).count();
+        log.info("[EXTRACTION] Phase 4 완료 — 병렬 추출 (total={}, success={}, failed={})",
+                chunkResults.size(), successCount, failedCount);
+
+        ExtractionAggregate aggregate = buildAggregate(chunkResults);
+        warnings.addAll(aggregate.warnings());
+        log.info("[EXTRACTION] Phase 5 완료 — 병합 (evidence={}, warnings={})",
+                aggregate.evidence().size(), aggregate.warnings().size());
+
+        OffsetDateTime finishedAt = extractionClock.now();
+
+        FactsDocument factsDocument = factsComposer.compose(new FactsCompositionContext(
+                FactsSchema.SCHEMA_VERSION,
+                facadeContext.jobMeta(),
+                facadeContext.buildMeta(),
+                preflightResult.resolvedMode(),
+                preflightResult.bytecodeAvailability() == null ? null : preflightResult.bytecodeAvailability().availability(),
+                facadeContext.startedAt(),
+                finishedAt,
+                facadeContext.engineVersions(),
+                warnings.snapshot(),
+                scannedModules(preflightResult),
+                scannedSourceRoots(preflightResult, facadeContext.repoRoot()),
+                scannedBytecodeRoots(preflightResult, facadeContext.repoRoot()),
+                request.includeObservations(),
+                aggregate
+        ));
+
+        log.info("[EXTRACTION] Phase 6 완료 — FactsDocument 구성");
+
+        FactsWriteContext writeContext = new FactsWriteContext(
+                facadeContext.runId(),
+                facadeContext.artifactsRoot(),
+                factsDocument,
+                warnings.snapshot()
+        );
+
+        FactsExtractResponse response = writeFactsAndBuildResponse(writeContext);
+        log.info("[EXTRACTION] Phase 7 완료 — facts.json 저장 완료 (runId={})", facadeContext.runId());
+
+        List<String> finalWarnings = response.warnings();
+        if (finalWarnings != null && !finalWarnings.isEmpty()) {
+            finalWarnings.forEach(w -> log.warn("[EXTRACTION] Warning: {}", w));
+        }
+
+        return response;
+    }
+
+    private ExtractionFacadeContext prepareFacadeContext(
+            FactsExtractRequest request,
+            OffsetDateTime startedAt,
+            WarningCollector warnings
+    ) {
+        String runId = request.runId();
+
+        RepoRun run = repoRunRepository.findById(runId)
+                .orElseThrow(() -> new ExtractionException(ExtractionErrorCode.RUN_NOT_FOUND));
+
+        Path workspaceRoot = Path.of(run.getWorkspaceRoot()).normalize();
+        if (!Files.exists(workspaceRoot) || !Files.isDirectory(workspaceRoot)) {
+            throw new ExtractionException(ExtractionErrorCode.WORKSPACE_NOT_FOUND,
+                    "workspace root does not exist: " + workspaceRoot);
+        }
+
+        JobMeta jobMeta = JobMeta.builder()
+                .jobId(runId)
+                .repoUrl(run.getRepoUrl())
+                .commitSha(run.getCommitSha())
+                .build();
+
+        Path repoRoot = resolveRepoRoot(workspaceRoot);
+        Path artifactsRoot = workspaceRoot.resolve("artifacts").normalize();
+
+        BuildManifest buildManifest = buildManifestLoader.load(artifactsRoot);
+        if (buildManifest == null) {
+            warnings.add("build_manifest could not be loaded from local artifacts for runId=" + runId);
+        }
+
+        Map<String, String> engineVersions = new LinkedHashMap<>();
+        engineVersions.put("ast", "javaparser");
+        engineVersions.put("bytecode", "asm");
+
+        return ExtractionFacadeContext.builder()
+                .request(request)
+                .runId(runId)
+                .startedAt(startedAt)
+                .workspaceRoot(workspaceRoot)
+                .repoRoot(repoRoot)
+                .artifactsRoot(artifactsRoot)
+                .buildManifestPath(null)
+                .buildManifest(buildManifest)
+                .chunkingPolicy(ChunkingPolicy.standard())
+                .jobMeta(jobMeta)
+                .buildMeta(BuildMeta.builder()
+                        .status(BuildStatus.UNKNOWN.code())
+                        .mode(null)
+                        .tool(null)
+                        .javaVersionUsed(null)
+                        .classpathFingerprint(null)
+                        .modules(List.of())
+                        .bytecodeRoots(List.of())
+                        .classpathEntries(List.of())
+                        .build())
+                .engineVersions(engineVersions)
+                .build();
+    }
+
+    private void ensureProceedable(ExtractionFacadeContext facadeContext, WarningCollector warnings) {
+        ExtractionPreflightResult preflightResult = facadeContext.preflightResult();
+        if (preflightResult != null && preflightResult.canProceed()) {
+            return;
+        }
+
+        List<String> blockingReasons = preflightResult == null
+                ? List.of("preflight result is missing")
+                : preflightResult.blockingReasons();
+        warnings.addAll(blockingReasons);
+        log.error("[EXTRACTION] Preflight 실패 — 진행 불가 (reasons={})", String.join("; ", blockingReasons));
+
+        throw new ExtractionException(
+                ExtractionErrorCode.EXTRACTION_PREFLIGHT_FAILED,
+                buildExceptionDetail(facadeContext.runId(), String.join("; ", blockingReasons), warnings)
+        );
+    }
+
+    private List<ChunkResult> executeChunksInParallel(
+            FactsExtractRequest request,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot,
+            List<ChunkDescriptor> chunks,
+            ChunkingPolicy chunkingPolicy,
+            WarningCollector warnings
+    ) {
+        if (chunks == null || chunks.isEmpty()) {
+            return List.of();
+        }
+
+        boolean failFast = request != null && request.failFast();
+
+        ExecutorService executor = Executors.newFixedThreadPool(
+                chunkingPolicy.workerCount(),
+                new ExtractionWorkerThreadFactory()
+        );
+
+        ExecutorCompletionService<ChunkExecutionOutcome> completionService =
+                new ExecutorCompletionService<>(executor);
+
+        try {
+            int submitted = 0;
+            for (ChunkDescriptor chunk : chunks) {
+                completionService.submit(() -> executeSingleChunk(
+                        request,
+                        preflightResult,
+                        repoRoot,
+                        chunk
+                ));
+                submitted++;
+            }
+
+            List<ChunkResult> results = new ArrayList<>();
+
+            for (int i = 0; i < submitted; i++) {
+                Future<ChunkExecutionOutcome> completedFuture;
+                try {
+                    completedFuture = completionService.take();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    cancelPending(executor);
+                    throw new ExtractionException(
+                            ExtractionErrorCode.EXTRACTION_ORCHESTRATION_INTERRUPTED,
+                            buildExceptionDetail(request != null ? request.runId() : "<unknown>",
+                                    "chunk result collection was interrupted", warnings),
+                            e
+                    );
+                }
+
+                ChunkExecutionOutcome outcome;
+                try {
+                    outcome = completedFuture.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    cancelPending(executor);
+                    throw new ExtractionException(
+                            ExtractionErrorCode.EXTRACTION_ORCHESTRATION_INTERRUPTED,
+                            buildExceptionDetail(request != null ? request.runId() : "<unknown>",
+                                    "waiting for a completed chunk result was interrupted", warnings),
+                            e
+                    );
+                } catch (ExecutionException e) {
+                    cancelPending(executor);
+                    Throwable cause = e.getCause() == null ? e : e.getCause();
+                    throw new ExtractionException(
+                            ExtractionErrorCode.EXTRACTION_ORCHESTRATION_FAILED,
+                            buildExceptionDetail(request != null ? request.runId() : "<unknown>",
+                                    "failed to retrieve completed chunk extraction result: " + safeMessage(cause), warnings),
+                            cause
+                    );
+                }
+
+                if (outcome.executionFailed()) {
+                    if (failFast) {
+                        cancelPending(executor);
+                        throw failFastAbort(outcome.chunk(), outcome.failureMessage());
+                    }
+                    results.add(failedChunk(outcome.chunk(), outcome.failureMessage()));
+                    continue;
+                }
+
+                ChunkResult chunkResult = outcome.chunkResult();
+                if (chunkResult == null) {
+                    if (failFast) {
+                        cancelPending(executor);
+                        throw failFastAbort(outcome.chunk(), "chunk extraction returned null result");
+                    }
+                    results.add(failedChunk(outcome.chunk(), "chunk extraction returned null result"));
+                    continue;
+                }
+
+                if (failFast && shouldAbortOnChunkFailure(chunkResult)) {
+                    cancelPending(executor);
+                    throw failFastAbort(chunkResult.descriptor(), firstFailureMessage(chunkResult));
+                }
+
+                log.debug("[EXTRACTION] 청크 완료: {} (status={})",
+                        chunkResult.descriptor() != null ? chunkResult.descriptor().chunkId() : "<unknown>",
+                        chunkResult.status());
+                results.add(chunkResult);
+            }
+
+            return List.copyOf(results);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private ChunkExecutionOutcome executeSingleChunk(
+            FactsExtractRequest request,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot,
+            ChunkDescriptor chunk
+    ) {
+        try {
+            ChunkResult chunkResult = chunkFactsExtractionCoordinator.extract(
+                    request,
+                    preflightResult,
+                    repoRoot,
+                    chunk
+            );
+            return ChunkExecutionOutcome.success(chunk, chunkResult);
+        } catch (Exception e) {
+            return ChunkExecutionOutcome.failure(chunk, safeMessage(e));
+        }
+    }
+
+    private boolean shouldAbortOnChunkFailure(ChunkResult chunkResult) {
+        if (chunkResult == null) {
+            return true;
+        }
+
+        if (chunkResult.status() == ChunkStatus.FAILED || chunkResult.status() == ChunkStatus.PARTIAL) {
+            return true;
+        }
+
+        return chunkResult.errors() != null && !chunkResult.errors().isEmpty();
+    }
+
+    private String firstFailureMessage(ChunkResult chunkResult) {
+        if (chunkResult == null) {
+            return "chunk extraction returned null result";
+        }
+        if (chunkResult.errors() != null && !chunkResult.errors().isEmpty()) {
+            return chunkResult.errors().get(0);
+        }
+        if (chunkResult.status() == ChunkStatus.PARTIAL) {
+            return "chunk extraction produced partial result";
+        }
+        if (chunkResult.status() == ChunkStatus.FAILED) {
+            return "chunk extraction failed";
+        }
+        return "chunk extraction aborted";
+    }
+
+    private ExtractionException failFastAbort(ChunkDescriptor chunk, String message) {
+        String chunkId = chunk == null || chunk.chunkId() == null || chunk.chunkId().isBlank()
+                ? "<unknown-chunk>"
+                : chunk.chunkId();
+
+        String detail = (message == null || message.isBlank())
+                ? "unknown chunk extraction failure"
+                : message;
+
+        return new ExtractionException(
+                ExtractionErrorCode.EXTRACTION_FAIL_FAST_ABORTED,
+                "chunkId=" + chunkId + ", reason=" + detail
+        );
+    }
+
+    private void cancelPending(ExecutorService executor) {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    private static String buildExceptionDetail(String runId, String reason, WarningCollector warnings) {
+        List<String> allWarnings = warnings.snapshot();
+        return "runId=" + runId
+                + ", reason=" + reason
+                + (allWarnings.isEmpty() ? "" : ", warnings=" + String.join("; ", allWarnings));
+    }
+
+    private String safeMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "unknown error";
+        }
+        String message = throwable.getMessage();
+        return (message == null || message.isBlank()) ? throwable.toString() : message;
+    }
+
+    private ChunkResult failedChunk(ChunkDescriptor chunk, String message) {
+        return ChunkResult.builder()
+                .descriptor(chunk)
+                .status(ChunkStatus.FAILED)
+                .evidence(Map.of())
+                .symbols(List.of())
+                .relations(List.of())
+                .observations(List.of())
+                .stats(StatsMeta.builder()
+                        .filesScanned(chunk == null ? 0L : chunk.fileCount())
+                        .chunksTotal(1L)
+                        .chunksFailed(1L)
+                        .errors(1L)
+                        .build())
+                .warnings(List.of())
+                .errors(message == null || message.isBlank()
+                        ? List.of("unknown chunk extraction failure")
+                        : List.of(message))
+                .build();
+    }
+
+    private ExtractionAggregate buildAggregate(List<ChunkResult> chunkResults) {
+        if (chunkResults == null || chunkResults.isEmpty()) {
+            return extractionMergeSupport.aggregate(List.of());
+        }
+
+        Map<String, Map<String, List<ChunkResult>>> groupedByModuleAndRoot = new LinkedHashMap<>();
+        for (ChunkResult chunkResult : chunkResults) {
+            if (chunkResult == null || chunkResult.descriptor() == null) {
+                continue;
+            }
+            String module = chunkResult.descriptor().module();
+            String rootPath = chunkResult.descriptor().rootPath();
+            groupedByModuleAndRoot
+                    .computeIfAbsent(module, ignored -> new LinkedHashMap<>())
+                    .computeIfAbsent(rootPath, ignored -> new ArrayList<>())
+                    .add(chunkResult);
+        }
+
+        List<ModuleMergeResult> modules = new ArrayList<>();
+        for (Map.Entry<String, Map<String, List<ChunkResult>>> moduleEntry : groupedByModuleAndRoot.entrySet()) {
+            List<RootMergeResult> roots = new ArrayList<>();
+            for (Map.Entry<String, List<ChunkResult>> rootEntry : moduleEntry.getValue().entrySet()) {
+                roots.add(extractionMergeSupport.mergeRoot(moduleEntry.getKey(), rootEntry.getKey(), rootEntry.getValue()));
+            }
+            modules.add(extractionMergeSupport.mergeModule(moduleEntry.getKey(), roots));
+        }
+
+        return extractionMergeSupport.aggregate(modules);
+    }
+
+    private BuildMeta buildBuildMeta(
+            BuildManifest buildManifest,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot
+    ) {
+        if (buildManifest == null) {
+            return BuildMeta.builder()
+                    .status(BuildStatus.UNKNOWN.code())
+                    .mode(null)
+                    .tool(null)
+                    .javaVersionUsed(null)
+                    .classpathFingerprint(null)
+                    .modules(List.of())
+                    .bytecodeRoots(List.of())
+                    .classpathEntries(List.of())
+                    .build();
+        }
+
+        List<BuildModuleManifest> modules = buildManifest.getModules() == null ? List.of() : buildManifest.getModules();
+        List<String> moduleIds = modules.stream()
+                .map(this::safeModuleId)
+                .distinct()
+                .toList();
+
+        List<String> bytecodeRoots = modules.stream()
+                .map(BuildModuleManifest::getClassesDirs)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(value -> value != null && !value.isBlank())
+                .map(value -> normalizeRepoRelative(repoRoot, value))
+                .distinct()
+                .toList();
+
+        List<String> classpathEntries = modules.stream()
+                .map(BuildModuleManifest::getCompileClasspath)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(value -> value != null && !value.isBlank())
+                .map(value -> normalizeRepoRelative(repoRoot, value))
+                .distinct()
+                .toList();
+
+        String mode = resolveBuildMode(buildManifest);
+        String status = resolveBuildStatus(mode);
+        String tool = buildManifest.getBuildTool() == null ? null : buildManifest.getBuildTool().name();
+
+        return BuildMeta.builder()
+                .status(status)
+                .mode(mode)
+                .tool(tool)
+                .javaVersionUsed(null)
+                .classpathFingerprint(classpathFingerprint(preflightResult))
+                .modules(moduleIds)
+                .bytecodeRoots(bytecodeRoots)
+                .classpathEntries(classpathEntries)
+                .build();
+    }
+
+    private String resolveBuildMode(BuildManifest buildManifest) {
+        if (buildManifest == null || buildManifest.getBuildMode() == null) {
+            return null;
+        }
+        return buildManifest.getBuildMode().name();
+    }
+
+    private String resolveBuildStatus(String buildMode) {
+        if (buildMode == null || buildMode.isBlank()) {
+            return BuildStatus.UNKNOWN.code();
+        }
+
+        return switch (buildMode) {
+            case "FULL", "COMPILE_ONLY" -> BuildStatus.SUCCESS.code();
+            case "SOURCE_ONLY" -> BuildStatus.PARTIAL.code();
+            case "FAILED" -> BuildStatus.FAILED.code();
+            case "SKIPPED" -> BuildStatus.SKIPPED.code();
+            default -> BuildStatus.UNKNOWN.code();
+        };
+    }
+
+    private String classpathFingerprint(ExtractionPreflightResult preflightResult) {
+        if (preflightResult == null || preflightResult.normalizedContext() == null) {
+            return null;
+        }
+        String joined = preflightResult.normalizedContext().compileClasspath().stream()
+                .map(Path::toString)
+                .collect(Collectors.joining("|"));
+        if (joined.isBlank()) {
+            return null;
+        }
+        return Integer.toHexString(joined.hashCode());
+    }
+
+    private List<String> scannedModules(ExtractionPreflightResult preflightResult) {
+        if (preflightResult == null || preflightResult.normalizedContext() == null) {
+            return List.of();
+        }
+        return preflightResult.normalizedContext().modules().stream()
+                .map(ExtractionPreflightResult.ModuleNormalizedContext::moduleName)
+                .filter(value -> value != null && !value.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private List<String> scannedSourceRoots(ExtractionPreflightResult preflightResult, Path repoRoot) {
+        if (preflightResult == null || preflightResult.normalizedContext() == null) {
+            return List.of();
+        }
+
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        for (ExtractionPreflightResult.ModuleNormalizedContext module : preflightResult.normalizedContext().modules()) {
+            for (Path sourceRoot : safePaths(module.sourceRoots())) {
+                values.add(RepoPathUtils.toRepoRelative(repoRoot, sourceRoot));
+            }
+            for (Path testRoot : safePaths(module.testRoots())) {
+                values.add(RepoPathUtils.toRepoRelative(repoRoot, testRoot));
+            }
+        }
+        return List.copyOf(values);
+    }
+
+    private List<String> scannedBytecodeRoots(ExtractionPreflightResult preflightResult, Path repoRoot) {
+        if (preflightResult == null || preflightResult.normalizedContext() == null) {
+            return List.of();
+        }
+
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        for (ExtractionPreflightResult.ModuleNormalizedContext module : preflightResult.normalizedContext().modules()) {
+            for (Path classesDir : safePaths(module.classesDirs())) {
+                values.add(RepoPathUtils.toRepoRelative(repoRoot, classesDir));
+            }
+        }
+        return List.copyOf(values);
+    }
+
+    private List<Path> safePaths(List<Path> paths) {
+        return paths == null ? List.of() : paths;
+    }
+
+    private FactsExtractResponse writeFactsAndBuildResponse(FactsWriteContext writeContext) {
+        return factsWriter.writeAndBuildResponse(writeContext);
+    }
+
+    private Path resolveRepoRoot(Path workspaceRoot) {
+        Path repoRoot = workspaceRoot.resolve("repo");
+        return repoRootResolver.resolveActualRoot(repoRoot).normalize();
+    }
+
+    private String normalizeRepoRelative(Path repoRoot, String rawPath) {
+        Path path = Path.of(rawPath);
+        Path normalized = path.isAbsolute() ? path.normalize() : repoRoot.resolve(path).normalize();
+        return RepoPathUtils.toRepoRelative(repoRoot, normalized);
+    }
+
+    private String safeModuleId(BuildModuleManifest module) {
+        if (module == null || module.getModuleId() == null || module.getModuleId().isBlank()) {
+            return "<unknown-module>";
+        }
+        return module.getModuleId();
+    }
+
+    private static final class ExtractionWorkerThreadFactory implements ThreadFactory {
+        private final AtomicInteger sequence = new AtomicInteger(1);
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "facts-extractor-" + sequence.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+
+    private record ChunkExecutionOutcome(
+            ChunkDescriptor chunk,
+            ChunkResult chunkResult,
+            boolean executionFailed,
+            String failureMessage
+    ) {
+        private static ChunkExecutionOutcome success(ChunkDescriptor chunk, ChunkResult chunkResult) {
+            return new ChunkExecutionOutcome(chunk, chunkResult, false, null);
+        }
+
+        private static ChunkExecutionOutcome failure(ChunkDescriptor chunk, String failureMessage) {
+            return new ChunkExecutionOutcome(chunk, null, true, failureMessage);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/facade/FactsExtractionFacade.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/facade/FactsExtractionFacade.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.extraction.facade;
+
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+
+/**
+ * extraction 전체 흐름 진입점
+ */
+public interface FactsExtractionFacade {
+
+    FactsExtractResponse extract(FactsExtractRequest request);
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/composer/DefaultFactsComposer.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/composer/DefaultFactsComposer.java
@@ -1,0 +1,138 @@
+package com.example.ossdoc.domain.extraction.service.composer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsCompositionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionAggregate;
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionMeta;
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+import com.example.ossdoc.domain.extraction.service.support.util.FactsSchema;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * merge가 끝난 aggregate를 facts.json 루트 구조로 조립하는 기본 구현.
+ *
+ * 보장 목표:
+ * - schema_version / job / build / extraction / stats / evidence / symbols / relations / observations 섹션이 항상 존재
+ * - 중복 symbol/relation/observation/evidence를 composer 단계에서 한 번 더 정리
+ * - stats가 최종 문서 내용과 어긋나지 않도록 재계산
+ */
+@Component
+public class DefaultFactsComposer implements FactsComposer {
+
+    private final FactsSectionFactory sectionFactory;
+    private final FactsStatsCalculator statsCalculator;
+
+    public DefaultFactsComposer() {
+        this(new FactsSectionFactory(), new FactsStatsCalculator());
+    }
+
+    public DefaultFactsComposer(FactsSectionFactory sectionFactory, FactsStatsCalculator statsCalculator) {
+        this.sectionFactory = Objects.requireNonNull(sectionFactory);
+        this.statsCalculator = Objects.requireNonNull(statsCalculator);
+    }
+
+    @Override
+    public FactsDocument compose(FactsCompositionContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+
+        ExtractionAggregate aggregate = context.aggregate();
+
+        Map<String, EvidenceFact> evidence = sectionFactory.composeEvidence(aggregate.evidence());
+        SymbolTable symbols = sectionFactory.composeSymbols(aggregate.symbols());
+        RelationTable relations = sectionFactory.composeRelations(aggregate.relations());
+        ObservationTable observations = context.includeObservations()
+                ? sectionFactory.composeObservations(aggregate.observations())
+                : sectionFactory.emptyObservationTable();
+
+        List<String> warnings = mergeWarnings(context.warnings(), aggregate.warnings());
+
+        ExtractionMeta extractionMeta = ExtractionMeta.builder()
+                .mode(context.mode())
+                .bytecodeAvailability(context.bytecodeAvailability())
+                .startedAt(context.startedAt())
+                .finishedAt(context.finishedAt())
+                .warnings(warnings)
+                .scannedModules(context.scannedModules())
+                .scannedSourceRoots(context.scannedSourceRoots())
+                .scannedBytecodeRoots(context.scannedBytecodeRoots())
+                .engineVersions(normalizeEngineVersions(context.engineVersions()))
+                .build();
+
+        StatsMeta stats = statsCalculator.compose(
+                aggregate.stats(),
+                evidence,
+                symbols,
+                relations,
+                observations
+        );
+
+        return FactsDocument.builder()
+                .schemaVersion(resolveSchemaVersion(context.schemaVersion()))
+                .job(sectionFactory.normalizeJob(context.job()))
+                .build(sectionFactory.normalizeBuild(context.build()))
+                .extraction(extractionMeta)
+                .stats(stats)
+                .evidence(evidence)
+                .symbols(symbols)
+                .relations(relations)
+                .observations(observations)
+                .build();
+    }
+
+    private String resolveSchemaVersion(String schemaVersion) {
+        if (schemaVersion == null || schemaVersion.isBlank()) {
+            return FactsSchema.SCHEMA_VERSION;
+        }
+        return schemaVersion;
+    }
+
+    private Map<String, String> normalizeEngineVersions(Map<String, String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> sorted = new TreeMap<>();
+        for (Map.Entry<String, String> entry : raw.entrySet()) {
+            if (entry.getKey() == null || entry.getKey().isBlank()) {
+                continue;
+            }
+            if (entry.getValue() == null || entry.getValue().isBlank()) {
+                continue;
+            }
+            sorted.put(entry.getKey(), entry.getValue());
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(sorted));
+    }
+
+    private List<String> mergeWarnings(List<String> left, List<String> right) {
+        LinkedHashSet<String> merged = new LinkedHashSet<>();
+        addWarnings(merged, left);
+        addWarnings(merged, right);
+        return List.copyOf(new ArrayList<>(merged));
+    }
+
+    private void addWarnings(LinkedHashSet<String> target, List<String> warnings) {
+        if (warnings == null || warnings.isEmpty()) {
+            return;
+        }
+        for (String warning : warnings) {
+            if (warning == null || warning.isBlank()) {
+                continue;
+            }
+            target.add(warning);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsComposer.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsComposer.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.extraction.service.composer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsCompositionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+
+/**
+ * composer 직전 최종 집계 결과를 facts.json 루트 문서로 조립하는 계약.
+ */
+public interface FactsComposer {
+
+    FactsDocument compose(FactsCompositionContext context);
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsDedupSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsDedupSupport.java
@@ -1,0 +1,351 @@
+package com.example.ossdoc.domain.extraction.service.composer;
+
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationResolution;
+import com.example.ossdoc.domain.extraction.dto.model.SignatureFact;
+import com.example.ossdoc.domain.extraction.dto.model.SourceSpan;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.TypeRef;
+import com.example.ossdoc.domain.extraction.enums.ResolutionStatus;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * AST/ASM에서 중복으로 들어올 수 있는 fact를 composer 단계에서 병합하기 위한 유틸.
+ */
+final class FactsDedupSupport {
+
+    private FactsDedupSupport() {
+    }
+
+    static EvidenceFact mergeEvidence(EvidenceFact left, EvidenceFact right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return EvidenceFact.builder()
+                .id(firstNonBlank(left.id(), right.id()))
+                .type(firstNonNull(left.type(), right.type()))
+                .path(firstNonBlank(left.path(), right.path()))
+                .span(mergeSpan(left.span(), right.span()))
+                .symbol(firstNonBlank(left.symbol(), right.symbol()))
+                .snippet(preferLonger(left.snippet(), right.snippet()))
+                .hash(firstNonBlank(left.hash(), right.hash()))
+                .attrs(mergeMaps(left.attrs(), right.attrs()))
+                .build();
+    }
+
+    static SymbolFact mergeSymbol(SymbolFact left, SymbolFact right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return SymbolFact.builder()
+                .symbol(firstNonBlank(left.symbol(), right.symbol()))
+                .kind(firstNonNull(left.kind(), right.kind()))
+                .typeKind(firstNonNull(left.typeKind(), right.typeKind()))
+                .name(firstNonBlank(left.name(), right.name()))
+                .qualifiedName(firstNonBlank(left.qualifiedName(), right.qualifiedName()))
+                .ownerTypeSymbol(firstNonBlank(left.ownerTypeSymbol(), right.ownerTypeSymbol()))
+                .packageSymbol(firstNonBlank(left.packageSymbol(), right.packageSymbol()))
+                .module(firstNonBlank(left.module(), right.module()))
+                .sourceRoot(firstNonBlank(left.sourceRoot(), right.sourceRoot()))
+                .bytecodeRoot(firstNonBlank(left.bytecodeRoot(), right.bytecodeRoot()))
+                .nestedIn(firstNonBlank(left.nestedIn(), right.nestedIn()))
+                .access(firstNonNull(left.access(), right.access()))
+                .modifiers(mergeSets(left.modifiers(), right.modifiers()))
+                .origin(firstNonNull(left.origin(), right.origin()))
+                .annotations(mergeDistinct(left.annotations(), right.annotations(), FactsDedupSupport::typeRefKey))
+                .evidenceIds(mergeDistinct(left.evidenceIds(), right.evidenceIds(), Function.identity()))
+                .attrs(mergeMaps(left.attrs(), right.attrs()))
+                .signature(mergeSignature(left.signature(), right.signature()))
+                .superTypeRef(mergeTypeRef(left.superTypeRef(), right.superTypeRef()))
+                .interfaceTypeRefs(mergeDistinct(left.interfaceTypeRefs(), right.interfaceTypeRefs(), FactsDedupSupport::typeRefKey))
+                .sourceFile(firstNonBlank(left.sourceFile(), right.sourceFile()))
+                .isBridge(firstNonNull(left.isBridge(), right.isBridge()))
+                .isSynthetic(firstNonNull(left.isSynthetic(), right.isSynthetic()))
+                .bytecodeDescriptor(firstNonBlank(left.bytecodeDescriptor(), right.bytecodeDescriptor()))
+                .localCalls(mergeDistinct(left.localCalls(), right.localCalls(), Function.identity()))
+                .build();
+    }
+
+    static RelationFact mergeRelation(RelationFact left, RelationFact right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return RelationFact.builder()
+                .kind(firstNonNull(left.kind(), right.kind()))
+                .srcSymbol(firstNonBlank(left.srcSymbol(), right.srcSymbol()))
+                .dstSymbol(firstNonBlank(left.dstSymbol(), right.dstSymbol()))
+                .dstRawRef(firstNonBlank(left.dstRawRef(), right.dstRawRef()))
+                .evidenceIds(mergeDistinct(left.evidenceIds(), right.evidenceIds(), Function.identity()))
+                .resolution(mergeResolution(left.resolution(), right.resolution()))
+                .origin(firstNonNull(left.origin(), right.origin()))
+                .confidenceHint(max(left.confidenceHint(), right.confidenceHint()))
+                .attrs(mergeMaps(left.attrs(), right.attrs()))
+                .build();
+    }
+
+    static ObservationFact mergeObservation(ObservationFact left, ObservationFact right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return ObservationFact.builder()
+                .kind(firstNonNull(left.kind(), right.kind()))
+                .siteSymbol(firstNonBlank(left.siteSymbol(), right.siteSymbol()))
+                .targetSymbol(firstNonBlank(left.targetSymbol(), right.targetSymbol()))
+                .targetTypeRef(mergeTypeRef(left.targetTypeRef(), right.targetTypeRef()))
+                .serviceInterfaceSymbol(firstNonBlank(left.serviceInterfaceSymbol(), right.serviceInterfaceSymbol()))
+                .note(preferLonger(left.note(), right.note()))
+                .evidenceIds(mergeDistinct(left.evidenceIds(), right.evidenceIds(), Function.identity()))
+                .origin(firstNonNull(left.origin(), right.origin()))
+                .attrs(mergeMaps(left.attrs(), right.attrs()))
+                .build();
+    }
+
+    static RelationResolution mergeResolution(RelationResolution left, RelationResolution right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        int leftRank = resolutionRank(left.status());
+        int rightRank = resolutionRank(right.status());
+        RelationResolution winner = leftRank >= rightRank ? left : right;
+        RelationResolution loser = leftRank >= rightRank ? right : left;
+
+        return RelationResolution.builder()
+                .status(firstNonNull(winner.status(), loser.status()))
+                .reason(firstNonBlank(winner.reason(), loser.reason()))
+                .build();
+    }
+
+    static SignatureFact mergeSignature(SignatureFact left, SignatureFact right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return SignatureFact.builder()
+                .params(mergeDistinct(left.params(), right.params(), FactsDedupSupport::typeRefKey))
+                .returns(mergeTypeRef(left.returns(), right.returns()))
+                .throwsTypes(mergeDistinct(left.throwsTypes(), right.throwsTypes(), FactsDedupSupport::typeRefKey))
+                .fieldType(mergeTypeRef(left.fieldType(), right.fieldType()))
+                .build();
+    }
+
+    static TypeRef mergeTypeRef(TypeRef left, TypeRef right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return TypeRef.builder()
+                .raw(firstNonBlank(left.raw(), right.raw()))
+                .args(mergeDistinct(left.args(), right.args(), FactsDedupSupport::typeRefKey))
+                .arrayDim(firstNonNull(left.arrayDim(), right.arrayDim()))
+                .primitive(firstNonNull(left.primitive(), right.primitive()))
+                .unresolved(firstNonNull(left.unresolved(), right.unresolved()))
+                .sourceText(firstNonBlank(left.sourceText(), right.sourceText()))
+                .build();
+    }
+
+    static SourceSpan mergeSpan(SourceSpan left, SourceSpan right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+
+        return SourceSpan.builder()
+                .startLine(firstNonNull(left.startLine(), right.startLine()))
+                .startCol(firstNonNull(left.startCol(), right.startCol()))
+                .endLine(firstNonNull(left.endLine(), right.endLine()))
+                .endCol(firstNonNull(left.endCol(), right.endCol()))
+                .build();
+    }
+
+    static <T> List<T> mergeDistinct(List<T> left, List<T> right, Function<T, String> keyFn) {
+        LinkedHashMap<String, T> merged = new LinkedHashMap<>();
+        addDistinct(merged, left, keyFn);
+        addDistinct(merged, right, keyFn);
+        return List.copyOf(merged.values());
+    }
+
+    static <T> Set<T> mergeSets(Set<T> left, Set<T> right) {
+        LinkedHashSet<T> merged = new LinkedHashSet<>();
+        if (left != null) {
+            merged.addAll(left);
+        }
+        if (right != null) {
+            merged.addAll(right);
+        }
+        if (merged.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(new LinkedHashSet<>(merged));
+    }
+
+    static <K, V> Map<K, V> mergeMaps(Map<K, V> left, Map<K, V> right) {
+        LinkedHashMap<K, V> merged = new LinkedHashMap<>();
+        if (left != null) {
+            merged.putAll(left);
+        }
+        if (right != null) {
+            merged.putAll(right);
+        }
+        if (merged.isEmpty()) {
+            return Map.of();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(merged));
+    }
+
+    static String relationKey(RelationFact relation) {
+        return String.join("|",
+                safe(relation.kind() == null ? null : relation.kind().code()),
+                safe(relation.srcSymbol()),
+                safe(relation.dstSymbol()),
+                safe(relation.dstRawRef())
+        );
+    }
+
+    static String observationKey(ObservationFact observation) {
+        return String.join("|",
+                safe(observation.kind() == null ? null : observation.kind().code()),
+                safe(observation.siteSymbol()),
+                safe(observation.targetSymbol()),
+                safe(typeRefKey(observation.targetTypeRef())),
+                safe(observation.serviceInterfaceSymbol())
+        );
+    }
+
+    static String evidenceKey(EvidenceFact evidenceFact) {
+        return safe(evidenceFact.id());
+    }
+
+    static String symbolKey(SymbolFact symbolFact) {
+        if (symbolFact.symbol() != null && !symbolFact.symbol().isBlank()) {
+            return symbolFact.symbol();
+        }
+        return String.join("|",
+                safe(symbolFact.kind() == null ? null : symbolFact.kind().code()),
+                safe(symbolFact.qualifiedName()),
+                safe(symbolFact.ownerTypeSymbol()),
+                safe(symbolFact.name())
+        );
+    }
+
+    static String typeRefKey(TypeRef typeRef) {
+        if (typeRef == null) {
+            return "";
+        }
+
+        List<String> argKeys = new ArrayList<>();
+        if (typeRef.args() != null) {
+            for (TypeRef arg : typeRef.args()) {
+                argKeys.add(typeRefKey(arg));
+            }
+        }
+
+        return String.join("|",
+                safe(typeRef.raw()),
+                String.join(",", argKeys),
+                safe(typeRef.arrayDim() == null ? null : String.valueOf(typeRef.arrayDim())),
+                safe(typeRef.primitive() == null ? null : String.valueOf(typeRef.primitive())),
+                safe(typeRef.unresolved() == null ? null : String.valueOf(typeRef.unresolved())),
+                safe(typeRef.sourceText())
+        );
+    }
+
+    static String preferLonger(String left, String right) {
+        if (left == null || left.isBlank()) {
+            return right;
+        }
+        if (right == null || right.isBlank()) {
+            return left;
+        }
+        return right.length() > left.length() ? right : left;
+    }
+
+    static <T> T firstNonNull(T left, T right) {
+        return left != null ? left : right;
+    }
+
+    static String firstNonBlank(String left, String right) {
+        if (left != null && !left.isBlank()) {
+            return left;
+        }
+        return (right != null && !right.isBlank()) ? right : null;
+    }
+
+    static Double max(Double left, Double right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+        return Math.max(left, right);
+    }
+
+    private static int resolutionRank(ResolutionStatus status) {
+        if (status == null) {
+            return -1;
+        }
+        return switch (status) {
+            case RESOLVED -> 3;
+            case PARTIAL -> 2;
+            case UNRESOLVED -> 1;
+        };
+    }
+
+    private static <T> void addDistinct(Map<String, T> target, Collection<T> values, Function<T, String> keyFn) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        for (T value : values) {
+            if (value == null) {
+                continue;
+            }
+            String key = safe(keyFn.apply(value));
+            if (!target.containsKey(key)) {
+                target.put(key, value);
+            }
+        }
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsSectionFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsSectionFactory.java
@@ -1,0 +1,343 @@
+package com.example.ossdoc.domain.extraction.service.composer;
+
+import com.example.ossdoc.domain.extraction.dto.model.BuildMeta;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.JobMeta;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * facts.json 각 section을 비어 있지 않은 표준 형태로 조립한다.
+ */
+final class FactsSectionFactory {
+
+    private static final Comparator<SymbolFact> SYMBOL_ORDER = Comparator
+            .comparing((SymbolFact it) -> safe(it.symbol()))
+            .thenComparing(it -> safe(it.qualifiedName()))
+            .thenComparing(it -> safe(it.name()));
+
+    private static final Comparator<RelationFact> RELATION_ORDER = Comparator
+            .comparing((RelationFact it) -> safe(it.srcSymbol()))
+            .thenComparing(it -> safe(it.dstSymbol()))
+            .thenComparing(it -> safe(it.dstRawRef()))
+            .thenComparing(it -> safe(it.kind() == null ? null : it.kind().code()));
+
+    private static final Comparator<ObservationFact> OBSERVATION_ORDER = Comparator
+            .comparing((ObservationFact it) -> safe(it.siteSymbol()))
+            .thenComparing(it -> safe(it.targetSymbol()))
+            .thenComparing(it -> safe(it.serviceInterfaceSymbol()))
+            .thenComparing(it -> safe(it.kind() == null ? null : it.kind().code()));
+
+    JobMeta normalizeJob(JobMeta raw) {
+        if (raw == null) {
+            return JobMeta.builder().build();
+        }
+        return JobMeta.builder()
+                .jobId(raw.jobId())
+                .repoUrl(raw.repoUrl())
+                .commitSha(raw.commitSha())
+                .build();
+    }
+
+    BuildMeta normalizeBuild(BuildMeta raw) {
+        if (raw == null) {
+            return emptyBuild();
+        }
+        return BuildMeta.builder()
+                .status(raw.status())
+                .tool(raw.tool())
+                .javaVersionUsed(raw.javaVersionUsed())
+                .classpathFingerprint(raw.classpathFingerprint())
+                .modules(normalizeStringList(raw.modules()))
+                .bytecodeRoots(normalizeStringList(raw.bytecodeRoots()))
+                .classpathEntries(normalizeStringList(raw.classpathEntries()))
+                .build();
+    }
+
+    Map<String, EvidenceFact> composeEvidence(Map<String, EvidenceFact> rawEvidence) {
+        LinkedHashMap<String, EvidenceFact> merged = new LinkedHashMap<>();
+        if (rawEvidence != null) {
+            for (Map.Entry<String, EvidenceFact> entry : rawEvidence.entrySet()) {
+                if (entry.getValue() == null) {
+                    continue;
+                }
+                String key = entry.getKey();
+                if (key == null || key.isBlank()) {
+                    key = FactsDedupSupport.evidenceKey(entry.getValue());
+                }
+                merged.merge(key, entry.getValue(), FactsDedupSupport::mergeEvidence);
+            }
+        }
+
+        Map<String, EvidenceFact> sorted = new TreeMap<>();
+        for (Map.Entry<String, EvidenceFact> entry : merged.entrySet()) {
+            EvidenceFact normalized = FactsDedupSupport.mergeEvidence(
+                    EvidenceFact.builder().id(entry.getKey()).build(),
+                    entry.getValue()
+            );
+            sorted.put(entry.getKey(), normalized);
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(sorted));
+    }
+
+    SymbolTable composeSymbols(SymbolTable raw) {
+        LinkedHashMap<String, SymbolFact> merged = new LinkedHashMap<>();
+        for (SymbolFact symbol : flattenSymbols(raw)) {
+            merged.merge(FactsDedupSupport.symbolKey(symbol), symbol, FactsDedupSupport::mergeSymbol);
+        }
+
+        List<SymbolFact> modules = new ArrayList<>();
+        List<SymbolFact> packages = new ArrayList<>();
+        List<SymbolFact> types = new ArrayList<>();
+        List<SymbolFact> constructors = new ArrayList<>();
+        List<SymbolFact> methods = new ArrayList<>();
+        List<SymbolFact> fields = new ArrayList<>();
+
+        for (SymbolFact symbol : merged.values()) {
+            if (symbol == null || symbol.kind() == null) {
+                continue;
+            }
+            switch (symbol.kind()) {
+                case MODULE -> modules.add(symbol);
+                case PACKAGE -> packages.add(symbol);
+                case TYPE -> types.add(symbol);
+                case CONSTRUCTOR -> constructors.add(symbol);
+                case METHOD -> methods.add(symbol);
+                case FIELD -> fields.add(symbol);
+            }
+        }
+
+        modules.sort(SYMBOL_ORDER);
+        packages.sort(SYMBOL_ORDER);
+        types.sort(SYMBOL_ORDER);
+        constructors.sort(SYMBOL_ORDER);
+        methods.sort(SYMBOL_ORDER);
+        fields.sort(SYMBOL_ORDER);
+
+        return SymbolTable.builder()
+                .modules(List.copyOf(modules))
+                .packages(List.copyOf(packages))
+                .types(List.copyOf(types))
+                .constructors(List.copyOf(constructors))
+                .methods(List.copyOf(methods))
+                .fields(List.copyOf(fields))
+                .build();
+    }
+
+    RelationTable composeRelations(RelationTable raw) {
+        LinkedHashMap<String, RelationFact> merged = new LinkedHashMap<>();
+        for (RelationFact relation : flattenRelations(raw)) {
+            merged.merge(FactsDedupSupport.relationKey(relation), relation, FactsDedupSupport::mergeRelation);
+        }
+
+        List<RelationFact> contains = new ArrayList<>();
+        List<RelationFact> extendsRelations = new ArrayList<>();
+        List<RelationFact> implementsRelations = new ArrayList<>();
+        List<RelationFact> overrides = new ArrayList<>();
+        List<RelationFact> calls = new ArrayList<>();
+        List<RelationFact> accessesField = new ArrayList<>();
+        List<RelationFact> fieldType = new ArrayList<>();
+        List<RelationFact> paramType = new ArrayList<>();
+        List<RelationFact> returnType = new ArrayList<>();
+        List<RelationFact> throwsType = new ArrayList<>();
+        List<RelationFact> annotatedBy = new ArrayList<>();
+
+        for (RelationFact relation : merged.values()) {
+            if (relation == null || relation.kind() == null) {
+                continue;
+            }
+            switch (relation.kind()) {
+                case CONTAINS -> contains.add(relation);
+                case EXTENDS -> extendsRelations.add(relation);
+                case IMPLEMENTS -> implementsRelations.add(relation);
+                case OVERRIDES -> overrides.add(relation);
+                case CALLS -> calls.add(relation);
+                case ACCESSES_FIELD -> accessesField.add(relation);
+                case FIELD_TYPE -> fieldType.add(relation);
+                case PARAM_TYPE -> paramType.add(relation);
+                case RETURN_TYPE -> returnType.add(relation);
+                case THROWS_TYPE -> throwsType.add(relation);
+                case ANNOTATED_BY -> annotatedBy.add(relation);
+            }
+        }
+
+        contains.sort(RELATION_ORDER);
+        extendsRelations.sort(RELATION_ORDER);
+        implementsRelations.sort(RELATION_ORDER);
+        overrides.sort(RELATION_ORDER);
+        calls.sort(RELATION_ORDER);
+        accessesField.sort(RELATION_ORDER);
+        fieldType.sort(RELATION_ORDER);
+        paramType.sort(RELATION_ORDER);
+        returnType.sort(RELATION_ORDER);
+        throwsType.sort(RELATION_ORDER);
+        annotatedBy.sort(RELATION_ORDER);
+
+        return RelationTable.builder()
+                .contains(List.copyOf(contains))
+                .extendsRelations(List.copyOf(extendsRelations))
+                .implementsRelations(List.copyOf(implementsRelations))
+                .overrides(List.copyOf(overrides))
+                .calls(List.copyOf(calls))
+                .accessesField(List.copyOf(accessesField))
+                .fieldType(List.copyOf(fieldType))
+                .paramType(List.copyOf(paramType))
+                .returnType(List.copyOf(returnType))
+                .throwsType(List.copyOf(throwsType))
+                .annotatedBy(List.copyOf(annotatedBy))
+                .build();
+    }
+
+    ObservationTable composeObservations(ObservationTable raw) {
+        LinkedHashMap<String, ObservationFact> merged = new LinkedHashMap<>();
+        for (ObservationFact observation : flattenObservations(raw)) {
+            merged.merge(FactsDedupSupport.observationKey(observation), observation, FactsDedupSupport::mergeObservation);
+        }
+
+        List<ObservationFact> diInjectionSites = new ArrayList<>();
+        List<ObservationFact> diProviders = new ArrayList<>();
+        List<ObservationFact> spiProviders = new ArrayList<>();
+        List<ObservationFact> eventPublish = new ArrayList<>();
+        List<ObservationFact> eventSubscribe = new ArrayList<>();
+        List<ObservationFact> reflectionUses = new ArrayList<>();
+        List<ObservationFact> configWiring = new ArrayList<>();
+
+        for (ObservationFact observation : merged.values()) {
+            if (observation == null || observation.kind() == null) {
+                continue;
+            }
+            switch (observation.kind()) {
+                case DI_INJECTION_SITE -> diInjectionSites.add(observation);
+                case DI_PROVIDER -> diProviders.add(observation);
+                case SPI_PROVIDER -> spiProviders.add(observation);
+                case EVENT_PUBLISH -> eventPublish.add(observation);
+                case EVENT_SUBSCRIBE -> eventSubscribe.add(observation);
+                case REFLECTION_USE -> reflectionUses.add(observation);
+                case CONFIG_WIRING -> configWiring.add(observation);
+            }
+        }
+
+        diInjectionSites.sort(OBSERVATION_ORDER);
+        diProviders.sort(OBSERVATION_ORDER);
+        spiProviders.sort(OBSERVATION_ORDER);
+        eventPublish.sort(OBSERVATION_ORDER);
+        eventSubscribe.sort(OBSERVATION_ORDER);
+        reflectionUses.sort(OBSERVATION_ORDER);
+        configWiring.sort(OBSERVATION_ORDER);
+
+        return ObservationTable.builder()
+                .diInjectionSites(List.copyOf(diInjectionSites))
+                .diProviders(List.copyOf(diProviders))
+                .spiProviders(List.copyOf(spiProviders))
+                .eventPublish(List.copyOf(eventPublish))
+                .eventSubscribe(List.copyOf(eventSubscribe))
+                .reflectionUses(List.copyOf(reflectionUses))
+                .configWiring(List.copyOf(configWiring))
+                .build();
+    }
+
+    ObservationTable emptyObservationTable() {
+        return ObservationTable.builder()
+                .diInjectionSites(List.of())
+                .diProviders(List.of())
+                .spiProviders(List.of())
+                .eventPublish(List.of())
+                .eventSubscribe(List.of())
+                .reflectionUses(List.of())
+                .configWiring(List.of())
+                .build();
+    }
+
+    private BuildMeta emptyBuild() {
+        return BuildMeta.builder()
+                .modules(List.of())
+                .bytecodeRoots(List.of())
+                .classpathEntries(List.of())
+                .build();
+    }
+
+    private List<SymbolFact> flattenSymbols(SymbolTable table) {
+        if (table == null) {
+            return List.of();
+        }
+        List<SymbolFact> all = new ArrayList<>();
+        addAll(all, table.modules());
+        addAll(all, table.packages());
+        addAll(all, table.types());
+        addAll(all, table.constructors());
+        addAll(all, table.methods());
+        addAll(all, table.fields());
+        return all;
+    }
+
+    private List<RelationFact> flattenRelations(RelationTable table) {
+        if (table == null) {
+            return List.of();
+        }
+        List<RelationFact> all = new ArrayList<>();
+        addAll(all, table.contains());
+        addAll(all, table.extendsRelations());
+        addAll(all, table.implementsRelations());
+        addAll(all, table.overrides());
+        addAll(all, table.calls());
+        addAll(all, table.accessesField());
+        addAll(all, table.fieldType());
+        addAll(all, table.paramType());
+        addAll(all, table.returnType());
+        addAll(all, table.throwsType());
+        addAll(all, table.annotatedBy());
+        return all;
+    }
+
+    private List<ObservationFact> flattenObservations(ObservationTable table) {
+        if (table == null) {
+            return List.of();
+        }
+        List<ObservationFact> all = new ArrayList<>();
+        addAll(all, table.diInjectionSites());
+        addAll(all, table.diProviders());
+        addAll(all, table.spiProviders());
+        addAll(all, table.eventPublish());
+        addAll(all, table.eventSubscribe());
+        addAll(all, table.reflectionUses());
+        addAll(all, table.configWiring());
+        return all;
+    }
+
+    private List<String> normalizeStringList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        LinkedHashSet<String> result = new LinkedHashSet<>();
+        for (String value : raw) {
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            result.add(value);
+        }
+        return List.copyOf(result);
+    }
+
+    private static <T> void addAll(List<T> target, List<T> source) {
+        if (source != null && !source.isEmpty()) {
+            target.addAll(source);
+        }
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsStatsCalculator.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/composer/FactsStatsCalculator.java
@@ -1,0 +1,84 @@
+package com.example.ossdoc.domain.extraction.service.composer;
+
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 최종 facts.json에 기록할 stats를 실제 조립 결과 기준으로 계산한다.
+ *
+ * file/chunk 실행 통계는 aggregate에서 받은 값을 유지하고,
+ * symbol/relation/observation/evidence 카운트는 최종 문서 기준으로 다시 맞춘다.
+ */
+final class FactsStatsCalculator {
+
+    StatsMeta compose(
+            StatsMeta rawStats,
+            Map<String, EvidenceFact> evidence,
+            SymbolTable symbols,
+            RelationTable relations,
+            ObservationTable observations
+    ) {
+        StatsMeta base = rawStats == null ? StatsMeta.builder().build() : rawStats;
+
+        long relationCount = size(relations.contains())
+                + size(relations.extendsRelations())
+                + size(relations.implementsRelations())
+                + size(relations.overrides())
+                + size(relations.calls())
+                + size(relations.accessesField())
+                + size(relations.fieldType())
+                + size(relations.paramType())
+                + size(relations.returnType())
+                + size(relations.throwsType())
+                + size(relations.annotatedBy());
+
+        long observationCount = size(observations.diInjectionSites())
+                + size(observations.diProviders())
+                + size(observations.spiProviders())
+                + size(observations.eventPublish())
+                + size(observations.eventSubscribe())
+                + size(observations.reflectionUses())
+                + size(observations.configWiring());
+
+        long derivedFilesScanned = base.astFilesScanned() + base.classFilesScanned();
+        long derivedFilesParsed = base.astFilesParsed() + base.classFilesParsed();
+
+        return StatsMeta.builder()
+                .filesScanned(preferExplicitOrDerived(base.filesScanned(), derivedFilesScanned))
+                .filesParsed(preferExplicitOrDerived(base.filesParsed(), derivedFilesParsed))
+                .filesSkipped(base.filesSkipped())
+                .astFilesScanned(base.astFilesScanned())
+                .classFilesScanned(base.classFilesScanned())
+                .astFilesParsed(base.astFilesParsed())
+                .classFilesParsed(base.classFilesParsed())
+                .chunksTotal(base.chunksTotal())
+                .chunksSucceeded(base.chunksSucceeded())
+                .chunksFailed(base.chunksFailed())
+                .chunksPartial(base.chunksPartial())
+                .types(size(symbols.types()))
+                .constructors(size(symbols.constructors()))
+                .methods(size(symbols.methods()))
+                .fields(size(symbols.fields()))
+                .edgeCandidates(base.edgeCandidates() > 0 ? base.edgeCandidates() : relationCount)
+                .relations(relationCount)
+                .observations(observationCount)
+                .evidence(evidence == null ? 0L : evidence.size())
+                .unresolvedTypeRefs(base.unresolvedTypeRefs())
+                .errors(base.errors())
+                .build();
+    }
+
+    private long size(List<?> list) {
+        return list == null ? 0L : list.size();
+    }
+
+    private long preferExplicitOrDerived(long explicitValue, long derivedValue) {
+        return explicitValue > 0 ? explicitValue : derivedValue;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/AsmBytecodeFactsExtractor.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/AsmBytecodeFactsExtractor.java
@@ -1,0 +1,618 @@
+package com.example.ossdoc.domain.extraction.service.extractor;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionSink;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.SignatureFact;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.TypeRef;
+import com.example.ossdoc.domain.extraction.enums.AccessLevel;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.EvidenceKind;
+import com.example.ossdoc.domain.extraction.enums.FactOriginKind;
+import com.example.ossdoc.domain.extraction.enums.ModifierKind;
+import com.example.ossdoc.domain.extraction.enums.ObservationKind;
+import com.example.ossdoc.domain.extraction.enums.RelationKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolOriginKind;
+import com.example.ossdoc.domain.extraction.enums.TypeKind;
+import com.example.ossdoc.domain.extraction.service.support.util.EvidenceIdGenerator;
+import com.example.ossdoc.domain.extraction.service.support.util.RelationResolutionFactory;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+import com.example.ossdoc.domain.extraction.service.support.util.SymbolIdFactory;
+import com.example.ossdoc.domain.extraction.service.support.util.TypeRefFactory;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * ASM 기반 bytecode extractor.
+ *
+ * 새 구조에서는 planner가 확정한 class 파일 목록만 처리한다.
+ */
+@Component
+public class AsmBytecodeFactsExtractor implements FactsExtractor {
+
+    private static final int ASM_API = Opcodes.ASM9;
+
+    @Override
+    public ChunkKind supports() {
+        return ChunkKind.ASM;
+    }
+
+    @Override
+    public ChunkResult extract(ExtractionContext context) {
+        ExtractionSink sink = new ExtractionSink(context.chunkKind());
+
+        if (!context.isAsmChunk()) {
+            sink.addError("ASM extractor received non-ASM chunk: " + context.chunkKind());
+            return sink.toChunkResult(context.chunk());
+        }
+
+        if (!context.hasFiles()) {
+            sink.addWarning("ASM chunk contains no files: " + context.chunkId());
+            return sink.toChunkResult(context.chunk());
+        }
+
+        for (Path classFile : context.files()) {
+            if (classFile == null || !Files.exists(classFile) || !Files.isRegularFile(classFile)) {
+                sink.addWarning("class file does not exist or is not a regular file: " + classFile);
+                sink.recordFileSkipped();
+                continue;
+            }
+            if (!classFile.toString().endsWith(".class")) {
+                sink.recordFileSkipped();
+                continue;
+            }
+            visitClassFile(context, classFile, sink);
+        }
+
+        return sink.toChunkResult(context.chunk());
+    }
+
+    private void visitClassFile(ExtractionContext context, Path classFile, ExtractionSink sink) {
+        String relativePath = RepoPathUtils.toRepoRelative(context.repoRoot(), classFile);
+        sink.recordFileScanned();
+
+        try {
+            ClassReader classReader = new ClassReader(Files.readAllBytes(classFile));
+            classReader.accept(new AsmFactsVisitor(context, classFile, relativePath, sink), ClassReader.SKIP_FRAMES);
+            sink.recordFileParsed();
+        } catch (Exception e) {
+            sink.addError("failed to read class file: " + relativePath + " (" + e.getMessage() + ")");
+        }
+    }
+
+    private final class AsmFactsVisitor extends ClassVisitor {
+
+        private final ExtractionContext context;
+        private final Path classFile;
+        private final String relativePath;
+        private final ExtractionSink sink;
+        private final String moduleSymbol;
+
+        private String packageName;
+        private String packageSymbol;
+        private String typeQualifiedName;
+        private String typeSymbol;
+        private String typeEvidenceId;
+
+        private AsmFactsVisitor(ExtractionContext context, Path classFile, String relativePath, ExtractionSink sink) {
+            super(ASM_API);
+            this.context = context;
+            this.classFile = classFile;
+            this.relativePath = relativePath;
+            this.sink = sink;
+            this.moduleSymbol = ensureModuleSymbol(context, sink);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            this.typeQualifiedName = internalNameToQualified(name);
+            this.typeSymbol = SymbolIdFactory.type(typeQualifiedName);
+            this.packageName = packageName(typeQualifiedName);
+            this.packageSymbol = ensurePackageSymbol(context, moduleSymbol, packageName, relativePath, sink);
+
+            EvidenceFact typeEvidence = buildBytecodeEvidence(typeSymbol);
+            this.typeEvidenceId = typeEvidence.id();
+            sink.addEvidence(typeEvidence);
+            sink.addSymbol(SymbolFact.builder()
+                    .symbol(typeSymbol)
+                    .kind(SymbolFactKind.TYPE)
+                    .typeKind(typeKind(access))
+                    .name(simpleName(typeQualifiedName))
+                    .qualifiedName(typeQualifiedName)
+                    .packageSymbol(packageSymbol)
+                    .module(context.module())
+                    .bytecodeRoot(context.bytecodeRootString())
+                    .access(accessLevel(access))
+                    .modifiers(modifierKinds(access))
+                    .origin(SymbolOriginKind.BYTECODE)
+                    .annotations(List.of())
+                    .evidenceIds(List.of(typeEvidence.id()))
+                    .sourceFile(relativePath)
+                    .isSynthetic((access & Opcodes.ACC_SYNTHETIC) != 0)
+                    .bytecodeDescriptor(name)
+                    .build());
+
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CONTAINS)
+                    .srcSymbol(packageSymbol)
+                    .dstSymbol(typeSymbol)
+                    .evidenceIds(List.of(typeEvidence.id()))
+                    .resolution(RelationResolutionFactory.resolved())
+                    .origin(FactOriginKind.BYTECODE)
+                    .build());
+
+            if (superName != null && !"java/lang/Object".equals(superName)) {
+                addTypeRelation(RelationKind.EXTENDS, typeSymbol, objectTypeRef(superName), typeEvidence.id());
+            }
+            if (interfaces != null) {
+                for (String iface : interfaces) {
+                    addTypeRelation(RelationKind.IMPLEMENTS, typeSymbol, objectTypeRef(iface), typeEvidence.id());
+                }
+            }
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            addAnnotatedBy(typeSymbol, descriptorToTypeRef(descriptor), typeEvidenceId);
+            if (context.includeObservations() && isProviderTypeAnnotation(descriptor)) {
+                sink.addObservation(ObservationFact.builder()
+                        .kind(ObservationKind.DI_PROVIDER)
+                        .siteSymbol(typeSymbol)
+                        .evidenceIds(List.of(typeEvidenceId))
+                        .origin(FactOriginKind.OBSERVED)
+                        .note("type-level provider annotation from bytecode")
+                        .attrs(Map.of("annotation", descriptorToTypeRef(descriptor).raw()))
+                        .build());
+            }
+            return super.visitAnnotation(descriptor, visible);
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            String fieldSymbol = SymbolIdFactory.field(typeQualifiedName, name);
+            EvidenceFact evidence = buildBytecodeEvidence(fieldSymbol);
+            sink.addEvidence(evidence);
+
+            TypeRef fieldTypeRef = typeRefFromAsmType(Type.getType(descriptor));
+            sink.addSymbol(SymbolFact.builder()
+                    .symbol(fieldSymbol)
+                    .kind(SymbolFactKind.FIELD)
+                    .name(name)
+                    .ownerTypeSymbol(typeSymbol)
+                    .module(context.module())
+                    .bytecodeRoot(context.bytecodeRootString())
+                    .access(accessLevel(access))
+                    .modifiers(modifierKinds(access))
+                    .origin(SymbolOriginKind.BYTECODE)
+                    .evidenceIds(List.of(evidence.id()))
+                    .signature(SignatureFact.builder().fieldType(fieldTypeRef).build())
+                    .sourceFile(relativePath)
+                    .isSynthetic((access & Opcodes.ACC_SYNTHETIC) != 0)
+                    .build());
+
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CONTAINS)
+                    .srcSymbol(typeSymbol)
+                    .dstSymbol(fieldSymbol)
+                    .evidenceIds(List.of(evidence.id()))
+                    .resolution(RelationResolutionFactory.resolved())
+                    .origin(FactOriginKind.BYTECODE)
+                    .build());
+            addTypeRelation(RelationKind.FIELD_TYPE, fieldSymbol, fieldTypeRef, evidence.id());
+
+            return new FieldVisitor(ASM_API) {
+                @Override
+                public AnnotationVisitor visitAnnotation(String annotationDescriptor, boolean visible) {
+                    addAnnotatedBy(fieldSymbol, descriptorToTypeRef(annotationDescriptor), evidence.id());
+
+                    if (context.includeObservations() && isInjectionAnnotation(annotationDescriptor)) {
+                        sink.addObservation(ObservationFact.builder()
+                                .kind(ObservationKind.DI_INJECTION_SITE)
+                                .siteSymbol(fieldSymbol)
+                                .targetTypeRef(fieldTypeRef)
+                                .evidenceIds(List.of(evidence.id()))
+                                .origin(FactOriginKind.OBSERVED)
+                                .note("field injection from bytecode annotation")
+                                .attrs(Map.of("annotation", descriptorToTypeRef(annotationDescriptor).raw()))
+                                .build());
+                    }
+                    return super.visitAnnotation(annotationDescriptor, visible);
+                }
+            };
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            boolean constructor = "<init>".equals(name);
+            SignatureFact methodSignature = methodSignature(descriptor, exceptions);
+            String symbol = constructor
+                    ? SymbolIdFactory.constructor(typeQualifiedName, methodSignature)
+                    : SymbolIdFactory.method(typeQualifiedName, name, methodSignature);
+
+            EvidenceFact evidence = buildBytecodeEvidence(symbol);
+            sink.addEvidence(evidence);
+            sink.addSymbol(SymbolFact.builder()
+                    .symbol(symbol)
+                    .kind(constructor ? SymbolFactKind.CONSTRUCTOR : SymbolFactKind.METHOD)
+                    .name(constructor ? simpleName(typeQualifiedName) : name)
+                    .ownerTypeSymbol(typeSymbol)
+                    .module(context.module())
+                    .bytecodeRoot(context.bytecodeRootString())
+                    .access(accessLevel(access))
+                    .modifiers(modifierKinds(access))
+                    .origin(SymbolOriginKind.BYTECODE)
+                    .evidenceIds(List.of(evidence.id()))
+                    .signature(methodSignature)
+                    .sourceFile(relativePath)
+                    .isBridge((access & Opcodes.ACC_BRIDGE) != 0)
+                    .isSynthetic((access & Opcodes.ACC_SYNTHETIC) != 0)
+                    .bytecodeDescriptor(descriptor)
+                    .build());
+
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CONTAINS)
+                    .srcSymbol(typeSymbol)
+                    .dstSymbol(symbol)
+                    .evidenceIds(List.of(evidence.id()))
+                    .resolution(RelationResolutionFactory.resolved())
+                    .origin(FactOriginKind.BYTECODE)
+                    .build());
+
+            for (TypeRef parameterType : methodSignature.params()) {
+                addTypeRelation(RelationKind.PARAM_TYPE, symbol, parameterType, evidence.id());
+            }
+            if (methodSignature.returns() != null) {
+                addTypeRelation(RelationKind.RETURN_TYPE, symbol, methodSignature.returns(), evidence.id());
+            }
+            if (methodSignature.throwsTypes() != null) {
+                for (TypeRef thrownType : methodSignature.throwsTypes()) {
+                    addTypeRelation(RelationKind.THROWS_TYPE, symbol, thrownType, evidence.id());
+                }
+            }
+
+            return new MethodVisitor(ASM_API) {
+                @Override
+                public AnnotationVisitor visitAnnotation(String annotationDescriptor, boolean visible) {
+                    addAnnotatedBy(symbol, descriptorToTypeRef(annotationDescriptor), evidence.id());
+
+                    if (context.includeObservations()) {
+                        if (isBeanAnnotation(annotationDescriptor)) {
+                            sink.addObservation(ObservationFact.builder()
+                                    .kind(ObservationKind.DI_PROVIDER)
+                                    .siteSymbol(symbol)
+                                    .targetTypeRef(methodSignature.returns())
+                                    .evidenceIds(List.of(evidence.id()))
+                                    .origin(FactOriginKind.OBSERVED)
+                                    .note("provider method from bytecode annotation")
+                                    .attrs(Map.of("annotation", descriptorToTypeRef(annotationDescriptor).raw()))
+                                    .build());
+                        }
+                        if (isEventListenerAnnotation(annotationDescriptor)) {
+                            sink.addObservation(ObservationFact.builder()
+                                    .kind(ObservationKind.EVENT_SUBSCRIBE)
+                                    .siteSymbol(symbol)
+                                    .targetTypeRef(methodSignature.params().isEmpty() ? null : methodSignature.params().get(0))
+                                    .evidenceIds(List.of(evidence.id()))
+                                    .origin(FactOriginKind.OBSERVED)
+                                    .note("event subscriber from bytecode annotation")
+                                    .attrs(Map.of("annotation", descriptorToTypeRef(annotationDescriptor).raw()))
+                                    .build());
+                        }
+                    }
+                    return super.visitAnnotation(annotationDescriptor, visible);
+                }
+
+                @Override
+                public void visitMethodInsn(int opcode, String owner, String methodName, String methodDescriptor, boolean isInterface) {
+                    Type methodType = Type.getMethodType(methodDescriptor);
+                    SignatureFact calleeSignature = SignatureFact.builder()
+                            .params(Arrays.stream(methodType.getArgumentTypes()).map(AsmBytecodeFactsExtractor.this::typeRefFromAsmType).toList())
+                            .build();
+
+                    String dstSymbol = "<init>".equals(methodName)
+                            ? SymbolIdFactory.constructor(internalNameToQualified(owner), calleeSignature)
+                            : SymbolIdFactory.method(internalNameToQualified(owner), methodName, calleeSignature);
+
+                    sink.addRelation(RelationFact.builder()
+                            .kind(RelationKind.CALLS)
+                            .srcSymbol(symbol)
+                            .dstSymbol(dstSymbol)
+                            .evidenceIds(List.of(evidence.id()))
+                            .resolution(RelationResolutionFactory.resolved())
+                            .origin(FactOriginKind.BYTECODE)
+                            .build());
+
+                    if (context.includeObservations() && isReflectionOwner(owner, methodName)) {
+                        sink.addObservation(ObservationFact.builder()
+                                .kind(ObservationKind.REFLECTION_USE)
+                                .siteSymbol(symbol)
+                                .evidenceIds(List.of(evidence.id()))
+                                .origin(FactOriginKind.OBSERVED)
+                                .note("reflection API usage from bytecode")
+                                .attrs(Map.of(
+                                        "owner", internalNameToQualified(owner),
+                                        "method", methodName,
+                                        "descriptor", methodDescriptor
+                                ))
+                                .build());
+                    }
+                }
+
+                @Override
+                public void visitFieldInsn(int opcode, String owner, String fieldName, String fieldDescriptor) {
+                    sink.addRelation(RelationFact.builder()
+                            .kind(RelationKind.ACCESSES_FIELD)
+                            .srcSymbol(symbol)
+                            .dstSymbol(SymbolIdFactory.field(internalNameToQualified(owner), fieldName))
+                            .evidenceIds(List.of(evidence.id()))
+                            .resolution(RelationResolutionFactory.resolved())
+                            .origin(FactOriginKind.BYTECODE)
+                            .build());
+                }
+            };
+        }
+
+        private void addAnnotatedBy(String srcSymbol, TypeRef annotationTypeRef, String evidenceId) {
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.ANNOTATED_BY)
+                    .srcSymbol(srcSymbol)
+                    .dstRawRef(annotationTypeRef.raw())
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(RelationResolutionFactory.partial("annotation symbol linking deferred"))
+                    .origin(FactOriginKind.BYTECODE)
+                    .build());
+        }
+
+        private void addTypeRelation(RelationKind kind, String srcSymbol, TypeRef dstTypeRef, String evidenceId) {
+            sink.addRelation(RelationFact.builder()
+                    .kind(kind)
+                    .srcSymbol(srcSymbol)
+                    .dstRawRef(dstTypeRef.raw())
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(RelationResolutionFactory.partial("bytecode type symbol linking deferred"))
+                    .origin(FactOriginKind.BYTECODE)
+                    .build());
+        }
+
+        private EvidenceFact buildBytecodeEvidence(String symbol) {
+            return EvidenceFact.builder()
+                    .id(EvidenceIdGenerator.generate(EvidenceKind.BYTECODE, relativePath, null, symbol))
+                    .type(EvidenceKind.BYTECODE)
+                    .path(relativePath)
+                    .symbol(symbol)
+                    .hash(Integer.toHexString(relativePath.hashCode()))
+                    .attrs(Map.of("class_file", true, "module", context.module()))
+                    .build();
+        }
+    }
+
+    private String ensureModuleSymbol(ExtractionContext context, ExtractionSink sink) {
+        String moduleSymbol = SymbolIdFactory.module(context.module());
+        String rootPath = context.rootPathString();
+
+        EvidenceFact evidence = EvidenceFact.builder()
+                .id(EvidenceIdGenerator.generate(EvidenceKind.BYTECODE, rootPath, null, moduleSymbol))
+                .type(EvidenceKind.BYTECODE)
+                .path(rootPath)
+                .symbol(moduleSymbol)
+                .attrs(Map.of("module", context.module(), "bytecode_root", rootPath))
+                .build();
+        sink.addEvidence(evidence);
+        sink.addSymbol(SymbolFact.builder()
+                .symbol(moduleSymbol)
+                .kind(SymbolFactKind.MODULE)
+                .name(context.module())
+                .qualifiedName(context.module())
+                .module(context.module())
+                .bytecodeRoot(context.bytecodeRootString())
+                .origin(SymbolOriginKind.BYTECODE)
+                .evidenceIds(List.of(evidence.id()))
+                .build());
+        return moduleSymbol;
+    }
+
+    private String ensurePackageSymbol(
+            ExtractionContext context,
+            String moduleSymbol,
+            String packageName,
+            String relativePath,
+            ExtractionSink sink
+    ) {
+        String packageSymbol = SymbolIdFactory.packageSymbol(packageName);
+        EvidenceFact packageEvidence = EvidenceFact.builder()
+                .id(EvidenceIdGenerator.generate(EvidenceKind.BYTECODE, relativePath, null, packageSymbol))
+                .type(EvidenceKind.BYTECODE)
+                .path(relativePath)
+                .symbol(packageSymbol)
+                .attrs(Map.of("package", packageName, "module", context.module()))
+                .build();
+        sink.addEvidence(packageEvidence);
+        sink.addSymbol(SymbolFact.builder()
+                .symbol(packageSymbol)
+                .kind(SymbolFactKind.PACKAGE)
+                .name(packageName)
+                .qualifiedName(packageName)
+                .module(context.module())
+                .bytecodeRoot(context.bytecodeRootString())
+                .origin(SymbolOriginKind.BYTECODE)
+                .evidenceIds(List.of(packageEvidence.id()))
+                .build());
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(moduleSymbol)
+                .dstSymbol(packageSymbol)
+                .evidenceIds(List.of(packageEvidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.BYTECODE)
+                .build());
+        return packageSymbol;
+    }
+
+    private SignatureFact methodSignature(String descriptor, String[] exceptions) {
+        Type methodType = Type.getMethodType(descriptor);
+        List<TypeRef> params = new ArrayList<>();
+        for (Type argumentType : methodType.getArgumentTypes()) {
+            params.add(typeRefFromAsmType(argumentType));
+        }
+
+        List<TypeRef> throwsTypes = new ArrayList<>();
+        if (exceptions != null) {
+            for (String exception : exceptions) {
+                throwsTypes.add(objectTypeRef(exception));
+            }
+        }
+
+        return SignatureFact.builder()
+                .params(params)
+                .returns(typeRefFromAsmType(methodType.getReturnType()))
+                .throwsTypes(throwsTypes)
+                .build();
+    }
+
+    private TypeRef descriptorToTypeRef(String descriptor) {
+        return typeRefFromAsmType(Type.getType(descriptor));
+    }
+
+    private TypeRef objectTypeRef(String internalName) {
+        return TypeRefFactory.simple(internalNameToQualified(internalName));
+    }
+
+    private TypeRef typeRefFromAsmType(Type type) {
+        if (type.getSort() == Type.VOID) {
+            return TypeRef.builder().raw("void").primitive(true).arrayDim(0).unresolved(false).build();
+        }
+        if (type.getSort() == Type.BOOLEAN || type.getSort() == Type.CHAR || type.getSort() == Type.BYTE
+                || type.getSort() == Type.SHORT || type.getSort() == Type.INT || type.getSort() == Type.FLOAT
+                || type.getSort() == Type.LONG || type.getSort() == Type.DOUBLE) {
+            return TypeRef.builder().raw(type.getClassName()).primitive(true).arrayDim(0).unresolved(false).build();
+        }
+        if (type.getSort() == Type.ARRAY) {
+            Type elementType = type.getElementType();
+            TypeRef element = typeRefFromAsmType(elementType);
+            return TypeRef.builder()
+                    .raw(element.raw())
+                    .args(element.args())
+                    .arrayDim(type.getDimensions())
+                    .primitive(element.primitive())
+                    .unresolved(false)
+                    .build();
+        }
+        return TypeRef.builder()
+                .raw(type.getClassName())
+                .primitive(false)
+                .arrayDim(0)
+                .unresolved(false)
+                .build();
+    }
+
+    private AccessLevel accessLevel(int access) {
+        if ((access & Opcodes.ACC_PUBLIC) != 0) {
+            return AccessLevel.PUBLIC;
+        }
+        if ((access & Opcodes.ACC_PROTECTED) != 0) {
+            return AccessLevel.PROTECTED;
+        }
+        if ((access & Opcodes.ACC_PRIVATE) != 0) {
+            return AccessLevel.PRIVATE;
+        }
+        return AccessLevel.PACKAGE;
+    }
+
+    private Set<ModifierKind> modifierKinds(int access) {
+        EnumSet<ModifierKind> set = EnumSet.noneOf(ModifierKind.class);
+        if ((access & Opcodes.ACC_STATIC) != 0) set.add(ModifierKind.STATIC);
+        if ((access & Opcodes.ACC_FINAL) != 0) set.add(ModifierKind.FINAL);
+        if ((access & Opcodes.ACC_ABSTRACT) != 0) set.add(ModifierKind.ABSTRACT);
+        if ((access & Opcodes.ACC_SYNCHRONIZED) != 0) set.add(ModifierKind.SYNCHRONIZED);
+        if ((access & Opcodes.ACC_NATIVE) != 0) set.add(ModifierKind.NATIVE);
+        if ((access & Opcodes.ACC_STRICT) != 0) set.add(ModifierKind.STRICTFP);
+        if ((access & Opcodes.ACC_TRANSIENT) != 0) set.add(ModifierKind.TRANSIENT);
+        if ((access & Opcodes.ACC_VOLATILE) != 0) set.add(ModifierKind.VOLATILE);
+        return set;
+    }
+
+    private TypeKind typeKind(int access) {
+        if ((access & Opcodes.ACC_ANNOTATION) != 0) {
+            return TypeKind.ANNOTATION;
+        }
+        if ((access & Opcodes.ACC_ENUM) != 0) {
+            return TypeKind.ENUM;
+        }
+        if ((access & Opcodes.ACC_INTERFACE) != 0) {
+            return TypeKind.INTERFACE;
+        }
+        if ((access & Opcodes.ACC_RECORD) != 0) {
+            return TypeKind.RECORD;
+        }
+        return TypeKind.CLASS;
+    }
+
+    private String internalNameToQualified(String internalName) {
+        return internalName.replace('/', '.');
+    }
+
+    private String packageName(String qualifiedName) {
+        int index = qualifiedName.lastIndexOf('.');
+        return index < 0 ? "(default)" : qualifiedName.substring(0, index);
+    }
+
+    private String simpleName(String qualifiedName) {
+        int index = qualifiedName.lastIndexOf('.');
+        return index < 0 ? qualifiedName : qualifiedName.substring(index + 1);
+    }
+
+    private boolean isInjectionAnnotation(String descriptor) {
+        String qualified = descriptorToTypeRef(descriptor).raw();
+        return qualified.endsWith("Inject")
+                || qualified.endsWith("Autowired")
+                || qualified.endsWith("Resource")
+                || qualified.endsWith("Qualifier");
+    }
+
+    private boolean isBeanAnnotation(String descriptor) {
+        String qualified = descriptorToTypeRef(descriptor).raw();
+        return qualified.endsWith("Bean") || qualified.endsWith("Produces");
+    }
+
+    private boolean isProviderTypeAnnotation(String descriptor) {
+        String qualified = descriptorToTypeRef(descriptor).raw();
+        return qualified.endsWith("Component")
+                || qualified.endsWith("Service")
+                || qualified.endsWith("Repository")
+                || qualified.endsWith("Controller")
+                || qualified.endsWith("RestController")
+                || qualified.endsWith("Named");
+    }
+
+    private boolean isEventListenerAnnotation(String descriptor) {
+        String qualified = descriptorToTypeRef(descriptor).raw();
+        return qualified.endsWith("EventListener") || qualified.endsWith("Subscribe");
+    }
+
+    private boolean isReflectionOwner(String owner, String methodName) {
+        String qualified = internalNameToQualified(owner);
+        return ("java.lang.Class".equals(qualified) && ("forName".equals(methodName) || "getMethod".equals(methodName) || "getDeclaredMethod".equals(methodName)))
+                || ("java.lang.reflect.Method".equals(qualified) && "invoke".equals(methodName))
+                || ("java.lang.reflect.Constructor".equals(qualified) && "newInstance".equals(methodName));
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/ChunkFactsExtractionCoordinator.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/ChunkFactsExtractionCoordinator.java
@@ -1,0 +1,43 @@
+package com.example.ossdoc.domain.extraction.service.extractor;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ChunkFactsExtractionCoordinator {
+
+    private final List<FactsExtractor> extractors;
+    private final ExtractionContextFactory extractionContextFactory;
+
+    public ChunkResult extract(
+            FactsExtractRequest request,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot,
+            ChunkDescriptor chunk
+    ) {
+        ExtractionContext context = extractionContextFactory.create(request, preflightResult, repoRoot, chunk);
+        return extract(context);
+    }
+
+    public ChunkResult extract(ExtractionContext context) {
+        FactsExtractor extractor = extractorFor(context.chunkKind());
+        return extractor.extract(context);
+    }
+
+    private FactsExtractor extractorFor(ChunkKind kind) {
+        return extractors.stream()
+                .filter(extractor -> extractor.supports() == kind)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No extractor registered for chunk kind: " + kind));
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/ExtractionContextFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/ExtractionContextFactory.java
@@ -1,0 +1,92 @@
+package com.example.ossdoc.domain.extraction.service.extractor;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightResult;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class ExtractionContextFactory {
+
+    public ExtractionContext create(
+            FactsExtractRequest request,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot,
+            ChunkDescriptor chunk
+    ) {
+        Objects.requireNonNull(preflightResult, "preflightResult must not be null");
+        Objects.requireNonNull(repoRoot, "repoRoot must not be null");
+        Objects.requireNonNull(chunk, "chunk must not be null");
+
+        Path normalizedRepoRoot = repoRoot.normalize();
+        Path rootPath = resolve(normalizedRepoRoot, chunk.rootPath());
+        List<Path> files = chunk.files().stream()
+                .map(file -> resolve(normalizedRepoRoot, file))
+                .toList();
+
+        ExtractionPreflightResult.ModuleNormalizedContext moduleContext = findModuleContext(preflightResult, chunk.module());
+        List<Path> astLookupRoots = astLookupRoots(request, moduleContext, chunk, rootPath);
+
+        return ExtractionContext.builder()
+                .repoRoot(normalizedRepoRoot)
+                .chunk(chunk)
+                .module(chunk.module())
+                .rootPath(rootPath)
+                .files(files)
+                .astLookupRoots(astLookupRoots)
+                .compileClasspathEntries(preflightResult.normalizedContext().compileClasspath())
+                .runtimeClasspathEntries(preflightResult.normalizedContext().runtimeClasspath())
+                .includeObservations(request != null && request.includeObservations())
+                .build();
+    }
+
+    private ExtractionPreflightResult.ModuleNormalizedContext findModuleContext(
+            ExtractionPreflightResult preflightResult,
+            String moduleName
+    ) {
+        return preflightResult.normalizedContext().modules().stream()
+                .filter(module -> Objects.equals(module.moduleName(), moduleName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<Path> astLookupRoots(
+            FactsExtractRequest request,
+            ExtractionPreflightResult.ModuleNormalizedContext moduleContext,
+            ChunkDescriptor chunk,
+            Path fallbackRoot
+    ) {
+        if (chunk.kind() != com.example.ossdoc.domain.extraction.enums.ChunkKind.AST) {
+            return List.of();
+        }
+
+        if (moduleContext == null) {
+            return List.of(fallbackRoot);
+        }
+
+        List<Path> lookupRoots = new ArrayList<>(moduleContext.sourceRoots());
+        if (request != null && request.includeTests()) {
+            lookupRoots.addAll(moduleContext.testRoots());
+        }
+
+        if (lookupRoots.isEmpty()) {
+            lookupRoots.add(fallbackRoot);
+        }
+        return List.copyOf(lookupRoots);
+    }
+
+    private Path resolve(Path repoRoot, String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new IllegalArgumentException("rawPath must not be blank");
+        }
+
+        Path path = Path.of(rawPath);
+        return path.isAbsolute() ? path.normalize() : repoRoot.resolve(path).normalize();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/FactsExtractor.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/FactsExtractor.java
@@ -1,0 +1,18 @@
+package com.example.ossdoc.domain.extraction.service.extractor;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+
+/**
+ * AST / BYTECODE extractor 공통 인터페이스.
+ *
+ * 새 구조에서는 "전체 extraction context"가 아니라
+ * planner가 만든 단일 chunk를 받아 ChunkResult를 반환한다.
+ */
+public interface FactsExtractor {
+
+    ChunkKind supports();
+
+    ChunkResult extract(ExtractionContext context);
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/JavaParserAstFactsExtractor.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/extractor/JavaParserAstFactsExtractor.java
@@ -1,0 +1,1297 @@
+package com.example.ossdoc.domain.extraction.service.extractor;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionSink;
+import com.example.ossdoc.domain.extraction.dto.context.ExtractionContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.SignatureFact;
+import com.example.ossdoc.domain.extraction.dto.model.SourceSpan;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.TypeRef;
+import com.example.ossdoc.domain.extraction.enums.AccessLevel;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.EvidenceKind;
+import com.example.ossdoc.domain.extraction.enums.FactOriginKind;
+import com.example.ossdoc.domain.extraction.enums.ModifierKind;
+import com.example.ossdoc.domain.extraction.enums.ObservationKind;
+import com.example.ossdoc.domain.extraction.enums.RelationKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolOriginKind;
+import com.example.ossdoc.domain.extraction.enums.TypeKind;
+import com.example.ossdoc.domain.extraction.service.support.util.EvidenceIdGenerator;
+import com.example.ossdoc.domain.extraction.service.support.util.RelationResolutionFactory;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+import com.example.ossdoc.domain.extraction.service.support.util.SymbolIdFactory;
+import com.example.ossdoc.domain.extraction.service.support.util.TypeRefFactory;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Position;
+import com.github.javaparser.Range;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithAccessModifiers;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import com.github.javaparser.resolution.types.ResolvedArrayType;
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * JavaParser + Symbol Solver 기반 AST extractor.
+ *
+ * 새 구조에서는 planner가 확정한 .java 파일 목록만 처리하고,
+ * JavaParser 인스턴스를 chunk별로 생성해 병렬 worker 간 static 설정 충돌을 피한다.
+ */
+@Component
+public class JavaParserAstFactsExtractor implements FactsExtractor {
+
+    @Override
+    public ChunkKind supports() {
+        return ChunkKind.AST;
+    }
+
+    @Override
+    public ChunkResult extract(ExtractionContext context) {
+        ExtractionSink sink = new ExtractionSink(context.chunkKind());
+
+        if (!context.isAstChunk()) {
+            sink.addError("AST extractor received non-AST chunk: " + context.chunkKind());
+            return sink.toChunkResult(context.chunk());
+        }
+
+        if (!context.hasFiles()) {
+            sink.addWarning("AST chunk contains no files: " + context.chunkId());
+            return sink.toChunkResult(context.chunk());
+        }
+
+        ParserConfiguration parserConfiguration = parserConfiguration(context, sink);
+        JavaParser parser = new JavaParser(parserConfiguration);
+
+        for (Path javaFile : context.files()) {
+            if (javaFile == null || !Files.exists(javaFile) || !Files.isRegularFile(javaFile)) {
+                sink.addWarning("source file does not exist or is not a regular file: " + javaFile);
+                sink.recordFileSkipped();
+                continue;
+            }
+            if (!javaFile.toString().endsWith(".java")) {
+                sink.recordFileSkipped();
+                continue;
+            }
+            parseFile(context, parser, javaFile, sink);
+        }
+
+        return sink.toChunkResult(context.chunk());
+    }
+
+    private ParserConfiguration parserConfiguration(ExtractionContext context, ExtractionSink sink) {
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE)
+                .setStoreTokens(false)
+                .setAttributeComments(false);
+
+        try {
+            TypeSolver typeSolver = buildTypeSolver(context, sink);
+            configuration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        } catch (Exception e) {
+            sink.addWarning("symbol solver initialization failed; unresolved refs may increase (" + e.getMessage() + ")");
+        }
+        return configuration;
+    }
+
+    private TypeSolver buildTypeSolver(ExtractionContext context, ExtractionSink sink) {
+        CombinedTypeSolver solver = new CombinedTypeSolver();
+        solver.add(new ReflectionTypeSolver(false));
+
+        for (Path sourceRoot : context.astLookupRoots()) {
+            if (sourceRoot != null && Files.isDirectory(sourceRoot)) {
+                solver.add(new JavaParserTypeSolver(sourceRoot));
+            }
+        }
+
+        for (Path classpathEntry : context.classpathEntries()) {
+            if (classpathEntry == null || !Files.exists(classpathEntry)) {
+                continue;
+            }
+
+            try {
+                if (Files.isRegularFile(classpathEntry)
+                        && classpathEntry.getFileName() != null
+                        && classpathEntry.getFileName().toString().endsWith(".jar")) {
+                    solver.add(new JarTypeSolver(classpathEntry.toString()));
+                }
+            } catch (IOException e) {
+                sink.addWarning("failed to attach classpath entry to symbol solver: "
+                        + classpathEntry + " (" + e.getMessage() + ")");
+            }
+        }
+
+        return solver;
+    }
+
+    private void parseFile(ExtractionContext context, JavaParser parser, Path javaFile, ExtractionSink sink) {
+        String relativePath = RepoPathUtils.toRepoRelative(context.repoRoot(), javaFile);
+        sink.recordFileScanned();
+
+        try {
+            ParseResult<CompilationUnit> parseResult = parser.parse(javaFile);
+            if (parseResult.getResult().isEmpty()) {
+                String problems = parseResult.getProblems().stream()
+                        .map(problem -> problem.getVerboseMessage())
+                        .collect(Collectors.joining(" | "));
+                sink.addError("failed to parse source file: " + relativePath + " (" + problems + ")");
+                return;
+            }
+
+            sink.recordFileParsed();
+            processCompilationUnit(context, javaFile, relativePath, parseResult.getResult().orElseThrow(), sink);
+        } catch (ParseProblemException | IOException e) {
+            sink.addError("failed to parse source file: " + relativePath + " (" + e.getMessage() + ")");
+        }
+    }
+
+    private void processCompilationUnit(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            CompilationUnit cu,
+            ExtractionSink sink
+    ) throws IOException {
+        String packageName = cu.getPackageDeclaration()
+                .map(pd -> pd.getNameAsString())
+                .filter(name -> !name.isBlank())
+                .orElse("(default)");
+
+        String moduleSymbol = ensureModuleSymbol(context, sink);
+        String packageSymbol = ensurePackageSymbol(context, packageName, relativePath, cu, moduleSymbol, sink, javaFile);
+
+        for (TypeDeclaration<?> typeDeclaration : cu.getTypes()) {
+            collectTypeRecursive(context, javaFile, relativePath, packageSymbol, null, typeDeclaration, sink);
+        }
+    }
+
+    private void collectTypeRecursive(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String packageSymbol,
+            String nestedOwnerSymbol,
+            TypeDeclaration<?> typeDeclaration,
+            ExtractionSink sink
+    ) throws IOException {
+        String qualifiedName = resolveQualifiedTypeName(typeDeclaration);
+        String typeSymbol = SymbolIdFactory.type(qualifiedName);
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, typeDeclaration, typeSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        TypeKind typeKind = typeKind(typeDeclaration);
+        SymbolFact typeFact = SymbolFact.builder()
+                .symbol(typeSymbol)
+                .kind(SymbolFactKind.TYPE)
+                .typeKind(typeKind)
+                .name(typeDeclaration.getNameAsString())
+                .qualifiedName(qualifiedName)
+                .packageSymbol(packageSymbol)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .nestedIn(nestedOwnerSymbol)
+                .access(accessLevel(typeDeclaration))
+                .modifiers(modifierKinds(typeDeclaration.getModifiers()))
+                .origin(SymbolOriginKind.SOURCE)
+                .annotations(annotationTypeRefs(typeDeclaration.getAnnotations(), sink))
+                .evidenceIds(List.of(evidence.id()))
+                .attrs(typeAttributes(typeDeclaration))
+                .superTypeRef(superTypeRef(typeDeclaration, sink))
+                .interfaceTypeRefs(interfaceTypeRefs(typeDeclaration, sink))
+                .sourceFile(relativePath)
+                .build();
+        sink.addSymbol(typeFact);
+
+        String containerSymbol = nestedOwnerSymbol != null ? nestedOwnerSymbol : packageSymbol;
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(containerSymbol)
+                .dstSymbol(typeSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+
+        addTypeHierarchyRelations(typeDeclaration, typeSymbol, evidence.id(), sink);
+        addAnnotationRelations(typeSymbol, typeDeclaration, evidence.id(), sink);
+        addTypeObservationsIfNeeded(context, typeDeclaration, typeSymbol, evidence.id(), sink);
+
+        for (BodyDeclaration<?> member : typeDeclaration.getMembers()) {
+            if (member instanceof FieldDeclaration fieldDeclaration) {
+                collectFieldDeclarations(context, javaFile, relativePath, typeSymbol, fieldDeclaration, sink);
+            } else if (member instanceof ConstructorDeclaration constructorDeclaration) {
+                collectConstructor(context, javaFile, relativePath, typeSymbol, constructorDeclaration, sink);
+            } else if (member instanceof MethodDeclaration methodDeclaration) {
+                collectMethod(context, javaFile, relativePath, typeSymbol, methodDeclaration, sink);
+            } else if (member instanceof TypeDeclaration<?> nestedType) {
+                collectTypeRecursive(context, javaFile, relativePath, packageSymbol, typeSymbol, nestedType, sink);
+            }
+        }
+
+        if (typeDeclaration instanceof EnumDeclaration enumDeclaration) {
+            for (EnumConstantDeclaration constant : enumDeclaration.getEntries()) {
+                collectEnumConstant(context, javaFile, relativePath, typeSymbol, constant, sink);
+            }
+        }
+
+        if (typeDeclaration instanceof RecordDeclaration recordDeclaration) {
+            for (Parameter parameter : recordDeclaration.getParameters()) {
+                collectRecordComponent(context, javaFile, relativePath, typeSymbol, parameter, sink);
+            }
+        }
+    }
+
+    private void collectFieldDeclarations(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String ownerTypeSymbol,
+            FieldDeclaration fieldDeclaration,
+            ExtractionSink sink
+    ) throws IOException {
+        for (com.github.javaparser.ast.body.VariableDeclarator variable : fieldDeclaration.getVariables()) {
+            String fieldSymbol = SymbolIdFactory.field(ownerTypeSymbol.substring("type:".length()), variable.getNameAsString());
+            EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, variable, fieldSymbol, EvidenceKind.AST);
+            sink.addEvidence(evidence);
+
+            TypeRef fieldTypeRef = toTypeRef(variable.getType(), sink);
+            SignatureFact signature = SignatureFact.builder()
+                    .fieldType(fieldTypeRef)
+                    .build();
+
+            SymbolFact fieldFact = SymbolFact.builder()
+                    .symbol(fieldSymbol)
+                    .kind(SymbolFactKind.FIELD)
+                    .name(variable.getNameAsString())
+                    .ownerTypeSymbol(ownerTypeSymbol)
+                    .module(context.module())
+                    .sourceRoot(context.sourceRootString())
+                    .access(accessLevel(fieldDeclaration))
+                    .modifiers(modifierKinds(fieldDeclaration.getModifiers()))
+                    .origin(SymbolOriginKind.SOURCE)
+                    .annotations(annotationTypeRefs(fieldDeclaration.getAnnotations(), sink))
+                    .evidenceIds(List.of(evidence.id()))
+                    .signature(signature)
+                    .sourceFile(relativePath)
+                    .build();
+            sink.addSymbol(fieldFact);
+
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CONTAINS)
+                    .srcSymbol(ownerTypeSymbol)
+                    .dstSymbol(fieldSymbol)
+                    .evidenceIds(List.of(evidence.id()))
+                    .resolution(RelationResolutionFactory.resolved())
+                    .origin(FactOriginKind.AST)
+                    .build());
+
+            addTypeRelation(RelationKind.FIELD_TYPE, fieldSymbol, fieldTypeRef, evidence.id(), sink);
+            addAnnotationRelations(fieldSymbol, fieldDeclaration, evidence.id(), sink);
+            addFieldObservationsIfNeeded(context, fieldDeclaration, fieldSymbol, fieldTypeRef, evidence.id(), sink);
+        }
+    }
+
+    private void collectConstructor(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String ownerTypeSymbol,
+            ConstructorDeclaration declaration,
+            ExtractionSink sink
+    ) throws IOException {
+        SignatureFact signature = callableSignature(declaration, sink);
+        String ownerQualifiedName = ownerTypeSymbol.substring("type:".length());
+        String constructorSymbol = SymbolIdFactory.constructor(ownerQualifiedName, signature);
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, declaration, constructorSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        SymbolFact fact = SymbolFact.builder()
+                .symbol(constructorSymbol)
+                .kind(SymbolFactKind.CONSTRUCTOR)
+                .name(declaration.getNameAsString())
+                .ownerTypeSymbol(ownerTypeSymbol)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .access(accessLevel(declaration))
+                .modifiers(modifierKinds(declaration.getModifiers()))
+                .origin(SymbolOriginKind.SOURCE)
+                .annotations(annotationTypeRefs(declaration.getAnnotations(), sink))
+                .evidenceIds(List.of(evidence.id()))
+                .signature(signature)
+                .sourceFile(relativePath)
+                .build();
+        sink.addSymbol(fact);
+
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(ownerTypeSymbol)
+                .dstSymbol(constructorSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+
+        addCallableTypeRelations(constructorSymbol, signature, evidence.id(), sink);
+        addAnnotationRelations(constructorSymbol, declaration, evidence.id(), sink);
+        addCallableBodyRelations(declaration, constructorSymbol, evidence.id(), sink);
+        addConstructorObservationsIfNeeded(context, declaration, constructorSymbol, evidence.id(), sink);
+    }
+
+    private void collectMethod(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String ownerTypeSymbol,
+            MethodDeclaration declaration,
+            ExtractionSink sink
+    ) throws IOException {
+        SignatureFact signature = callableSignature(declaration, sink);
+        String ownerQualifiedName = ownerTypeSymbol.substring("type:".length());
+        String methodSymbol = SymbolIdFactory.method(ownerQualifiedName, declaration.getNameAsString(), signature);
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, declaration, methodSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        SymbolFact fact = SymbolFact.builder()
+                .symbol(methodSymbol)
+                .kind(SymbolFactKind.METHOD)
+                .name(declaration.getNameAsString())
+                .ownerTypeSymbol(ownerTypeSymbol)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .access(accessLevel(declaration))
+                .modifiers(modifierKinds(declaration.getModifiers()))
+                .origin(SymbolOriginKind.SOURCE)
+                .annotations(annotationTypeRefs(declaration.getAnnotations(), sink))
+                .evidenceIds(List.of(evidence.id()))
+                .signature(signature)
+                .sourceFile(relativePath)
+                .build();
+        sink.addSymbol(fact);
+
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(ownerTypeSymbol)
+                .dstSymbol(methodSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+
+        addCallableTypeRelations(methodSymbol, signature, evidence.id(), sink);
+        addAnnotationRelations(methodSymbol, declaration, evidence.id(), sink);
+        addCallableBodyRelations(declaration, methodSymbol, evidence.id(), sink);
+        addMethodObservationsIfNeeded(context, declaration, methodSymbol, evidence.id(), sink);
+    }
+
+    private void collectEnumConstant(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String ownerTypeSymbol,
+            EnumConstantDeclaration constant,
+            ExtractionSink sink
+    ) throws IOException {
+        String fieldSymbol = SymbolIdFactory.field(ownerTypeSymbol.substring("type:".length()), constant.getNameAsString());
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, constant, fieldSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        SymbolFact fact = SymbolFact.builder()
+                .symbol(fieldSymbol)
+                .kind(SymbolFactKind.FIELD)
+                .name(constant.getNameAsString())
+                .ownerTypeSymbol(ownerTypeSymbol)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .access(AccessLevel.PUBLIC)
+                .modifiers(Set.of(ModifierKind.STATIC, ModifierKind.FINAL))
+                .origin(SymbolOriginKind.SOURCE)
+                .evidenceIds(List.of(evidence.id()))
+                .signature(SignatureFact.builder()
+                        .fieldType(TypeRefFactory.simple(ownerTypeSymbol.substring("type:".length())))
+                        .build())
+                .sourceFile(relativePath)
+                .build();
+        sink.addSymbol(fact);
+
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(ownerTypeSymbol)
+                .dstSymbol(fieldSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+    }
+
+    private void collectRecordComponent(
+            ExtractionContext context,
+            Path javaFile,
+            String relativePath,
+            String ownerTypeSymbol,
+            Parameter parameter,
+            ExtractionSink sink
+    ) throws IOException {
+        String fieldSymbol = SymbolIdFactory.field(ownerTypeSymbol.substring("type:".length()), parameter.getNameAsString());
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, parameter, fieldSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        TypeRef fieldTypeRef = toTypeRef(parameter.getType(), sink);
+        SymbolFact fact = SymbolFact.builder()
+                .symbol(fieldSymbol)
+                .kind(SymbolFactKind.FIELD)
+                .name(parameter.getNameAsString())
+                .ownerTypeSymbol(ownerTypeSymbol)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .access(AccessLevel.PRIVATE)
+                .modifiers(Set.of(ModifierKind.FINAL))
+                .origin(SymbolOriginKind.GENERATED)
+                .evidenceIds(List.of(evidence.id()))
+                .signature(SignatureFact.builder().fieldType(fieldTypeRef).build())
+                .sourceFile(relativePath)
+                .build();
+        sink.addSymbol(fact);
+
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(ownerTypeSymbol)
+                .dstSymbol(fieldSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+
+        addTypeRelation(RelationKind.FIELD_TYPE, fieldSymbol, fieldTypeRef, evidence.id(), sink);
+    }
+
+    private void addTypeHierarchyRelations(TypeDeclaration<?> typeDeclaration, String typeSymbol, String evidenceId, ExtractionSink sink) {
+        if (typeDeclaration instanceof ClassOrInterfaceDeclaration classOrInterface) {
+            for (ClassOrInterfaceType extendedType : classOrInterface.getExtendedTypes()) {
+                addTypeRelation(RelationKind.EXTENDS, typeSymbol, toTypeRef(extendedType, sink), evidenceId, sink);
+            }
+            for (ClassOrInterfaceType implementedType : classOrInterface.getImplementedTypes()) {
+                addTypeRelation(RelationKind.IMPLEMENTS, typeSymbol, toTypeRef(implementedType, sink), evidenceId, sink);
+            }
+        } else if (typeDeclaration instanceof EnumDeclaration enumDeclaration) {
+            for (ClassOrInterfaceType implementedType : enumDeclaration.getImplementedTypes()) {
+                addTypeRelation(RelationKind.IMPLEMENTS, typeSymbol, toTypeRef(implementedType, sink), evidenceId, sink);
+            }
+        } else if (typeDeclaration instanceof RecordDeclaration recordDeclaration) {
+            for (ClassOrInterfaceType implementedType : recordDeclaration.getImplementedTypes()) {
+                addTypeRelation(RelationKind.IMPLEMENTS, typeSymbol, toTypeRef(implementedType, sink), evidenceId, sink);
+            }
+        }
+    }
+
+    private void addCallableTypeRelations(String callableSymbol, SignatureFact signature, String evidenceId, ExtractionSink sink) {
+        if (signature.params() != null) {
+            for (TypeRef parameterType : signature.params()) {
+                addTypeRelation(RelationKind.PARAM_TYPE, callableSymbol, parameterType, evidenceId, sink);
+            }
+        }
+        if (signature.returns() != null) {
+            addTypeRelation(RelationKind.RETURN_TYPE, callableSymbol, signature.returns(), evidenceId, sink);
+        }
+        if (signature.throwsTypes() != null) {
+            for (TypeRef thrownType : signature.throwsTypes()) {
+                addTypeRelation(RelationKind.THROWS_TYPE, callableSymbol, thrownType, evidenceId, sink);
+            }
+        }
+    }
+
+    private void addCallableBodyRelations(CallableDeclaration<?> declaration, String callableSymbol, String evidenceId, ExtractionSink sink) {
+        declaration.findAll(MethodCallExpr.class).forEach(methodCallExpr -> addMethodCallRelation(callableSymbol, methodCallExpr, evidenceId, sink));
+        declaration.findAll(ObjectCreationExpr.class).forEach(objectCreationExpr -> addObjectCreationCallRelation(callableSymbol, objectCreationExpr, evidenceId, sink));
+        declaration.findAll(NameExpr.class).forEach(nameExpr -> addFieldAccessRelation(callableSymbol, nameExpr, evidenceId, sink));
+        declaration.findAll(FieldAccessExpr.class).forEach(fieldAccessExpr -> addFieldAccessRelation(callableSymbol, fieldAccessExpr, evidenceId, sink));
+    }
+
+    private void addMethodCallRelation(String callerSymbol, MethodCallExpr methodCallExpr, String evidenceId, ExtractionSink sink) {
+        try {
+            ResolvedMethodDeclaration resolved = methodCallExpr.resolve();
+            String dstSymbol = methodSymbol(resolved, sink);
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CALLS)
+                    .srcSymbol(callerSymbol)
+                    .dstSymbol(dstSymbol)
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(RelationResolutionFactory.resolved())
+                    .origin(FactOriginKind.AST)
+                    .build());
+        } catch (Exception e) {
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CALLS)
+                    .srcSymbol(callerSymbol)
+                    .dstRawRef(methodCallExpr.getNameAsString() + signatureHint(methodCallExpr.getArguments().size()))
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(RelationResolutionFactory.unresolved(e.getClass().getSimpleName()))
+                    .origin(FactOriginKind.AST)
+                    .build());
+        }
+    }
+
+    private void addObjectCreationCallRelation(String callerSymbol, ObjectCreationExpr objectCreationExpr, String evidenceId, ExtractionSink sink) {
+        try {
+            String rawType = objectCreationExpr.getType().getNameWithScope();
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.CALLS)
+                    .srcSymbol(callerSymbol)
+                    .dstRawRef("new " + rawType + signatureHint(objectCreationExpr.getArguments().size()))
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(RelationResolutionFactory.partial("constructor resolution deferred"))
+                    .origin(FactOriginKind.AST)
+                    .build());
+        } catch (Exception e) {
+            sink.addWarning("failed to record constructor call relation: " + e.getMessage());
+        }
+    }
+
+    private void addFieldAccessRelation(String callerSymbol, Expression expression, String evidenceId, ExtractionSink sink) {
+        try {
+            if (expression instanceof NameExpr nameExpr) {
+                var resolved = nameExpr.resolve();
+                if (!resolved.isField()) {
+                    return;
+                }
+
+                ResolvedFieldDeclaration field = resolved.asField();
+                sink.addRelation(RelationFact.builder()
+                        .kind(RelationKind.ACCESSES_FIELD)
+                        .srcSymbol(callerSymbol)
+                        .dstSymbol(fieldSymbol(field))
+                        .evidenceIds(List.of(evidenceId))
+                        .resolution(RelationResolutionFactory.resolved())
+                        .origin(FactOriginKind.AST)
+                        .build());
+                return;
+            }
+
+            if (expression instanceof FieldAccessExpr fieldAccessExpr) {
+                var resolved = fieldAccessExpr.resolve();
+                if (!resolved.isField()) {
+                    return;
+                }
+
+                ResolvedFieldDeclaration field = resolved.asField();
+                sink.addRelation(RelationFact.builder()
+                        .kind(RelationKind.ACCESSES_FIELD)
+                        .srcSymbol(callerSymbol)
+                        .dstSymbol(fieldSymbol(field))
+                        .evidenceIds(List.of(evidenceId))
+                        .resolution(RelationResolutionFactory.resolved())
+                        .origin(FactOriginKind.AST)
+                        .build());
+            }
+        } catch (Exception ignored) {
+            // best-effort
+        }
+    }
+
+    private void addAnnotationRelations(String srcSymbol, NodeWithAnnotations<?> node, String evidenceId, ExtractionSink sink) {
+        for (AnnotationExpr annotationExpr : node.getAnnotations()) {
+            TypeRef annotationTypeRef = toAnnotationTypeRef(annotationExpr, sink);
+            sink.addRelation(RelationFact.builder()
+                    .kind(RelationKind.ANNOTATED_BY)
+                    .srcSymbol(srcSymbol)
+                    .dstRawRef(annotationTypeRef.raw())
+                    .evidenceIds(List.of(evidenceId))
+                    .resolution(annotationTypeRef.unresolved() == Boolean.TRUE
+                            ? RelationResolutionFactory.unresolved("annotation type unresolved")
+                            : RelationResolutionFactory.partial("annotation symbol linking deferred"))
+                    .origin(FactOriginKind.AST)
+                    .build());
+        }
+    }
+
+    private void addTypeRelation(RelationKind kind, String srcSymbol, TypeRef typeRef, String evidenceId, ExtractionSink sink) {
+        if (typeRef == null || typeRef.raw() == null || typeRef.raw().isBlank()) {
+            return;
+        }
+
+        if (Boolean.TRUE.equals(typeRef.unresolved())) {
+            sink.recordUnresolvedTypeRef();
+        }
+
+        sink.addRelation(RelationFact.builder()
+                .kind(kind)
+                .srcSymbol(srcSymbol)
+                .dstRawRef(typeRef.raw())
+                .evidenceIds(List.of(evidenceId))
+                .resolution(Boolean.TRUE.equals(typeRef.unresolved())
+                        ? RelationResolutionFactory.unresolved("type unresolved in AST")
+                        : RelationResolutionFactory.partial("type symbol linking deferred"))
+                .origin(FactOriginKind.AST)
+                .build());
+    }
+
+    private void addTypeObservationsIfNeeded(
+            ExtractionContext context,
+            TypeDeclaration<?> typeDeclaration,
+            String typeSymbol,
+            String evidenceId,
+            ExtractionSink sink
+    ) {
+        if (!context.includeObservations()) {
+            return;
+        }
+
+        Set<String> annotationNames = nodeAnnotationNames(typeDeclaration, sink);
+        if (annotationNames.stream().anyMatch(this::isDiProviderTypeAnnotation)) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.DI_PROVIDER)
+                    .siteSymbol(typeSymbol)
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("type-level DI provider annotation")
+                    .attrs(Map.of("annotations", annotationNames))
+                    .build());
+        }
+
+        if (annotationNames.stream().anyMatch(this::isConfigurationAnnotation)) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.CONFIG_WIRING)
+                    .siteSymbol(typeSymbol)
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("configuration class annotation")
+                    .attrs(Map.of("annotations", annotationNames))
+                    .build());
+        }
+    }
+
+    private void addFieldObservationsIfNeeded(
+            ExtractionContext context,
+            FieldDeclaration fieldDeclaration,
+            String fieldSymbol,
+            TypeRef fieldTypeRef,
+            String evidenceId,
+            ExtractionSink sink
+    ) {
+        if (!context.includeObservations()) {
+            return;
+        }
+
+        Set<String> annotationNames = nodeAnnotationNames(fieldDeclaration, sink);
+        if (annotationNames.stream().anyMatch(this::isInjectionAnnotation)) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.DI_INJECTION_SITE)
+                    .siteSymbol(fieldSymbol)
+                    .targetTypeRef(fieldTypeRef)
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("field injection")
+                    .attrs(Map.of("annotations", annotationNames))
+                    .build());
+        }
+    }
+
+    private void addConstructorObservationsIfNeeded(
+            ExtractionContext context,
+            ConstructorDeclaration declaration,
+            String constructorSymbol,
+            String evidenceId,
+            ExtractionSink sink
+    ) {
+        if (!context.includeObservations()) {
+            return;
+        }
+
+        boolean hasInjection = nodeAnnotationNames(declaration, sink).stream().anyMatch(this::isInjectionAnnotation);
+        if (!hasInjection) {
+            return;
+        }
+
+        for (Parameter parameter : declaration.getParameters()) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.DI_INJECTION_SITE)
+                    .siteSymbol(constructorSymbol)
+                    .targetTypeRef(toTypeRef(parameter.getType(), sink))
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("constructor injection parameter")
+                    .attrs(Map.of("parameter", parameter.getNameAsString()))
+                    .build());
+        }
+    }
+
+    private void addMethodObservationsIfNeeded(
+            ExtractionContext context,
+            MethodDeclaration declaration,
+            String methodSymbol,
+            String evidenceId,
+            ExtractionSink sink
+    ) {
+        if (!context.includeObservations()) {
+            return;
+        }
+
+        Set<String> annotationNames = nodeAnnotationNames(declaration, sink);
+        if (annotationNames.stream().anyMatch(this::isBeanAnnotation)) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.DI_PROVIDER)
+                    .siteSymbol(methodSymbol)
+                    .targetTypeRef(declaration.getType().isVoidType() ? null : toTypeRef(declaration.getType(), sink))
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("@Bean style provider method")
+                    .attrs(Map.of("annotations", annotationNames))
+                    .build());
+        }
+
+        if (annotationNames.stream().anyMatch(this::isEventSubscriberAnnotation)) {
+            sink.addObservation(ObservationFact.builder()
+                    .kind(ObservationKind.EVENT_SUBSCRIBE)
+                    .siteSymbol(methodSymbol)
+                    .targetTypeRef(firstParameterType(declaration, sink))
+                    .evidenceIds(List.of(evidenceId))
+                    .origin(FactOriginKind.OBSERVED)
+                    .note("event subscriber method")
+                    .attrs(Map.of("annotations", annotationNames))
+                    .build());
+        }
+
+        declaration.findAll(MethodCallExpr.class).forEach(call -> {
+            if (isPublishEventCall(call)) {
+                sink.addObservation(ObservationFact.builder()
+                        .kind(ObservationKind.EVENT_PUBLISH)
+                        .siteSymbol(methodSymbol)
+                        .targetTypeRef(firstArgumentType(call, sink))
+                        .evidenceIds(List.of(evidenceId))
+                        .origin(FactOriginKind.OBSERVED)
+                        .note("event publish candidate")
+                        .attrs(Map.of("method", call.getNameAsString()))
+                        .build());
+            }
+
+            if (isReflectionCall(call)) {
+                sink.addObservation(ObservationFact.builder()
+                        .kind(ObservationKind.REFLECTION_USE)
+                        .siteSymbol(methodSymbol)
+                        .evidenceIds(List.of(evidenceId))
+                        .origin(FactOriginKind.OBSERVED)
+                        .note("reflection API usage")
+                        .attrs(Map.of(
+                                "method", call.getNameAsString(),
+                                "scope", call.getScope().map(Expression::toString).orElse("")
+                        ))
+                        .build());
+            }
+        });
+    }
+
+    private String ensureModuleSymbol(ExtractionContext context, ExtractionSink sink) {
+        String moduleSymbol = SymbolIdFactory.module(context.module());
+        String rootPath = context.rootPathString();
+
+        EvidenceFact evidence = EvidenceFact.builder()
+                .id(EvidenceIdGenerator.generate(EvidenceKind.AST, rootPath, null, moduleSymbol))
+                .type(EvidenceKind.AST)
+                .path(rootPath)
+                .symbol(moduleSymbol)
+                .attrs(Map.of("module", context.module(), "source_root", rootPath))
+                .build();
+        sink.addEvidence(evidence);
+
+        sink.addSymbol(SymbolFact.builder()
+                .symbol(moduleSymbol)
+                .kind(SymbolFactKind.MODULE)
+                .name(context.module())
+                .qualifiedName(context.module())
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .origin(SymbolOriginKind.SOURCE)
+                .evidenceIds(List.of(evidence.id()))
+                .build());
+        return moduleSymbol;
+    }
+
+    private String ensurePackageSymbol(
+            ExtractionContext context,
+            String packageName,
+            String relativePath,
+            CompilationUnit cu,
+            String moduleSymbol,
+            ExtractionSink sink,
+            Path javaFile
+    ) throws IOException {
+        String packageSymbol = SymbolIdFactory.packageSymbol(packageName);
+        EvidenceFact evidence = buildAstEvidence(relativePath, javaFile, cu, packageSymbol, EvidenceKind.AST);
+        sink.addEvidence(evidence);
+
+        SymbolFact packageFact = SymbolFact.builder()
+                .symbol(packageSymbol)
+                .kind(SymbolFactKind.PACKAGE)
+                .name(packageName)
+                .qualifiedName(packageName)
+                .module(context.module())
+                .sourceRoot(context.sourceRootString())
+                .origin(SymbolOriginKind.SOURCE)
+                .evidenceIds(List.of(evidence.id()))
+                .attrs(Map.of("source_file", relativePath))
+                .build();
+        sink.addSymbol(packageFact);
+
+        sink.addRelation(RelationFact.builder()
+                .kind(RelationKind.CONTAINS)
+                .srcSymbol(moduleSymbol)
+                .dstSymbol(packageSymbol)
+                .evidenceIds(List.of(evidence.id()))
+                .resolution(RelationResolutionFactory.resolved())
+                .origin(FactOriginKind.AST)
+                .build());
+        return packageSymbol;
+    }
+
+    private SignatureFact callableSignature(CallableDeclaration<?> declaration, ExtractionSink sink) {
+        List<TypeRef> params = declaration.getParameters().stream()
+                .map(Parameter::getType)
+                .map(type -> toTypeRef(type, sink))
+                .toList();
+
+        TypeRef returns = declaration instanceof MethodDeclaration methodDeclaration
+                ? toTypeRef(methodDeclaration.getType(), sink)
+                : null;
+
+        List<TypeRef> throwsTypes = declaration.getThrownExceptions().stream()
+                .map(type -> toTypeRef(type, sink))
+                .toList();
+
+        return SignatureFact.builder()
+                .params(params)
+                .returns(returns)
+                .throwsTypes(throwsTypes)
+                .build();
+    }
+
+    private TypeRef superTypeRef(TypeDeclaration<?> typeDeclaration, ExtractionSink sink) {
+        if (typeDeclaration instanceof ClassOrInterfaceDeclaration classOrInterface && !classOrInterface.getExtendedTypes().isEmpty()) {
+            return toTypeRef(classOrInterface.getExtendedTypes().get(0), sink);
+        }
+        return null;
+    }
+
+    private List<TypeRef> interfaceTypeRefs(TypeDeclaration<?> typeDeclaration, ExtractionSink sink) {
+        if (typeDeclaration instanceof ClassOrInterfaceDeclaration classOrInterface) {
+            return classOrInterface.getImplementedTypes().stream().map(type -> toTypeRef(type, sink)).toList();
+        }
+        if (typeDeclaration instanceof EnumDeclaration enumDeclaration) {
+            return enumDeclaration.getImplementedTypes().stream().map(type -> toTypeRef(type, sink)).toList();
+        }
+        if (typeDeclaration instanceof RecordDeclaration recordDeclaration) {
+            return recordDeclaration.getImplementedTypes().stream().map(type -> toTypeRef(type, sink)).toList();
+        }
+        return List.of();
+    }
+
+    private Map<String, Object> typeAttributes(TypeDeclaration<?> typeDeclaration) {
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        if (typeDeclaration instanceof RecordDeclaration recordDeclaration) {
+            attrs.put("record_components", recordDeclaration.getParameters().stream().map(Parameter::getNameAsString).toList());
+        }
+        return attrs.isEmpty() ? null : attrs;
+    }
+
+    private List<TypeRef> annotationTypeRefs(List<AnnotationExpr> annotations, ExtractionSink sink) {
+        if (annotations == null || annotations.isEmpty()) {
+            return List.of();
+        }
+        return annotations.stream().map(annotation -> toAnnotationTypeRef(annotation, sink)).toList();
+    }
+
+    private Set<String> nodeAnnotationNames(NodeWithAnnotations<?> node, ExtractionSink sink) {
+        return node.getAnnotations().stream()
+                .map(annotation -> toAnnotationTypeRef(annotation, sink).raw())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private TypeRef toAnnotationTypeRef(AnnotationExpr annotationExpr, ExtractionSink sink) {
+        try {
+            return TypeRefFactory.simple(annotationExpr.resolve().getQualifiedName());
+        } catch (Exception e) {
+            sink.recordUnresolvedTypeRef();
+            return TypeRefFactory.unresolved(annotationExpr.getNameAsString(), annotationExpr.getNameAsString());
+        }
+    }
+
+    private TypeRef toTypeRef(Type type, ExtractionSink sink) {
+        if (type == null) {
+            return null;
+        }
+
+        try {
+            ResolvedType resolvedType = type.resolve();
+            return toTypeRef(resolvedType, type.asString(), sink);
+        } catch (Exception e) {
+            sink.recordUnresolvedTypeRef();
+            return fallbackTypeRefFromAst(type);
+        }
+    }
+
+    private TypeRef toTypeRef(ResolvedType resolvedType, String sourceText, ExtractionSink sink) {
+        if (resolvedType == null) {
+            sink.recordUnresolvedTypeRef();
+            return TypeRefFactory.unresolved(sourceText, sourceText);
+        }
+
+        if (resolvedType.isPrimitive()) {
+            ResolvedPrimitiveType primitiveType = resolvedType.asPrimitive();
+            return TypeRef.builder()
+                    .raw(primitiveType.describe())
+                    .arrayDim(0)
+                    .primitive(true)
+                    .unresolved(false)
+                    .sourceText(sourceText)
+                    .build();
+        }
+
+        if (resolvedType.isArray()) {
+            ResolvedArrayType arrayType = resolvedType.asArrayType();
+            int dim = 0;
+            ResolvedType component = arrayType;
+            while (component.isArray()) {
+                dim++;
+                component = component.asArrayType().getComponentType();
+            }
+            TypeRef base = toTypeRef(component, sourceText, sink);
+            return TypeRef.builder()
+                    .raw(base.raw())
+                    .args(base.args())
+                    .arrayDim(dim)
+                    .primitive(base.primitive())
+                    .unresolved(base.unresolved())
+                    .sourceText(sourceText)
+                    .build();
+        }
+
+        if (resolvedType.isReferenceType()) {
+            ResolvedReferenceType referenceType = resolvedType.asReferenceType();
+            String raw = referenceType.getQualifiedName();
+            List<TypeRef> args = referenceType.typeParametersValues().stream()
+                    .map(arg -> toTypeRef(arg, arg.describe(), sink))
+                    .toList();
+            return TypeRef.builder()
+                    .raw(raw)
+                    .args(args)
+                    .arrayDim(0)
+                    .primitive(false)
+                    .unresolved(false)
+                    .sourceText(sourceText)
+                    .build();
+        }
+
+        if (resolvedType.isVoid()) {
+            return TypeRef.builder()
+                    .raw("void")
+                    .arrayDim(0)
+                    .primitive(true)
+                    .unresolved(false)
+                    .sourceText(sourceText)
+                    .build();
+        }
+
+        sink.recordUnresolvedTypeRef();
+        return TypeRefFactory.unresolved(resolvedType.describe(), sourceText);
+    }
+
+    private TypeRef fallbackTypeRefFromAst(Type type) {
+        if (type.isPrimitiveType()) {
+            PrimitiveType primitiveType = type.asPrimitiveType();
+            return TypeRef.builder()
+                    .raw(primitiveType.asString())
+                    .arrayDim(0)
+                    .primitive(true)
+                    .unresolved(false)
+                    .sourceText(type.asString())
+                    .build();
+        }
+
+        if (type.isArrayType()) {
+            com.github.javaparser.ast.type.ArrayType arrayType = type.asArrayType();
+            int dim = 0;
+            Type component = arrayType;
+            while (component.isArrayType()) {
+                dim++;
+                component = component.asArrayType().getComponentType();
+            }
+            TypeRef base = fallbackTypeRefFromAst(component);
+            return TypeRef.builder()
+                    .raw(base.raw())
+                    .args(base.args())
+                    .arrayDim(dim)
+                    .primitive(base.primitive())
+                    .unresolved(true)
+                    .sourceText(type.asString())
+                    .build();
+        }
+
+        if (type.isClassOrInterfaceType()) {
+            ClassOrInterfaceType classOrInterfaceType = type.asClassOrInterfaceType();
+            List<TypeRef> args = classOrInterfaceType.getTypeArguments()
+                    .map(items -> items.stream().map(this::fallbackTypeRefFromAst).toList())
+                    .orElse(List.of());
+            return TypeRef.builder()
+                    .raw(classOrInterfaceType.getNameWithScope())
+                    .args(args)
+                    .arrayDim(0)
+                    .primitive(false)
+                    .unresolved(true)
+                    .sourceText(type.asString())
+                    .build();
+        }
+
+        return TypeRef.builder()
+                .raw(type.asString())
+                .arrayDim(0)
+                .primitive(false)
+                .unresolved(true)
+                .sourceText(type.asString())
+                .build();
+    }
+
+    private String resolveQualifiedTypeName(TypeDeclaration<?> typeDeclaration) {
+        return typeDeclaration.getFullyQualifiedName().orElseGet(() -> {
+            Optional<TypeDeclaration<?>> parentType = typeDeclaration.getParentNode()
+                    .filter(TypeDeclaration.class::isInstance)
+                    .map(node -> (TypeDeclaration<?>) node);
+
+            if (parentType.isPresent()) {
+                return resolveQualifiedTypeName(parentType.get()) + "$" + typeDeclaration.getNameAsString();
+            }
+
+            String packageName = typeDeclaration.findCompilationUnit()
+                    .flatMap(CompilationUnit::getPackageDeclaration)
+                    .map(pd -> pd.getNameAsString())
+                    .orElse("");
+
+            return packageName.isBlank()
+                    ? typeDeclaration.getNameAsString()
+                    : packageName + "." + typeDeclaration.getNameAsString();
+        });
+    }
+
+    private TypeKind typeKind(TypeDeclaration<?> typeDeclaration) {
+        if (typeDeclaration instanceof AnnotationDeclaration) {
+            return TypeKind.ANNOTATION;
+        }
+        if (typeDeclaration instanceof EnumDeclaration) {
+            return TypeKind.ENUM;
+        }
+        if (typeDeclaration instanceof RecordDeclaration) {
+            return TypeKind.RECORD;
+        }
+        if (typeDeclaration instanceof ClassOrInterfaceDeclaration classOrInterface && classOrInterface.isInterface()) {
+            return TypeKind.INTERFACE;
+        }
+        return TypeKind.CLASS;
+    }
+
+    private AccessLevel accessLevel(Node node) {
+        if (node instanceof NodeWithAccessModifiers<?> accessNode) {
+            return switch (accessNode.getAccessSpecifier()) {
+                case PUBLIC -> AccessLevel.PUBLIC;
+                case PROTECTED -> AccessLevel.PROTECTED;
+                case PRIVATE -> AccessLevel.PRIVATE;
+                default -> AccessLevel.PACKAGE;
+            };
+        }
+        return AccessLevel.PACKAGE;
+    }
+
+    private Set<ModifierKind> modifierKinds(List<Modifier> modifiers) {
+        EnumSet<ModifierKind> set = EnumSet.noneOf(ModifierKind.class);
+        for (Modifier modifier : modifiers) {
+            switch (modifier.getKeyword()) {
+                case STATIC -> set.add(ModifierKind.STATIC);
+                case FINAL -> set.add(ModifierKind.FINAL);
+                case ABSTRACT -> set.add(ModifierKind.ABSTRACT);
+                case SYNCHRONIZED -> set.add(ModifierKind.SYNCHRONIZED);
+                case NATIVE -> set.add(ModifierKind.NATIVE);
+                case STRICTFP -> set.add(ModifierKind.STRICTFP);
+                case TRANSIENT -> set.add(ModifierKind.TRANSIENT);
+                case VOLATILE -> set.add(ModifierKind.VOLATILE);
+                default -> {
+                }
+            }
+        }
+        return set;
+    }
+
+    private EvidenceFact buildAstEvidence(String relativePath, Path javaFile, Node node, String symbol, EvidenceKind kind) throws IOException {
+        SourceSpan span = sourceSpan(node);
+        String snippet = readSnippet(javaFile, span);
+        String evidenceId = EvidenceIdGenerator.generate(kind, relativePath, span, symbol);
+        return EvidenceFact.builder()
+                .id(evidenceId)
+                .type(kind)
+                .path(relativePath)
+                .span(span)
+                .symbol(symbol)
+                .snippet(snippet)
+                .hash(snippet == null || snippet.isBlank() ? null : Integer.toHexString(snippet.hashCode()))
+                .build();
+    }
+
+    private SourceSpan sourceSpan(Node node) {
+        return node.getRange()
+                .map(this::sourceSpan)
+                .orElse(null);
+    }
+
+    private SourceSpan sourceSpan(Range range) {
+        Position begin = range.begin;
+        Position end = range.end;
+        return SourceSpan.builder()
+                .startLine(begin.line)
+                .startCol(begin.column)
+                .endLine(end.line)
+                .endCol(end.column)
+                .build();
+    }
+
+    private String readSnippet(Path javaFile, SourceSpan span) throws IOException {
+        if (span == null || span.startLine() == null || span.endLine() == null) {
+            return null;
+        }
+
+        List<String> lines = Files.readAllLines(javaFile);
+        int start = Math.max(1, span.startLine());
+        int end = Math.min(lines.size(), span.endLine());
+        if (start > end) {
+            return null;
+        }
+        return String.join("\n", lines.subList(start - 1, end));
+    }
+
+    private String methodSymbol(ResolvedMethodDeclaration resolved, ExtractionSink sink) {
+        String owner = resolved.declaringType().getQualifiedName();
+        List<TypeRef> params = new ArrayList<>();
+        for (int i = 0; i < resolved.getNumberOfParams(); i++) {
+            ResolvedParameterDeclaration parameter = resolved.getParam(i);
+            params.add(toTypeRef(parameter.getType(), parameter.describeType(), sink));
+        }
+        SignatureFact signatureFact = SignatureFact.builder().params(params).build();
+        return SymbolIdFactory.method(owner, resolved.getName(), signatureFact);
+    }
+
+    private String fieldSymbol(ResolvedFieldDeclaration field) {
+        return SymbolIdFactory.field(field.declaringType().getQualifiedName(), field.getName());
+    }
+
+    private String signatureHint(int argCount) {
+        return "(" + argCount + " args)";
+    }
+
+    private boolean isInjectionAnnotation(String annotationName) {
+        return annotationName.endsWith("Inject")
+                || annotationName.endsWith("Autowired")
+                || annotationName.endsWith("Resource")
+                || annotationName.endsWith("Qualifier");
+    }
+
+    private boolean isBeanAnnotation(String annotationName) {
+        return annotationName.endsWith("Bean") || annotationName.endsWith("Produces");
+    }
+
+    private boolean isDiProviderTypeAnnotation(String annotationName) {
+        return annotationName.endsWith("Component")
+                || annotationName.endsWith("Service")
+                || annotationName.endsWith("Repository")
+                || annotationName.endsWith("Controller")
+                || annotationName.endsWith("RestController")
+                || annotationName.endsWith("Named");
+    }
+
+    private boolean isConfigurationAnnotation(String annotationName) {
+        return annotationName.endsWith("Configuration") || annotationName.endsWith("Import");
+    }
+
+    private boolean isEventSubscriberAnnotation(String annotationName) {
+        return annotationName.endsWith("EventListener") || annotationName.endsWith("Subscribe");
+    }
+
+    private boolean isPublishEventCall(MethodCallExpr call) {
+        String name = call.getNameAsString();
+        return "publishEvent".equals(name) || "post".equals(name);
+    }
+
+    private boolean isReflectionCall(MethodCallExpr call) {
+        String name = call.getNameAsString();
+        return "forName".equals(name)
+                || "getDeclaredMethod".equals(name)
+                || "getMethod".equals(name)
+                || "newInstance".equals(name)
+                || "invoke".equals(name)
+                || "getDeclaredField".equals(name)
+                || "getField".equals(name);
+    }
+
+    private TypeRef firstParameterType(MethodDeclaration declaration, ExtractionSink sink) {
+        return declaration.getParameters().isEmpty() ? null : toTypeRef(declaration.getParameter(0).getType(), sink);
+    }
+
+    private TypeRef firstArgumentType(MethodCallExpr call, ExtractionSink sink) {
+        if (call.getArguments().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return toTypeRef(call.getArgument(0).calculateResolvedType(), call.getArgument(0).toString(), sink);
+        } catch (Exception e) {
+            sink.recordUnresolvedTypeRef();
+            return TypeRefFactory.unresolved(call.getArgument(0).toString(), call.getArgument(0).toString());
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/merge/ExtractionMergeSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/merge/ExtractionMergeSupport.java
@@ -1,0 +1,290 @@
+package com.example.ossdoc.domain.extraction.service.support.merge;
+import com.example.ossdoc.domain.extraction.service.support.util.WarningCollector;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.EvidenceFact;
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionAggregate;
+import com.example.ossdoc.domain.extraction.dto.model.ModuleMergeResult;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationFact;
+import com.example.ossdoc.domain.extraction.dto.model.ObservationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RelationFact;
+import com.example.ossdoc.domain.extraction.dto.model.RelationTable;
+import com.example.ossdoc.domain.extraction.dto.model.RootMergeResult;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolTable;
+import com.example.ossdoc.domain.extraction.enums.MergeStage;
+import com.example.ossdoc.domain.extraction.enums.ObservationKind;
+import com.example.ossdoc.domain.extraction.enums.RelationKind;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+public class ExtractionMergeSupport {
+
+    public RootMergeResult mergeRoot(String module, String rootPath, List<ChunkResult> chunkResults) {
+        List<ChunkResult> safeResults = chunkResults == null ? List.of() : List.copyOf(chunkResults);
+        StatsAccumulator stats = new StatsAccumulator();
+        WarningCollector warnings = new WarningCollector();
+
+        Map<String, EvidenceFact> evidence = new LinkedHashMap<>();
+        Map<String, SymbolFact> symbols = new LinkedHashMap<>();
+        Map<String, RelationFact> relations = new LinkedHashMap<>();
+        Map<String, ObservationFact> observations = new LinkedHashMap<>();
+
+        for (ChunkResult chunkResult : safeResults) {
+            if (chunkResult == null) {
+                continue;
+            }
+
+            stats.recordChunkResult(chunkResult);
+            warnings.addAll(chunkResult.warnings());
+            warnings.addAll(chunkResult.errors());
+            mergeEvidence(evidence, chunkResult.evidence());
+            mergeSymbols(symbols, chunkResult.symbols(), stats);
+            mergeRelations(relations, chunkResult.relations(), stats);
+            mergeObservations(observations, chunkResult.observations(), stats);
+        }
+
+        return RootMergeResult.builder()
+                .module(module)
+                .rootPath(rootPath)
+                .kind(safeResults.isEmpty() || safeResults.get(0) == null || safeResults.get(0).descriptor() == null
+                        ? null
+                        : safeResults.get(0).descriptor().kind())
+                .stage(MergeStage.ROOT)
+                .chunkResults(safeResults)
+                .evidence(evidence)
+                .symbols(new ArrayList<>(symbols.values()))
+                .relations(new ArrayList<>(relations.values()))
+                .observations(new ArrayList<>(observations.values()))
+                .stats(stats.snapshot())
+                .warnings(warnings.snapshot())
+                .build();
+    }
+
+    public ModuleMergeResult mergeModule(String module, List<RootMergeResult> roots) {
+        List<RootMergeResult> safeRoots = roots == null ? List.of() : List.copyOf(roots);
+        StatsAccumulator stats = new StatsAccumulator();
+        WarningCollector warnings = new WarningCollector();
+
+        Map<String, EvidenceFact> evidence = new LinkedHashMap<>();
+        Map<String, SymbolFact> symbols = new LinkedHashMap<>();
+        Map<String, RelationFact> relations = new LinkedHashMap<>();
+        Map<String, ObservationFact> observations = new LinkedHashMap<>();
+
+        for (RootMergeResult root : safeRoots) {
+            if (root == null) {
+                continue;
+            }
+            stats.merge(root.stats());
+            warnings.addAll(root.warnings());
+            mergeEvidence(evidence, root.evidence());
+            mergeSymbols(symbols, root.symbols(), null);
+            mergeRelations(relations, root.relations(), null);
+            mergeObservations(observations, root.observations(), null);
+        }
+
+        return ModuleMergeResult.builder()
+                .module(module)
+                .stage(MergeStage.MODULE)
+                .roots(safeRoots)
+                .evidence(evidence)
+                .symbols(new ArrayList<>(symbols.values()))
+                .relations(new ArrayList<>(relations.values()))
+                .observations(new ArrayList<>(observations.values()))
+                .stats(stats.snapshot())
+                .warnings(warnings.snapshot())
+                .build();
+    }
+
+    public ExtractionAggregate aggregate(List<ModuleMergeResult> modules) {
+        List<ModuleMergeResult> safeModules = modules == null ? List.of() : List.copyOf(modules);
+        StatsAccumulator stats = new StatsAccumulator();
+        WarningCollector warnings = new WarningCollector();
+
+        Map<String, EvidenceFact> evidence = new LinkedHashMap<>();
+        Map<String, SymbolFact> symbols = new LinkedHashMap<>();
+        Map<String, RelationFact> relations = new LinkedHashMap<>();
+        Map<String, ObservationFact> observations = new LinkedHashMap<>();
+
+        for (ModuleMergeResult module : safeModules) {
+            if (module == null) {
+                continue;
+            }
+            stats.merge(module.stats());
+            warnings.addAll(module.warnings());
+            mergeEvidence(evidence, module.evidence());
+            mergeSymbols(symbols, module.symbols(), null);
+            mergeRelations(relations, module.relations(), null);
+            mergeObservations(observations, module.observations(), null);
+        }
+
+        return ExtractionAggregate.builder()
+                .evidence(evidence)
+                .symbols(toSymbolTable(symbols.values()))
+                .relations(toRelationTable(relations.values()))
+                .observations(toObservationTable(observations.values()))
+                .stats(stats.snapshot())
+                .warnings(warnings.snapshot())
+                .build();
+    }
+
+    private void mergeEvidence(Map<String, EvidenceFact> target, Map<String, EvidenceFact> source) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, EvidenceFact> entry : source.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            target.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void mergeSymbols(Map<String, SymbolFact> target, List<SymbolFact> source, StatsAccumulator stats) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        for (SymbolFact symbol : source) {
+            if (symbol == null || symbol.symbol() == null || symbol.symbol().isBlank()) {
+                continue;
+            }
+            SymbolFact previous = target.putIfAbsent(symbol.symbol(), symbol);
+            if (previous == null && stats != null) {
+                stats.recordSymbol(symbol);
+            }
+        }
+    }
+
+    private void mergeRelations(Map<String, RelationFact> target, List<RelationFact> source, StatsAccumulator stats) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        for (RelationFact relation : source) {
+            if (relation == null) {
+                continue;
+            }
+            String key = relationKey(relation);
+            RelationFact previous = target.putIfAbsent(key, relation);
+            if (previous == null && stats != null) {
+                stats.recordRelation();
+            }
+        }
+    }
+
+    private void mergeObservations(Map<String, ObservationFact> target, List<ObservationFact> source, StatsAccumulator stats) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        for (ObservationFact observation : source) {
+            if (observation == null) {
+                continue;
+            }
+            String key = observationKey(observation);
+            ObservationFact previous = target.putIfAbsent(key, observation);
+            if (previous == null && stats != null) {
+                stats.recordObservation();
+            }
+        }
+    }
+
+    private String relationKey(RelationFact relation) {
+        return String.join("|",
+                safeCode(relation.kind()),
+                nullToEmpty(relation.srcSymbol()),
+                nullToEmpty(relation.dstSymbol()),
+                nullToEmpty(relation.dstRawRef()),
+                nullToEmpty(relation.origin() == null ? null : relation.origin().code())
+        );
+    }
+
+    private String observationKey(ObservationFact observation) {
+        return String.join("|",
+                safeCode(observation.kind()),
+                nullToEmpty(observation.siteSymbol()),
+                nullToEmpty(observation.targetSymbol()),
+                nullToEmpty(observation.serviceInterfaceSymbol()),
+                nullToEmpty(observation.note())
+        );
+    }
+
+    private String safeCode(Object enumValue) {
+        return enumValue == null ? "" : enumValue.toString();
+    }
+
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private SymbolTable toSymbolTable(Collection<SymbolFact> values) {
+        List<SymbolFact> all = values == null ? List.of() : new ArrayList<>(values);
+        return SymbolTable.builder()
+                .modules(filterSymbols(all, SymbolFactKind.MODULE))
+                .packages(filterSymbols(all, SymbolFactKind.PACKAGE))
+                .types(filterSymbols(all, SymbolFactKind.TYPE))
+                .constructors(filterSymbols(all, SymbolFactKind.CONSTRUCTOR))
+                .methods(filterSymbols(all, SymbolFactKind.METHOD))
+                .fields(filterSymbols(all, SymbolFactKind.FIELD))
+                .build();
+    }
+
+    private RelationTable toRelationTable(Collection<RelationFact> values) {
+        List<RelationFact> all = values == null ? List.of() : new ArrayList<>(values);
+        return RelationTable.builder()
+                .contains(filterRelations(all, RelationKind.CONTAINS))
+                .extendsRelations(filterRelations(all, RelationKind.EXTENDS))
+                .implementsRelations(filterRelations(all, RelationKind.IMPLEMENTS))
+                .overrides(filterRelations(all, RelationKind.OVERRIDES))
+                .calls(filterRelations(all, RelationKind.CALLS))
+                .accessesField(filterRelations(all, RelationKind.ACCESSES_FIELD))
+                .fieldType(filterRelations(all, RelationKind.FIELD_TYPE))
+                .paramType(filterRelations(all, RelationKind.PARAM_TYPE))
+                .returnType(filterRelations(all, RelationKind.RETURN_TYPE))
+                .throwsType(filterRelations(all, RelationKind.THROWS_TYPE))
+                .annotatedBy(filterRelations(all, RelationKind.ANNOTATED_BY))
+                .build();
+    }
+
+    private ObservationTable toObservationTable(Collection<ObservationFact> values) {
+        List<ObservationFact> all = values == null ? List.of() : new ArrayList<>(values);
+        return ObservationTable.builder()
+                .diInjectionSites(filterObservations(all, ObservationKind.DI_INJECTION_SITE))
+                .diProviders(filterObservations(all, ObservationKind.DI_PROVIDER))
+                .spiProviders(filterObservations(all, ObservationKind.SPI_PROVIDER))
+                .eventPublish(filterObservations(all, ObservationKind.EVENT_PUBLISH))
+                .eventSubscribe(filterObservations(all, ObservationKind.EVENT_SUBSCRIBE))
+                .reflectionUses(filterObservations(all, ObservationKind.REFLECTION_USE))
+                .configWiring(filterObservations(all, ObservationKind.CONFIG_WIRING))
+                .build();
+    }
+
+    private List<SymbolFact> filterSymbols(List<SymbolFact> values, SymbolFactKind kind) {
+        return values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> value.kind() == kind)
+                .toList();
+    }
+
+    private List<RelationFact> filterRelations(List<RelationFact> values, RelationKind kind) {
+        return values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> value.kind() == kind)
+                .toList();
+    }
+
+    private List<ObservationFact> filterObservations(List<ObservationFact> values, ObservationKind kind) {
+        return values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> value.kind() == kind)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/merge/StatsAccumulator.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/merge/StatsAccumulator.java
@@ -1,0 +1,234 @@
+package com.example.ossdoc.domain.extraction.service.support.merge;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkResult;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.model.SymbolFact;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.ChunkStatus;
+import com.example.ossdoc.domain.extraction.enums.SymbolFactKind;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * 추출 중간 통계를 누적하고 마지막에 StatsMeta로 변환
+ */
+public class StatsAccumulator {
+
+    private final LongAdder filesScanned = new LongAdder();
+    private final LongAdder filesParsed = new LongAdder();
+    private final LongAdder filesSkipped = new LongAdder();
+
+    private final LongAdder astFilesScanned = new LongAdder();
+    private final LongAdder classFilesScanned = new LongAdder();
+    private final LongAdder astFilesParsed = new LongAdder();
+    private final LongAdder classFilesParsed = new LongAdder();
+
+    private final LongAdder chunksTotal = new LongAdder();
+    private final LongAdder chunksSucceeded = new LongAdder();
+    private final LongAdder chunksFailed = new LongAdder();
+    private final LongAdder chunksPartial = new LongAdder();
+
+    private final LongAdder types = new LongAdder();
+    private final LongAdder constructors = new LongAdder();
+    private final LongAdder methods = new LongAdder();
+    private final LongAdder fields = new LongAdder();
+
+    private final LongAdder edgeCandidates = new LongAdder();
+    private final LongAdder relations = new LongAdder();
+    private final LongAdder observations = new LongAdder();
+    private final LongAdder evidence = new LongAdder();
+    private final LongAdder unresolvedTypeRefs = new LongAdder();
+    private final LongAdder errors = new LongAdder();
+
+    public void recordFileScanned() {
+        filesScanned.increment();
+    }
+
+    public void recordFileParsed() {
+        filesParsed.increment();
+    }
+
+    public void recordFileSkipped() {
+        filesSkipped.increment();
+    }
+
+    public void recordAstFileScanned() {
+        recordFileScanned();
+        astFilesScanned.increment();
+    }
+
+    public void recordClassFileScanned() {
+        recordFileScanned();
+        classFilesScanned.increment();
+    }
+
+    public void recordAstFileParsed() {
+        recordFileParsed();
+        astFilesParsed.increment();
+    }
+
+    public void recordClassFileParsed() {
+        recordFileParsed();
+        classFilesParsed.increment();
+    }
+
+    public void recordChunkPlanned() {
+        chunksTotal.increment();
+    }
+
+    public void recordChunkStatus(ChunkStatus status) {
+        if (status == null) {
+            return;
+        }
+        switch (status) {
+            case SUCCEEDED -> chunksSucceeded.increment();
+            case FAILED -> chunksFailed.increment();
+            case PARTIAL -> chunksPartial.increment();
+            case PENDING, RUNNING -> {
+                // snapshot 시점 집계에서는 별도 카운트하지 않음
+            }
+        }
+    }
+
+    public void recordChunkResult(ChunkResult chunkResult) {
+        if (chunkResult == null) {
+            return;
+        }
+
+        recordChunkPlanned();
+        recordChunkStatus(chunkResult.status());
+        merge(chunkResult.stats());
+    }
+
+    public void recordScannedFileKind(ChunkKind kind) {
+        if (kind == null) {
+            recordFileScanned();
+            return;
+        }
+        if (kind == ChunkKind.AST) {
+            recordAstFileScanned();
+        } else {
+            recordClassFileScanned();
+        }
+    }
+
+    public void recordParsedFileKind(ChunkKind kind) {
+        if (kind == null) {
+            recordFileParsed();
+            return;
+        }
+        if (kind == ChunkKind.AST) {
+            recordAstFileParsed();
+        } else {
+            recordClassFileParsed();
+        }
+    }
+
+    public void recordType() {
+        types.increment();
+    }
+
+    public void recordConstructor() {
+        constructors.increment();
+    }
+
+    public void recordMethod() {
+        methods.increment();
+    }
+
+    public void recordField() {
+        fields.increment();
+    }
+
+    public void recordRelation() {
+        relations.increment();
+        edgeCandidates.increment();
+    }
+
+    public void recordObservation() {
+        observations.increment();
+    }
+
+    public void recordEvidence() {
+        evidence.increment();
+    }
+
+    public void recordUnresolvedTypeRef() {
+        unresolvedTypeRefs.increment();
+    }
+
+    public void recordError() {
+        errors.increment();
+    }
+
+    public void recordSymbol(SymbolFact symbolFact) {
+        if (symbolFact == null || symbolFact.kind() == null) {
+            return;
+        }
+
+        SymbolFactKind kind = symbolFact.kind();
+        switch (kind) {
+            case TYPE -> recordType();
+            case CONSTRUCTOR -> recordConstructor();
+            case METHOD -> recordMethod();
+            case FIELD -> recordField();
+            case MODULE, PACKAGE -> {
+                // 현재 StatsMeta에는 module/package 카운트 필드가 없음
+            }
+        }
+    }
+
+    public void merge(StatsMeta stats) {
+        if (stats == null) {
+            return;
+        }
+
+        filesScanned.add(stats.filesScanned());
+        filesParsed.add(stats.filesParsed());
+        filesSkipped.add(stats.filesSkipped());
+        astFilesScanned.add(stats.astFilesScanned());
+        classFilesScanned.add(stats.classFilesScanned());
+        astFilesParsed.add(stats.astFilesParsed());
+        classFilesParsed.add(stats.classFilesParsed());
+        chunksTotal.add(stats.chunksTotal());
+        chunksSucceeded.add(stats.chunksSucceeded());
+        chunksFailed.add(stats.chunksFailed());
+        chunksPartial.add(stats.chunksPartial());
+        types.add(stats.types());
+        constructors.add(stats.constructors());
+        methods.add(stats.methods());
+        fields.add(stats.fields());
+        edgeCandidates.add(stats.edgeCandidates());
+        relations.add(stats.relations());
+        observations.add(stats.observations());
+        evidence.add(stats.evidence());
+        unresolvedTypeRefs.add(stats.unresolvedTypeRefs());
+        errors.add(stats.errors());
+    }
+
+    public StatsMeta snapshot() {
+        return StatsMeta.builder()
+                .filesScanned(filesScanned.sum())
+                .filesParsed(filesParsed.sum())
+                .filesSkipped(filesSkipped.sum())
+                .astFilesScanned(astFilesScanned.sum())
+                .classFilesScanned(classFilesScanned.sum())
+                .astFilesParsed(astFilesParsed.sum())
+                .classFilesParsed(classFilesParsed.sum())
+                .chunksTotal(chunksTotal.sum())
+                .chunksSucceeded(chunksSucceeded.sum())
+                .chunksFailed(chunksFailed.sum())
+                .chunksPartial(chunksPartial.sum())
+                .types(types.sum())
+                .constructors(constructors.sum())
+                .methods(methods.sum())
+                .fields(fields.sum())
+                .edgeCandidates(edgeCandidates.sum())
+                .relations(relations.sum())
+                .observations(observations.sum())
+                .evidence(evidence.sum())
+                .unresolvedTypeRefs(unresolvedTypeRefs.sum())
+                .errors(errors.sum())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/planning/ChunkPlanner.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/planning/ChunkPlanner.java
@@ -1,0 +1,263 @@
+package com.example.ossdoc.domain.extraction.service.support.planning;
+import com.example.ossdoc.domain.extraction.service.support.util.HashSupport;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+import com.example.ossdoc.domain.extraction.service.support.preflight.ExtractionPreflightResult;
+
+import com.example.ossdoc.domain.extraction.dto.model.ChunkDescriptor;
+import com.example.ossdoc.domain.extraction.dto.model.ChunkingPolicy;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.enums.ChunkKind;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Component
+public class ChunkPlanner {
+
+    public List<ChunkDescriptor> plan(
+            FactsExtractRequest request,
+            ExtractionPreflightResult preflightResult,
+            Path repoRoot,
+            ChunkingPolicy policy
+    ) {
+        Objects.requireNonNull(preflightResult, "preflightResult must not be null");
+        Objects.requireNonNull(repoRoot, "repoRoot must not be null");
+
+        ChunkingPolicy effectivePolicy = policy == null ? ChunkingPolicy.standard() : policy;
+        IncludeGlobMatcher includeMatcher = new IncludeGlobMatcher(request == null ? List.of() : request.includeGlobs());
+        IncludeGlobMatcher excludeMatcher = new IncludeGlobMatcher(request == null ? List.of() : request.excludeGlobs());
+
+        List<ChunkDescriptor> chunks = new ArrayList<>();
+
+        for (ExtractionPreflightResult.ModuleNormalizedContext module : preflightResult.normalizedContext().modules()) {
+            if (!isTargetModule(request, module.moduleName())) {
+                continue;
+            }
+
+            chunks.addAll(planAstChunks(request, repoRoot, effectivePolicy, includeMatcher, excludeMatcher, module));
+
+            if (supportsAsm(preflightResult)) {
+                chunks.addAll(planAsmChunks(repoRoot, effectivePolicy, includeMatcher, excludeMatcher, module));
+            }
+        }
+
+        return List.copyOf(chunks);
+    }
+
+    private boolean supportsAsm(ExtractionPreflightResult preflightResult) {
+        ExtractionMode mode = preflightResult.resolvedMode();
+        return mode == ExtractionMode.AST_PLUS_BYTECODE || mode == ExtractionMode.AST_PLUS_PARTIAL_BYTECODE;
+    }
+
+    private boolean isTargetModule(FactsExtractRequest request, String moduleName) {
+        if (request == null || request.targetModules() == null || request.targetModules().isEmpty()) {
+            return true;
+        }
+        return request.targetModules().stream()
+                .filter(value -> value != null && !value.isBlank())
+                .anyMatch(moduleName::equals);
+    }
+
+    private List<ChunkDescriptor> planAstChunks(
+            FactsExtractRequest request,
+            Path repoRoot,
+            ChunkingPolicy policy,
+            IncludeGlobMatcher includeMatcher,
+            IncludeGlobMatcher excludeMatcher,
+            ExtractionPreflightResult.ModuleNormalizedContext module
+    ) {
+        List<ChunkDescriptor> chunks = new ArrayList<>();
+        chunks.addAll(planChunksForRoots(
+                repoRoot,
+                module.moduleName(),
+                module.sourceRoots(),
+                ChunkKind.AST,
+                ".java",
+                policy.astMaxFiles(),
+                policy.astMaxBytes(),
+                includeMatcher,
+                excludeMatcher
+        ));
+
+        if (request != null && request.includeTests()) {
+            chunks.addAll(planChunksForRoots(
+                    repoRoot,
+                    module.moduleName(),
+                    module.testRoots(),
+                    ChunkKind.AST,
+                    ".java",
+                    policy.astMaxFiles(),
+                    policy.astMaxBytes(),
+                    includeMatcher,
+                    excludeMatcher
+            ));
+        }
+        return chunks;
+    }
+
+    private List<ChunkDescriptor> planAsmChunks(
+            Path repoRoot,
+            ChunkingPolicy policy,
+            IncludeGlobMatcher includeMatcher,
+            IncludeGlobMatcher excludeMatcher,
+            ExtractionPreflightResult.ModuleNormalizedContext module
+    ) {
+        return planChunksForRoots(
+                repoRoot,
+                module.moduleName(),
+                module.classesDirs(),
+                ChunkKind.ASM,
+                ".class",
+                policy.asmMaxFiles(),
+                policy.asmMaxBytes(),
+                includeMatcher,
+                excludeMatcher
+        );
+    }
+
+    private List<ChunkDescriptor> planChunksForRoots(
+            Path repoRoot,
+            String moduleName,
+            List<Path> roots,
+            ChunkKind kind,
+            String fileSuffix,
+            int maxFiles,
+            long maxBytes,
+            IncludeGlobMatcher includeMatcher,
+            IncludeGlobMatcher excludeMatcher
+    ) {
+        List<ChunkDescriptor> chunks = new ArrayList<>();
+        if (roots == null || roots.isEmpty()) {
+            return chunks;
+        }
+
+        for (Path root : roots) {
+            List<Path> files = collectFiles(root, fileSuffix);
+            if (files.isEmpty()) {
+                continue;
+            }
+
+            List<FileEntry> accepted = new ArrayList<>();
+            for (Path file : files) {
+                String repoRelative = RepoPathUtils.toRepoRelative(repoRoot, file);
+                if (!includeMatcher.matches(repoRelative)) {
+                    continue;
+                }
+                if (excludeMatcher.hasRules() && excludeMatcher.matches(repoRelative)) {
+                    continue;
+                }
+
+                try {
+                    long size = Files.size(file);
+                    accepted.add(new FileEntry(file, repoRelative, size));
+                } catch (IOException e) {
+                    // 파일 크기 계산 실패 시 skip
+                }
+            }
+
+            if (accepted.isEmpty()) {
+                continue;
+            }
+
+            accepted.sort(Comparator.comparing(FileEntry::repoRelative));
+            chunks.addAll(sliceRootIntoChunks(repoRoot, moduleName, root, kind, accepted, maxFiles, maxBytes));
+        }
+
+        return chunks;
+    }
+
+    private List<ChunkDescriptor> sliceRootIntoChunks(
+            Path repoRoot,
+            String moduleName,
+            Path root,
+            ChunkKind kind,
+            List<FileEntry> accepted,
+            int maxFiles,
+            long maxBytes
+    ) {
+        List<ChunkDescriptor> chunks = new ArrayList<>();
+        List<String> currentFiles = new ArrayList<>();
+        long currentBytes = 0L;
+        int chunkIndex = 0;
+
+        for (FileEntry entry : accepted) {
+            boolean shouldRotate = !currentFiles.isEmpty()
+                    && (currentFiles.size() >= maxFiles || currentBytes + entry.size() > maxBytes);
+
+            if (shouldRotate) {
+                chunks.add(buildChunk(repoRoot, moduleName, root, kind, chunkIndex++, currentFiles, currentBytes));
+                currentFiles = new ArrayList<>();
+                currentBytes = 0L;
+            }
+
+            currentFiles.add(entry.repoRelative());
+            currentBytes += entry.size();
+        }
+
+        if (!currentFiles.isEmpty()) {
+            chunks.add(buildChunk(repoRoot, moduleName, root, kind, chunkIndex, currentFiles, currentBytes));
+        }
+
+        return chunks;
+    }
+
+    private ChunkDescriptor buildChunk(
+            Path repoRoot,
+            String moduleName,
+            Path root,
+            ChunkKind kind,
+            int chunkIndex,
+            List<String> files,
+            long totalBytes
+    ) {
+        String rootPath = RepoPathUtils.toRepoRelative(repoRoot, root);
+        String key = String.join("|",
+                kind.code(),
+                moduleName,
+                rootPath,
+                String.valueOf(chunkIndex),
+                String.join(",", files)
+        );
+
+        String chunkId = "chunk_" + HashSupport.sha256Hex(key).substring(0, 16);
+
+        return ChunkDescriptor.builder()
+                .chunkId(chunkId)
+                .kind(kind)
+                .module(moduleName)
+                .rootPath(rootPath)
+                .files(List.copyOf(files))
+                .totalBytes(totalBytes)
+                .fileCount(files.size())
+                .build();
+    }
+
+    private List<Path> collectFiles(Path root, String suffix) {
+        if (root == null || !Files.exists(root) || !Files.isDirectory(root)) {
+            return List.of();
+        }
+
+        try (Stream<Path> stream = Files.walk(root)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(suffix))
+                    .sorted()
+                    .toList();
+        } catch (IOException e) {
+            return List.of();
+        }
+    }
+
+    private record FileEntry(Path path, String repoRelative, long size) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/planning/IncludeGlobMatcher.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/planning/IncludeGlobMatcher.java
@@ -1,0 +1,134 @@
+package com.example.ossdoc.domain.extraction.service.support.planning;
+import com.example.ossdoc.domain.extraction.service.support.util.RepoPathUtils;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * 경로 prefix / glob 매칭 유틸
+ *
+ * 지원 예:
+ * - src/main/java
+ * - module-a/src/main/java
+ * - {@code **}/*.java
+ * - {@code **}/generated/{@code **}
+ */
+public class IncludeGlobMatcher {
+
+    private final List<String> normalizedPrefixes;
+    private final List<Pattern> globPatterns;
+
+    public IncludeGlobMatcher(List<String> includeGlobs) {
+        this.normalizedPrefixes = new ArrayList<>();
+        this.globPatterns = new ArrayList<>();
+
+        if (includeGlobs == null || includeGlobs.isEmpty()) {
+            return;
+        }
+
+        for (String glob : includeGlobs) {
+            if (glob == null || glob.isBlank()) {
+                continue;
+            }
+
+            String normalized = normalizeGlob(glob);
+            if (containsGlobToken(normalized)) {
+                globPatterns.add(Pattern.compile(toRegex(normalized)));
+            } else {
+                normalizedPrefixes.add(trimTrailingSlash(normalized));
+            }
+        }
+    }
+
+    public boolean hasRules() {
+        return !(normalizedPrefixes.isEmpty() && globPatterns.isEmpty());
+    }
+
+    public boolean matches(Path relativePath) {
+        Objects.requireNonNull(relativePath, "relativePath must not be null");
+        return matches(relativePath.toString());
+    }
+
+    public boolean matches(String relativePath) {
+        Objects.requireNonNull(relativePath, "relativePath must not be null");
+
+        if (!hasRules()) {
+            return true;
+        }
+
+        String normalizedPath = trimTrailingSlash(RepoPathUtils.normalizeSeparators(relativePath));
+
+        for (String prefix : normalizedPrefixes) {
+            if (normalizedPath.equals(prefix) || normalizedPath.startsWith(prefix + "/")) {
+                return true;
+            }
+        }
+
+        for (Pattern pattern : globPatterns) {
+            if (pattern.matcher(normalizedPath).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static String normalizeGlob(String value) {
+        return trimTrailingSlash(RepoPathUtils.normalizeSeparators(value.trim()));
+    }
+
+    private static String trimTrailingSlash(String value) {
+        if (value == null) {
+            return null;
+        }
+        String result = value;
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private static boolean containsGlobToken(String value) {
+        return value.contains("*")
+                || value.contains("?")
+                || value.contains("[")
+                || value.contains("]")
+                || value.contains("{")
+                || value.contains("}");
+    }
+
+    private static String toRegex(String glob) {
+        StringBuilder regex = new StringBuilder("^");
+
+        for (int i = 0; i < glob.length(); i++) {
+            char ch = glob.charAt(i);
+
+            if (ch == '*') {
+                boolean doubleStar = (i + 1 < glob.length()) && glob.charAt(i + 1) == '*';
+                if (doubleStar) {
+                    regex.append(".*");
+                    i++;
+                } else {
+                    regex.append("[^/]*");
+                }
+                continue;
+            }
+
+            if (ch == '?') {
+                regex.append("[^/]");
+                continue;
+            }
+
+            if ("\\.[]{}()+-^$|".indexOf(ch) >= 0) {
+                regex.append("\\");
+            }
+            regex.append(ch);
+        }
+
+        regex.append("$");
+        return regex.toString();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BuildManifestLoader.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BuildManifestLoader.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuildManifestLoader {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 로컬 artifacts 디렉터리에서 build_manifest.json을 읽어 BuildManifest로 반환.
+     * 파일이 없거나 역직렬화 실패 시 null 반환 (warning은 호출부에서 추가).
+     */
+    public BuildManifest load(Path artifactsDir) {
+        Path file = artifactsDir.resolve("build_manifest.json");
+        if (!Files.exists(file)) {
+            log.warn("build_manifest.json not found — path: {}", file);
+            return null;
+        }
+        try {
+            return objectMapper.readValue(file.toFile(), BuildManifest.class);
+        } catch (Exception e) {
+            log.warn("build_manifest.json 로드 실패 — path: {}, 원인: {}", file, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BuildOutputVerifier.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BuildOutputVerifier.java
@@ -1,0 +1,131 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.build.enums.BuildMode;
+import com.example.ossdoc.domain.build.enums.BuildToolKind;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BuildOutputVerifier {
+
+    public BuildOutputVerificationResult verify(BuildManifest buildManifest) {
+        List<String> warnings = new ArrayList<>();
+
+        if (buildManifest == null) {
+            warnings.add("build_manifest is null");
+            return new BuildOutputVerificationResult(
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    List.copyOf(warnings)
+            );
+        }
+
+        boolean manifestExists = true;
+
+        if (isBlank(buildManifest.getRunId())) {
+            warnings.add("build_manifest.runId is missing");
+        }
+        if (buildManifest.getDetectedAt() == null) {
+            warnings.add("build_manifest.detectedAt is missing");
+        }
+
+        BuildToolKind buildTool = buildManifest.getBuildTool();
+        if (buildTool == null) {
+            warnings.add("build_manifest.buildTool is missing");
+        } else if (buildTool == BuildToolKind.NONE) {
+            warnings.add("build_manifest.buildTool is NONE");
+        }
+
+        BuildMode buildMode = buildManifest.getBuildMode();
+        if (buildMode == null) {
+            warnings.add("build_manifest.buildMode is missing");
+        }
+
+        List<BuildModuleManifest> modules = safeModules(buildManifest.getModules());
+        if (modules.isEmpty()) {
+            warnings.add("build_manifest.modules is empty");
+        }
+
+        boolean hasSourceMetadata = modules.stream().anyMatch(this::hasAnyJavaSourceMetadata);
+        boolean hasDeclaredClassDirs = modules.stream().anyMatch(m -> hasTextValues(m.getClassesDirs()));
+        boolean hasCompileClasspathMetadata = modules.stream().anyMatch(m -> hasTextValues(m.getCompileClasspath()));
+        boolean hasRuntimeClasspathMetadata = modules.stream().anyMatch(m -> hasTextValues(m.getRuntimeClasspath()));
+
+        if (!hasSourceMetadata) {
+            warnings.add("No module contains sourceRoots or testRoots, so AST extraction cannot proceed");
+        }
+
+        if (buildMode == BuildMode.FULL && !hasDeclaredClassDirs) {
+            warnings.add("BuildMode is FULL but no classesDirs metadata was recorded");
+        }
+
+        if (buildMode == BuildMode.FULL && !hasCompileClasspathMetadata) {
+            warnings.add("BuildMode is FULL but compileClasspath metadata is missing");
+        }
+
+        if (buildMode != null && buildMode != BuildMode.FULL && hasDeclaredClassDirs) {
+            warnings.add("classesDirs metadata exists although buildMode is not FULL; stale bytecode will not be trusted automatically");
+        }
+
+        boolean outputMetadataPresent =
+                hasDeclaredClassDirs || hasCompileClasspathMetadata || hasRuntimeClasspathMetadata;
+
+        boolean buildUsable =
+                buildTool != null
+                        && buildTool != BuildToolKind.NONE
+                        && buildMode != null
+                        && buildMode != BuildMode.FAILED
+                        && hasSourceMetadata;
+
+        return new BuildOutputVerificationResult(
+                manifestExists,
+                buildUsable,
+                hasSourceMetadata,
+                hasDeclaredClassDirs,
+                hasCompileClasspathMetadata,
+                outputMetadataPresent,
+                List.copyOf(warnings)
+        );
+    }
+
+    private boolean hasAnyJavaSourceMetadata(BuildModuleManifest module) {
+        return hasTextValues(module.getSourceRoots()) || hasTextValues(module.getTestRoots());
+    }
+
+    private boolean hasTextValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return false;
+        }
+        return values.stream().anyMatch(v -> v != null && !v.isBlank());
+    }
+
+    private List<BuildModuleManifest> safeModules(List<BuildModuleManifest> modules) {
+        return modules == null ? List.of() : modules;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    public record BuildOutputVerificationResult(
+            boolean manifestExists,
+            boolean buildUsable,
+            boolean hasSourceMetadata,
+            boolean hasDeclaredClassDirs,
+            boolean hasCompileClasspathMetadata,
+            boolean outputMetadataPresent,
+            List<String> warnings
+    ) {
+        public BuildOutputVerificationResult {
+            warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BytecodeAvailabilityChecker.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/BytecodeAvailabilityChecker.java
@@ -1,0 +1,166 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.extraction.enums.BytecodeAvailability;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class BytecodeAvailabilityChecker {
+
+    public BytecodeAvailabilityResult check(BuildManifest buildManifest, Path repoRoot) {
+        List<String> warnings = new ArrayList<>();
+
+        if (buildManifest == null) {
+            warnings.add("build_manifest is null");
+            return BytecodeAvailabilityResult.empty(warnings);
+        }
+
+        if (repoRoot == null) {
+            warnings.add("repoRoot is null");
+            return BytecodeAvailabilityResult.empty(warnings);
+        }
+
+        Set<Path> declaredRoots = new LinkedHashSet<>();
+        Set<Path> existingRoots = new LinkedHashSet<>();
+        Set<Path> missingRoots = new LinkedHashSet<>();
+
+        long classFileCount = 0L;
+
+        for (BuildModuleManifest module : safeModules(buildManifest.getModules())) {
+            for (String rawRoot : safeStrings(module.getClassesDirs())) {
+                if (rawRoot == null || rawRoot.isBlank()) {
+                    warnings.add("Blank classesDirs entry found in module: " + safeModuleId(module));
+                    continue;
+                }
+
+                Path resolvedRoot;
+                try {
+                    resolvedRoot = normalizePath(repoRoot, rawRoot);
+                } catch (Exception e) {
+                    warnings.add("Invalid classesDirs path '" + rawRoot + "' in module: " + safeModuleId(module));
+                    continue;
+                }
+
+                declaredRoots.add(resolvedRoot);
+
+                if (!Files.exists(resolvedRoot) || !Files.isDirectory(resolvedRoot)) {
+                    missingRoots.add(resolvedRoot);
+                    warnings.add("classesDirs path does not exist: " + resolvedRoot);
+                    continue;
+                }
+
+                existingRoots.add(resolvedRoot);
+
+                try {
+                    long count = countClassFiles(resolvedRoot);
+                    if (count == 0L) {
+                        warnings.add("classesDirs exists but contains no .class files: " + resolvedRoot);
+                    } else {
+                        classFileCount += count;
+                    }
+                } catch (IOException e) {
+                    warnings.add("Failed to scan classesDirs: " + resolvedRoot + " (" + e.getMessage() + ")");
+                    existingRoots.remove(resolvedRoot);
+                    missingRoots.add(resolvedRoot);
+                }
+            }
+        }
+
+        int declaredRootCount = declaredRoots.size();
+        int existingRootCount = existingRoots.size();
+
+        boolean hasUsableBytecode = classFileCount > 0L;
+        boolean partialAvailability =
+                hasUsableBytecode && declaredRootCount > 0 && existingRootCount < declaredRootCount;
+
+        return new BytecodeAvailabilityResult(
+                hasUsableBytecode,
+                partialAvailability,
+                declaredRootCount,
+                existingRootCount,
+                List.copyOf(existingRoots),
+                List.copyOf(missingRoots),
+                classFileCount,
+                List.copyOf(warnings)
+        );
+    }
+
+    private long countClassFiles(Path root) throws IOException {
+        try (var stream = Files.walk(root)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".class"))
+                    .count();
+        }
+    }
+
+    private Path normalizePath(Path repoRoot, String rawPath) {
+        Path path = Path.of(rawPath);
+        return path.isAbsolute() ? path.normalize() : repoRoot.resolve(path).normalize();
+    }
+
+    private List<BuildModuleManifest> safeModules(List<BuildModuleManifest> modules) {
+        return modules == null ? List.of() : modules;
+    }
+
+    private List<String> safeStrings(List<String> values) {
+        return values == null ? List.of() : values;
+    }
+
+    private String safeModuleId(BuildModuleManifest module) {
+        if (module == null || module.getModuleId() == null || module.getModuleId().isBlank()) {
+            return "<unknown-module>";
+        }
+        return module.getModuleId();
+    }
+
+    public record BytecodeAvailabilityResult(
+            boolean hasUsableBytecode,
+            boolean partialAvailability,
+            int declaredRootCount,
+            int existingRootCount,
+            List<Path> existingRoots,
+            List<Path> missingRoots,
+            long classFileCount,
+            List<String> warnings
+    ) {
+        public BytecodeAvailabilityResult {
+            existingRoots = existingRoots == null ? List.of() : List.copyOf(existingRoots);
+            missingRoots = missingRoots == null ? List.of() : List.copyOf(missingRoots);
+            warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        }
+
+        public BytecodeAvailability availability() {
+            if (!hasUsableBytecode) {
+                return BytecodeAvailability.NONE;
+            }
+            return partialAvailability ? BytecodeAvailability.PARTIAL : BytecodeAvailability.FULL;
+        }
+
+        public boolean hasDeclaredRoots() {
+            return declaredRootCount > 0;
+        }
+
+        public static BytecodeAvailabilityResult empty(List<String> warnings) {
+            return new BytecodeAvailabilityResult(
+                    false,
+                    false,
+                    0,
+                    0,
+                    List.of(),
+                    List.of(),
+                    0L,
+                    warnings
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionModeResolver.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionModeResolver.java
@@ -1,0 +1,121 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.enums.BuildMode;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ExtractionModeResolver {
+
+    public ExtractionModeResolutionResult resolve(
+            FactsExtractRequest request,
+            BuildManifest buildManifest,
+            BuildOutputVerifier.BuildOutputVerificationResult buildVerificationResult,
+            BytecodeAvailabilityChecker.BytecodeAvailabilityResult bytecodeAvailabilityResult
+    ) {
+        List<String> warnings = new ArrayList<>();
+
+        ExtractionMode requestedMode = request == null ? null : request.mode();
+        ExtractionMode manifestMode = deriveManifestMode(buildManifest);
+        ExtractionMode candidateMode = requestedMode != null ? requestedMode : manifestMode;
+
+        boolean fallbackApplied = false;
+        String fallbackReason = null;
+        ExtractionMode resolvedMode = candidateMode;
+
+        if (candidateMode == null) {
+            warnings.add("No requested mode and no manifest-derived mode were available");
+            return new ExtractionModeResolutionResult(
+                    requestedMode,
+                    manifestMode,
+                    null,
+                    false,
+                    null,
+                    List.copyOf(warnings)
+            );
+        }
+
+        boolean buildFull = buildManifest != null && buildManifest.getBuildMode() == BuildMode.FULL;
+        boolean buildUsable = buildVerificationResult != null && buildVerificationResult.buildUsable();
+        boolean hasUsableBytecode = bytecodeAvailabilityResult != null && bytecodeAvailabilityResult.hasUsableBytecode();
+        boolean partialBytecode = bytecodeAvailabilityResult != null && bytecodeAvailabilityResult.partialAvailability();
+
+        if (candidateMode == ExtractionMode.AST_PLUS_BYTECODE
+                || candidateMode == ExtractionMode.AST_PLUS_PARTIAL_BYTECODE) {
+            if (!buildFull) {
+                resolvedMode = ExtractionMode.AST_ONLY;
+                fallbackApplied = true;
+                fallbackReason = "Bytecode-backed extraction requires BuildMode.FULL";
+                warnings.add("Requested bytecode extraction but buildMode is not FULL, so AST_ONLY fallback was applied");
+            } else if (!buildUsable) {
+                resolvedMode = ExtractionMode.AST_ONLY;
+                fallbackApplied = true;
+                fallbackReason = "Build metadata is not usable for extraction";
+                warnings.add("Requested bytecode extraction but build metadata is not usable, so AST_ONLY fallback was applied");
+            } else if (!hasUsableBytecode) {
+                resolvedMode = ExtractionMode.AST_ONLY;
+                fallbackApplied = true;
+                fallbackReason = "No usable .class files were found";
+                warnings.add("Requested bytecode extraction but no usable .class files were found, so AST_ONLY fallback was applied");
+            } else if (partialBytecode) {
+                resolvedMode = ExtractionMode.AST_PLUS_PARTIAL_BYTECODE;
+                warnings.add("Partial bytecode availability detected; ASM extraction will run only on existing class roots");
+            } else {
+                resolvedMode = ExtractionMode.AST_PLUS_BYTECODE;
+            }
+        }
+
+        if (candidateMode == ExtractionMode.AST_ONLY
+                && buildVerificationResult != null
+                && !buildVerificationResult.hasSourceMetadata()) {
+            warnings.add("AST_ONLY was selected but no sourceRoots/testRoots metadata was recorded");
+        }
+
+        if (buildManifest != null
+                && buildManifest.getBuildMode() != null
+                && buildManifest.getBuildMode() != BuildMode.FULL
+                && bytecodeAvailabilityResult != null
+                && bytecodeAvailabilityResult.hasUsableBytecode()) {
+            warnings.add("Bytecode exists on disk but buildMode is not FULL; extraction will not trust it automatically");
+        }
+
+        return new ExtractionModeResolutionResult(
+                requestedMode,
+                manifestMode,
+                resolvedMode,
+                fallbackApplied,
+                fallbackReason,
+                List.copyOf(warnings)
+        );
+    }
+
+    private ExtractionMode deriveManifestMode(BuildManifest buildManifest) {
+        if (buildManifest == null || buildManifest.getBuildMode() == null) {
+            return null;
+        }
+
+        return switch (buildManifest.getBuildMode()) {
+            case FULL -> ExtractionMode.AST_PLUS_BYTECODE;
+            case COMPILE_ONLY, SOURCE_ONLY -> ExtractionMode.AST_ONLY;
+            case FAILED -> null;
+        };
+    }
+
+    public record ExtractionModeResolutionResult(
+            ExtractionMode requestedMode,
+            ExtractionMode manifestMode,
+            ExtractionMode resolvedMode,
+            boolean fallbackApplied,
+            String fallbackReason,
+            List<String> warnings
+    ) {
+        public ExtractionModeResolutionResult {
+            warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionPreflightChecker.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionPreflightChecker.java
@@ -1,0 +1,267 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+import com.example.ossdoc.domain.extraction.service.support.util.WarningCollector;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ExtractionPreflightChecker {
+
+    private final BuildOutputVerifier buildOutputVerifier;
+    private final BytecodeAvailabilityChecker bytecodeAvailabilityChecker;
+    private final ExtractionModeResolver extractionModeResolver;
+
+    public ExtractionPreflightResult check(
+            FactsExtractRequest request,
+            BuildManifest buildManifest,
+            Path repoRoot
+    ) {
+        BuildOutputVerifier.BuildOutputVerificationResult buildVerification =
+                buildOutputVerifier.verify(buildManifest);
+
+        BytecodeAvailabilityChecker.BytecodeAvailabilityResult bytecodeAvailability =
+                bytecodeAvailabilityChecker.check(buildManifest, repoRoot);
+
+        ExtractionModeResolver.ExtractionModeResolutionResult modeResolution =
+                extractionModeResolver.resolve(
+                        request,
+                        buildManifest,
+                        buildVerification,
+                        bytecodeAvailability
+                );
+
+        PathNormalizationResult normalizationResult = normalizeContext(buildManifest, repoRoot, request);
+
+        WarningCollector warnings = new WarningCollector();
+        warnings.addAll(buildVerification.warnings());
+        warnings.addAll(bytecodeAvailability.warnings());
+        warnings.addAll(modeResolution.warnings());
+        warnings.addAll(normalizationResult.warnings());
+
+        List<String> blockingReasons = collectBlockingReasons(
+                buildVerification,
+                modeResolution,
+                normalizationResult.context(),
+                bytecodeAvailability
+        );
+
+        boolean canProceed = blockingReasons.isEmpty();
+
+        return new ExtractionPreflightResult(
+                buildManifest,
+                buildVerification,
+                bytecodeAvailability,
+                modeResolution,
+                normalizationResult.context(),
+                warnings.snapshot(),
+                blockingReasons,
+                canProceed
+        );
+    }
+
+    private List<String> collectBlockingReasons(
+            BuildOutputVerifier.BuildOutputVerificationResult buildVerification,
+            ExtractionModeResolver.ExtractionModeResolutionResult modeResolution,
+            ExtractionPreflightResult.NormalizedExtractionContext normalizedContext,
+            BytecodeAvailabilityChecker.BytecodeAvailabilityResult bytecodeAvailability
+    ) {
+        List<String> blockingReasons = new ArrayList<>();
+
+        if (buildVerification == null || !buildVerification.manifestExists()) {
+            blockingReasons.add("build_manifest is missing");
+        }
+
+        if (buildVerification == null || !buildVerification.buildUsable()) {
+            blockingReasons.add("build metadata is not usable for extraction");
+        }
+
+        if (modeResolution == null || modeResolution.resolvedMode() == null) {
+            blockingReasons.add("extraction mode could not be resolved");
+        }
+
+        if (normalizedContext == null || !normalizedContext.hasAnyJavaRoots()) {
+            blockingReasons.add("no usable sourceRoots/testRoots were found after normalization");
+        }
+
+        ExtractionMode resolvedMode = modeResolution == null ? null : modeResolution.resolvedMode();
+        boolean requiresBytecode = resolvedMode == ExtractionMode.AST_PLUS_BYTECODE
+                || resolvedMode == ExtractionMode.AST_PLUS_PARTIAL_BYTECODE;
+
+        if (requiresBytecode && (bytecodeAvailability == null || !bytecodeAvailability.hasUsableBytecode())) {
+            blockingReasons.add("resolved mode requires bytecode but no usable .class files were found");
+        }
+
+        return List.copyOf(blockingReasons);
+    }
+
+    private PathNormalizationResult normalizeContext(
+            BuildManifest buildManifest,
+            Path repoRoot,
+            FactsExtractRequest request
+    ) {
+        WarningCollector warnings = new WarningCollector();
+
+        if (buildManifest == null) {
+            warnings.add("Cannot normalize extraction paths because build_manifest is null");
+            return new PathNormalizationResult(
+                    ExtractionPreflightResult.NormalizedExtractionContext.empty(),
+                    warnings.snapshot()
+            );
+        }
+
+        if (repoRoot == null) {
+            warnings.add("Cannot normalize extraction paths because repoRoot is null");
+            return new PathNormalizationResult(
+                    ExtractionPreflightResult.NormalizedExtractionContext.empty(),
+                    warnings.snapshot()
+            );
+        }
+
+        List<ExtractionPreflightResult.ModuleNormalizedContext> modules = new ArrayList<>();
+        Set<Path> compileClasspath = new LinkedHashSet<>();
+        Set<Path> runtimeClasspath = new LinkedHashSet<>();
+
+        for (BuildModuleManifest module : safeModules(buildManifest.getModules())) {
+            String moduleName = safeModuleId(module);
+
+            if (!isTargetModule(request, moduleName)) {
+                continue;
+            }
+
+            Set<Path> sourceRoots = new LinkedHashSet<>();
+            Set<Path> testRoots = new LinkedHashSet<>();
+            Set<Path> resourceRoots = new LinkedHashSet<>();
+            Set<Path> classesDirs = new LinkedHashSet<>();
+
+            normalizeDirectoryList(repoRoot, module.getSourceRoots(), sourceRoots, warnings, "sourceRoots", module);
+            normalizeDirectoryList(repoRoot, module.getTestRoots(), testRoots, warnings, "testRoots", module);
+            normalizeDirectoryList(repoRoot, module.getResourceRoots(), resourceRoots, warnings, "resourceRoots", module);
+            normalizeDirectoryList(repoRoot, module.getClassesDirs(), classesDirs, warnings, "classesDirs", module);
+
+            normalizeClasspathList(repoRoot, module.getCompileClasspath(), compileClasspath, warnings, "compileClasspath", module);
+            normalizeClasspathList(repoRoot, module.getRuntimeClasspath(), runtimeClasspath, warnings, "runtimeClasspath", module);
+
+            modules.add(new ExtractionPreflightResult.ModuleNormalizedContext(
+                    moduleName,
+                    List.copyOf(sourceRoots),
+                    List.copyOf(testRoots),
+                    List.copyOf(resourceRoots),
+                    List.copyOf(classesDirs)
+            ));
+        }
+
+        ExtractionPreflightResult.NormalizedExtractionContext context =
+                new ExtractionPreflightResult.NormalizedExtractionContext(
+                        List.copyOf(modules),
+                        List.copyOf(compileClasspath),
+                        List.copyOf(runtimeClasspath)
+                );
+
+        return new PathNormalizationResult(context, warnings.snapshot());
+    }
+
+    private boolean isTargetModule(FactsExtractRequest request, String moduleName) {
+        if (request == null || request.targetModules() == null || request.targetModules().isEmpty()) {
+            return true;
+        }
+        return request.targetModules().stream()
+                .filter(value -> value != null && !value.isBlank())
+                .anyMatch(moduleName::equals);
+    }
+
+    private void normalizeDirectoryList(
+            Path repoRoot,
+            List<String> rawPaths,
+            Set<Path> target,
+            WarningCollector warnings,
+            String fieldName,
+            BuildModuleManifest module
+    ) {
+        if (rawPaths == null) {
+            return;
+        }
+
+        for (String rawPath : rawPaths) {
+            if (rawPath == null || rawPath.isBlank()) {
+                warnings.add("Blank " + fieldName + " entry found in module: " + safeModuleId(module));
+                continue;
+            }
+
+            try {
+                Path normalized = normalizePath(repoRoot, rawPath);
+                if (!Files.exists(normalized) || !Files.isDirectory(normalized)) {
+                    warnings.add(fieldName + " path does not exist or is not a directory: " + normalized);
+                    continue;
+                }
+                target.add(normalized);
+            } catch (Exception e) {
+                warnings.add("Failed to normalize " + fieldName + " path '" + rawPath + "' in module: " + safeModuleId(module));
+            }
+        }
+    }
+
+    private void normalizeClasspathList(
+            Path repoRoot,
+            List<String> rawPaths,
+            Set<Path> target,
+            WarningCollector warnings,
+            String fieldName,
+            BuildModuleManifest module
+    ) {
+        if (rawPaths == null) {
+            return;
+        }
+
+        for (String rawPath : rawPaths) {
+            if (rawPath == null || rawPath.isBlank()) {
+                warnings.add("Blank " + fieldName + " entry found in module: " + safeModuleId(module));
+                continue;
+            }
+
+            try {
+                Path normalized = normalizePath(repoRoot, rawPath);
+                if (!Files.exists(normalized)) {
+                    warnings.add(fieldName + " entry does not exist: " + normalized);
+                    continue;
+                }
+                target.add(normalized);
+            } catch (Exception e) {
+                warnings.add("Failed to normalize " + fieldName + " path '" + rawPath + "' in module: " + safeModuleId(module));
+            }
+        }
+    }
+
+    private Path normalizePath(Path repoRoot, String rawPath) {
+        Path path = Path.of(rawPath);
+        return path.isAbsolute() ? path.normalize() : repoRoot.resolve(path).normalize();
+    }
+
+    private List<BuildModuleManifest> safeModules(List<BuildModuleManifest> modules) {
+        return modules == null ? List.of() : modules;
+    }
+
+    private String safeModuleId(BuildModuleManifest module) {
+        if (module == null || module.getModuleId() == null || module.getModuleId().isBlank()) {
+            return "<unknown-module>";
+        }
+        return module.getModuleId();
+    }
+
+    private record PathNormalizationResult(
+            ExtractionPreflightResult.NormalizedExtractionContext context,
+            List<String> warnings
+    ) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionPreflightResult.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/preflight/ExtractionPreflightResult.java
@@ -1,0 +1,142 @@
+package com.example.ossdoc.domain.extraction.service.support.preflight;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public record ExtractionPreflightResult(
+        BuildManifest buildManifest,
+        BuildOutputVerifier.BuildOutputVerificationResult buildVerification,
+        BytecodeAvailabilityChecker.BytecodeAvailabilityResult bytecodeAvailability,
+        ExtractionModeResolver.ExtractionModeResolutionResult modeResolution,
+        NormalizedExtractionContext normalizedContext,
+        List<String> warnings,
+        List<String> blockingReasons,
+        boolean canProceed
+) {
+    public ExtractionPreflightResult {
+        normalizedContext = normalizedContext == null
+                ? NormalizedExtractionContext.empty()
+                : normalizedContext;
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        blockingReasons = blockingReasons == null ? List.of() : List.copyOf(blockingReasons);
+    }
+
+    public ExtractionMode resolvedMode() {
+        return modeResolution == null ? null : modeResolution.resolvedMode();
+    }
+
+    public boolean bytecodeAvailable() {
+        return bytecodeAvailability != null && bytecodeAvailability.hasUsableBytecode();
+    }
+
+    public boolean classpathReady() {
+        return normalizedContext != null && normalizedContext.classpathReady();
+    }
+
+    public boolean hasBlockingReasons() {
+        return !blockingReasons.isEmpty();
+    }
+
+    public boolean hasAnyUsableSourceInput() {
+        return normalizedContext != null && normalizedContext.hasAnyJavaRoots();
+    }
+
+    public boolean hasAnyUsableBytecodeInput() {
+        return normalizedContext != null && normalizedContext.hasAnyClassesDirs();
+    }
+
+    public record NormalizedExtractionContext(
+            List<ModuleNormalizedContext> modules,
+            List<Path> compileClasspath,
+            List<Path> runtimeClasspath
+    ) {
+        public NormalizedExtractionContext {
+            modules = modules == null ? List.of() : List.copyOf(modules);
+            compileClasspath = compileClasspath == null ? List.of() : List.copyOf(compileClasspath);
+            runtimeClasspath = runtimeClasspath == null ? List.of() : List.copyOf(runtimeClasspath);
+        }
+
+        public boolean hasAnyJavaRoots() {
+            return modules.stream().anyMatch(ModuleNormalizedContext::hasAnyJavaRoots);
+        }
+
+        public boolean hasAnyClassesDirs() {
+            return modules.stream().anyMatch(ModuleNormalizedContext::hasAnyClassesDirs);
+        }
+
+        public boolean classpathReady() {
+            return !compileClasspath.isEmpty();
+        }
+
+        /**
+         * 기존 평평한 루트 접근 방식이 필요할 때 사용
+         */
+        public List<Path> sourceRoots() {
+            return modules.stream()
+                    .flatMap(module -> module.sourceRoots().stream())
+                    .toList();
+        }
+
+        public List<Path> testRoots() {
+            return modules.stream()
+                    .flatMap(module -> module.testRoots().stream())
+                    .toList();
+        }
+
+        public List<Path> resourceRoots() {
+            return modules.stream()
+                    .flatMap(module -> module.resourceRoots().stream())
+                    .toList();
+        }
+
+        public List<Path> classesDirs() {
+            return modules.stream()
+                    .flatMap(module -> module.classesDirs().stream())
+                    .toList();
+        }
+
+        public static NormalizedExtractionContext empty() {
+            return new NormalizedExtractionContext(
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
+    }
+
+    public record ModuleNormalizedContext(
+            String moduleName,
+            List<Path> sourceRoots,
+            List<Path> testRoots,
+            List<Path> resourceRoots,
+            List<Path> classesDirs
+    ) {
+        public ModuleNormalizedContext {
+            sourceRoots = sourceRoots == null ? List.of() : List.copyOf(sourceRoots);
+            testRoots = testRoots == null ? List.of() : List.copyOf(testRoots);
+            resourceRoots = resourceRoots == null ? List.of() : List.copyOf(resourceRoots);
+            classesDirs = classesDirs == null ? List.of() : List.copyOf(classesDirs);
+        }
+
+        public boolean hasAnyJavaRoots() {
+            return !sourceRoots.isEmpty() || !testRoots.isEmpty();
+        }
+
+        public boolean hasAnyClassesDirs() {
+            return !classesDirs.isEmpty();
+        }
+
+        public static ModuleNormalizedContext empty(String moduleName) {
+            return new ModuleNormalizedContext(
+                    moduleName,
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/EvidenceIdGenerator.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/EvidenceIdGenerator.java
@@ -1,0 +1,40 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import com.example.ossdoc.domain.extraction.dto.model.SourceSpan;
+import com.example.ossdoc.domain.extraction.enums.EvidenceKind;
+
+import java.util.Objects;
+
+/**
+ * evidence id를 결정적으로 생성
+ */
+public final class EvidenceIdGenerator {
+
+    private EvidenceIdGenerator() {
+    }
+
+    public static String generate(EvidenceKind kind, String path, SourceSpan span, String symbol) {
+        Objects.requireNonNull(kind, "kind must not be null");
+
+        String normalizedPath = RepoPathUtils.normalizeSeparators(path);
+        String key = String.join("|",
+                "kind=" + kind.code(),
+                "path=" + nullToEmpty(normalizedPath),
+                "startLine=" + valueOf(span == null ? null : span.startLine()),
+                "startCol=" + valueOf(span == null ? null : span.startCol()),
+                "endLine=" + valueOf(span == null ? null : span.endLine()),
+                "endCol=" + valueOf(span == null ? null : span.endCol()),
+                "symbol=" + nullToEmpty(symbol)
+        );
+
+        return "ev_" + HashSupport.sha256Hex(key).substring(0, 16);
+    }
+
+    private static String valueOf(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/ExtractionClock.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/ExtractionClock.java
@@ -1,0 +1,28 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * 테스트 가능하게 분리한 시간 공급자
+ */
+@Component
+public class ExtractionClock {
+
+    private final Clock clock;
+
+    public ExtractionClock() {
+        this(Clock.systemUTC());
+    }
+
+    public ExtractionClock(Clock clock) {
+        this.clock = Objects.requireNonNull(clock);
+    }
+
+    public OffsetDateTime now() {
+        return OffsetDateTime.now(clock);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/FactsSchema.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/FactsSchema.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+/**
+ * facts.json 관련 고정 상수
+ */
+public final class FactsSchema {
+
+    public static final String SCHEMA_VERSION = "0.1";
+    public static final String FACTS_FILE_NAME = "facts.json";
+    public static final String FACTS_SHA256_FILE_NAME = "facts.json.sha256";
+
+    private FactsSchema() {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/HashSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/HashSupport.java
@@ -1,0 +1,55 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+
+/**
+ * sha-256 해시 유틸
+ */
+public final class HashSupport {
+
+    private static final int BUFFER_SIZE = 8192;
+
+    private HashSupport() {
+    }
+
+    public static String sha256Hex(String value) {
+        Objects.requireNonNull(value, "value must not be null");
+        return digest(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String sha256Hex(Path file) throws IOException {
+        Objects.requireNonNull(file, "file must not be null");
+
+        MessageDigest digest = newDigest();
+        try (InputStream in = Files.newInputStream(file)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static String digest(byte[] bytes) {
+        MessageDigest digest = newDigest();
+        digest.update(bytes);
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/RelationResolutionFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/RelationResolutionFactory.java
@@ -1,0 +1,33 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import com.example.ossdoc.domain.extraction.dto.model.RelationResolution;
+import com.example.ossdoc.domain.extraction.enums.ResolutionStatus;
+
+/**
+ * relation resolution 생성 보조 유틸
+ */
+public final class RelationResolutionFactory {
+
+    private RelationResolutionFactory() {
+    }
+
+    public static RelationResolution resolved() {
+        return RelationResolution.builder()
+                .status(ResolutionStatus.RESOLVED)
+                .build();
+    }
+
+    public static RelationResolution partial(String reason) {
+        return RelationResolution.builder()
+                .status(ResolutionStatus.PARTIAL)
+                .reason(reason)
+                .build();
+    }
+
+    public static RelationResolution unresolved(String reason) {
+        return RelationResolution.builder()
+                .status(ResolutionStatus.UNRESOLVED)
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/RepoPathUtils.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/RepoPathUtils.java
@@ -1,0 +1,40 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * repo 상대경로/경로 문자열 정규화 유틸
+ */
+public final class RepoPathUtils {
+
+    private RepoPathUtils() {
+    }
+
+    public static String toRepoRelative(Path repoRoot, Path target) {
+        Objects.requireNonNull(repoRoot, "repoRoot must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+
+        Path normalizedRoot = repoRoot.normalize();
+        Path normalizedTarget = target.normalize();
+
+        String value = normalizedTarget.startsWith(normalizedRoot)
+                ? normalizedRoot.relativize(normalizedTarget).toString()
+                : normalizedTarget.toString();
+
+        return normalizeSeparators(value);
+    }
+
+    public static String normalizeSeparators(String path) {
+        if (path == null || path.isBlank()) {
+            return path;
+        }
+        return path.replace('\\', '/');
+    }
+
+    public static String fileName(Path path) {
+        Objects.requireNonNull(path, "path must not be null");
+        Path fileName = path.getFileName();
+        return fileName == null ? "" : fileName.toString();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/SymbolIdFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/SymbolIdFactory.java
@@ -1,0 +1,87 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import com.example.ossdoc.domain.extraction.dto.model.SignatureFact;
+import com.example.ossdoc.domain.extraction.dto.model.TypeRef;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * facts 단계용 symbol id 생성 규칙
+ */
+public final class SymbolIdFactory {
+
+    private SymbolIdFactory() {
+    }
+
+    public static String module(String moduleName) {
+        return "module:" + requireText(moduleName, "moduleName");
+    }
+
+    public static String packageSymbol(String packageName) {
+        return "package:" + requireText(packageName, "packageName");
+    }
+
+    public static String type(String qualifiedName) {
+        return "type:" + requireText(qualifiedName, "qualifiedName");
+    }
+
+    public static String field(String ownerTypeQualifiedName, String fieldName) {
+        return "field:" + requireText(ownerTypeQualifiedName, "ownerTypeQualifiedName")
+                + "#" + requireText(fieldName, "fieldName");
+    }
+
+    public static String constructor(String ownerTypeQualifiedName, SignatureFact signature) {
+        return "ctor:" + requireText(ownerTypeQualifiedName, "ownerTypeQualifiedName")
+                + "#<init>(" + renderParams(signature) + ")";
+    }
+
+    public static String method(String ownerTypeQualifiedName, String methodName, SignatureFact signature) {
+        return "method:" + requireText(ownerTypeQualifiedName, "ownerTypeQualifiedName")
+                + "#" + requireText(methodName, "methodName")
+                + "(" + renderParams(signature) + ")";
+    }
+
+    private static String renderParams(SignatureFact signature) {
+        if (signature == null || signature.params() == null || signature.params().isEmpty()) {
+            return "";
+        }
+
+        return signature.params().stream()
+                .map(SymbolIdFactory::renderTypeRef)
+                .collect(Collectors.joining(","));
+    }
+
+    private static String renderTypeRef(TypeRef typeRef) {
+        if (typeRef == null) {
+            return "?";
+        }
+
+        String base = firstNonBlank(typeRef.raw(), typeRef.sourceText(), "?");
+        int arrayDim = typeRef.arrayDim() == null ? 0 : Math.max(0, typeRef.arrayDim());
+
+        if (arrayDim == 0) {
+            return base;
+        }
+
+        return base + "[]".repeat(arrayDim);
+    }
+
+    private static String requireText(String value, String fieldName) {
+        Objects.requireNonNull(value, fieldName + " must not be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/TypeRefFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/TypeRefFactory.java
@@ -1,0 +1,85 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import com.example.ossdoc.domain.extraction.dto.model.TypeRef;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * TypeRef 생성 보조 유틸
+ */
+public final class TypeRefFactory {
+
+    private static final Set<String> PRIMITIVES = Set.of(
+            "byte", "short", "int", "long", "float", "double", "boolean", "char", "void"
+    );
+
+    private TypeRefFactory() {
+    }
+
+    public static TypeRef simple(String raw) {
+        String normalized = requireRaw(raw);
+        return TypeRef.builder()
+                .raw(normalized)
+                .args(List.of())
+                .arrayDim(0)
+                .primitive(isPrimitiveName(normalized))
+                .unresolved(false)
+                .build();
+    }
+
+    public static TypeRef unresolved(String raw, String sourceText) {
+        String normalized = requireRaw(raw);
+        return TypeRef.builder()
+                .raw(normalized)
+                .args(List.of())
+                .arrayDim(0)
+                .primitive(isPrimitiveName(normalized))
+                .unresolved(true)
+                .sourceText(sourceText)
+                .build();
+    }
+
+    public static TypeRef parameterized(String raw, List<TypeRef> args, String sourceText) {
+        String normalized = requireRaw(raw);
+        return TypeRef.builder()
+                .raw(normalized)
+                .args(args == null ? List.of() : List.copyOf(args))
+                .arrayDim(0)
+                .primitive(isPrimitiveName(normalized))
+                .unresolved(false)
+                .sourceText(sourceText)
+                .build();
+    }
+
+    public static TypeRef arrayOf(TypeRef baseType, int additionalDimensions) {
+        Objects.requireNonNull(baseType, "baseType must not be null");
+        if (additionalDimensions < 1) {
+            throw new IllegalArgumentException("additionalDimensions must be >= 1");
+        }
+
+        int current = baseType.arrayDim() == null ? 0 : Math.max(0, baseType.arrayDim());
+
+        return TypeRef.builder()
+                .raw(baseType.raw())
+                .args(baseType.args() == null ? List.of() : List.copyOf(baseType.args()))
+                .arrayDim(current + additionalDimensions)
+                .primitive(Boolean.TRUE.equals(baseType.primitive()))
+                .unresolved(Boolean.TRUE.equals(baseType.unresolved()))
+                .sourceText(baseType.sourceText())
+                .build();
+    }
+
+    public static boolean isPrimitiveName(String raw) {
+        return raw != null && PRIMITIVES.contains(raw);
+    }
+
+    private static String requireRaw(String raw) {
+        Objects.requireNonNull(raw, "raw must not be null");
+        if (raw.isBlank()) {
+            throw new IllegalArgumentException("raw must not be blank");
+        }
+        return raw;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/WarningCollector.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/support/util/WarningCollector.java
@@ -1,0 +1,38 @@
+package com.example.ossdoc.domain.extraction.service.support.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * warnings 중복 제거 + 순서 보존
+ */
+public class WarningCollector {
+
+    private final Set<String> warnings = new LinkedHashSet<>();
+
+    public void add(String warning) {
+        if (warning == null || warning.isBlank()) {
+            return;
+        }
+        warnings.add(warning);
+    }
+
+    public void addAll(List<String> warningList) {
+        if (warningList == null || warningList.isEmpty()) {
+            return;
+        }
+        for (String warning : warningList) {
+            add(warning);
+        }
+    }
+
+    public boolean isEmpty() {
+        return warnings.isEmpty();
+    }
+
+    public List<String> snapshot() {
+        return new ArrayList<>(warnings);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/writer/DefaultFactsWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/writer/DefaultFactsWriter.java
@@ -1,0 +1,121 @@
+package com.example.ossdoc.domain.extraction.service.writer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsWriteContext;
+
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+import com.example.ossdoc.domain.extraction.exception.ExtractionErrorCode;
+import com.example.ossdoc.domain.extraction.exception.ExtractionException;
+import com.example.ossdoc.domain.extraction.service.support.util.FactsSchema;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * writer 기본 구현
+ *
+ * 책임:
+ * - facts.json S3 업로드
+ * - FactsExtractResponse 생성
+ */
+@Slf4j
+@Component
+public class DefaultFactsWriter implements FactsWriter {
+
+    private final FactsResponseFactory responseFactory;
+    private final ObjectMapper objectMapper;
+    private final RepoRunRepository repoRunRepository;
+    private final ArtifactService artifactService;
+
+    public DefaultFactsWriter(
+            FactsResponseFactory responseFactory,
+            ObjectMapper objectMapper,
+            RepoRunRepository repoRunRepository,
+            ArtifactService artifactService
+    ) {
+        this.responseFactory = Objects.requireNonNull(responseFactory, "responseFactory must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.repoRunRepository = Objects.requireNonNull(repoRunRepository, "repoRunRepository must not be null");
+        this.artifactService = Objects.requireNonNull(artifactService, "artifactService must not be null");
+    }
+
+    @Override
+    public FactsExtractResponse writeAndBuildResponse(FactsWriteContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        validateDocument(context.document());
+        saveToLocal(context);
+        uploadToS3(context);
+        return responseFactory.create(context);
+    }
+
+    private void validateDocument(FactsDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
+
+        if (document.schemaVersion() == null || document.schemaVersion().isBlank()) {
+            throw new IllegalArgumentException("FactsDocument.schemaVersion must not be blank");
+        }
+        if (document.job() == null) {
+            throw new IllegalArgumentException("FactsDocument.job must not be null");
+        }
+        if (document.build() == null) {
+            throw new IllegalArgumentException("FactsDocument.build must not be null");
+        }
+        if (document.extraction() == null) {
+            throw new IllegalArgumentException("FactsDocument.extraction must not be null");
+        }
+        if (document.stats() == null) {
+            throw new IllegalArgumentException("FactsDocument.stats must not be null");
+        }
+        if (document.evidence() == null) {
+            throw new IllegalArgumentException("FactsDocument.evidence must not be null");
+        }
+        if (document.symbols() == null) {
+            throw new IllegalArgumentException("FactsDocument.symbols must not be null");
+        }
+        if (document.relations() == null) {
+            throw new IllegalArgumentException("FactsDocument.relations must not be null");
+        }
+        if (document.observations() == null) {
+            throw new IllegalArgumentException("FactsDocument.observations must not be null");
+        }
+    }
+
+    private void saveToLocal(FactsWriteContext context) {
+        Path artifactsDir = context.artifactsRoot();
+        try {
+            Files.createDirectories(artifactsDir);
+            Path out = artifactsDir.resolve(FactsSchema.FACTS_FILE_NAME);
+            objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValue(out.toFile(), context.document());
+            log.info("[EXTRACTION] facts.json 로컬 저장 완료: {}", out);
+        } catch (Exception e) {
+            log.warn("[EXTRACTION] facts.json 로컬 저장 실패 (S3 업로드는 계속 진행): {}", e.getMessage());
+        }
+    }
+
+    private void uploadToS3(FactsWriteContext context) {
+        RepoRun run = repoRunRepository.findById(context.runId())
+                .orElseThrow(() -> new ExtractionException(ExtractionErrorCode.RUN_NOT_FOUND));
+        JsonNode jsonNode = objectMapper.valueToTree(context.document());
+        artifactService.saveJsonArtifact(
+                run,
+                ArtifactKind.FACTS_JSON,
+                resolveSchemaVersion(context.document()),
+                FactsSchema.FACTS_FILE_NAME,
+                jsonNode
+        );
+    }
+
+    private String resolveSchemaVersion(FactsDocument document) {
+        String v = document.schemaVersion();
+        return (v == null || v.isBlank()) ? FactsSchema.SCHEMA_VERSION : v;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/writer/FactsResponseFactory.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/writer/FactsResponseFactory.java
@@ -1,0 +1,81 @@
+package com.example.ossdoc.domain.extraction.service.writer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsWriteContext;
+
+import com.example.ossdoc.domain.extraction.dto.model.ExtractionMeta;
+import com.example.ossdoc.domain.extraction.dto.model.FactsDocument;
+import com.example.ossdoc.domain.extraction.dto.model.StatsMeta;
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+import com.example.ossdoc.domain.extraction.enums.BytecodeAvailability;
+import com.example.ossdoc.domain.extraction.enums.ExtractionMode;
+import com.example.ossdoc.domain.extraction.service.support.util.FactsSchema;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * writer 결과를 API 응답 dto로 변환한다.
+ */
+@Component
+public class FactsResponseFactory {
+
+    public FactsExtractResponse create(FactsWriteContext context) {
+        FactsDocument document = context.document();
+        ExtractionMeta extraction = document.extraction();
+
+        return FactsExtractResponse.builder()
+                .runId(context.runId())
+                .mode(resolveMode(extraction))
+                .bytecodeAvailability(resolveBytecodeAvailability(extraction))
+                .schemaVersion(resolveSchemaVersion(document))
+                .scannedModules(resolveScannedModules(extraction))
+                .stats(resolveStats(document))
+                .warnings(mergeWarnings(context.additionalWarnings(), extraction == null ? null : extraction.warnings()))
+                .build();
+    }
+
+    private String resolveSchemaVersion(FactsDocument document) {
+        String v = document == null ? null : document.schemaVersion();
+        return (v == null || v.isBlank()) ? FactsSchema.SCHEMA_VERSION : v;
+    }
+
+    private ExtractionMode resolveMode(ExtractionMeta extraction) {
+        return extraction == null ? null : extraction.mode();
+    }
+
+    private BytecodeAvailability resolveBytecodeAvailability(ExtractionMeta extraction) {
+        return extraction == null ? null : extraction.bytecodeAvailability();
+    }
+
+    private List<String> resolveScannedModules(ExtractionMeta extraction) {
+        if (extraction == null || extraction.scannedModules() == null) {
+            return List.of();
+        }
+        return List.copyOf(extraction.scannedModules());
+    }
+
+    private StatsMeta resolveStats(FactsDocument document) {
+        return document == null ? null : document.stats();
+    }
+
+    private List<String> mergeWarnings(List<String> additionalWarnings, List<String> extractionWarnings) {
+        Set<String> merged = new LinkedHashSet<>();
+        addWarnings(merged, additionalWarnings);
+        addWarnings(merged, extractionWarnings);
+        return new ArrayList<>(merged);
+    }
+
+    private void addWarnings(Set<String> target, List<String> warnings) {
+        if (warnings == null || warnings.isEmpty()) {
+            return;
+        }
+        for (String warning : warnings) {
+            if (warning == null || warning.isBlank()) {
+                continue;
+            }
+            target.add(warning);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/extraction/service/writer/FactsWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/extraction/service/writer/FactsWriter.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.extraction.service.writer;
+import com.example.ossdoc.domain.extraction.dto.context.FactsWriteContext;
+
+import com.example.ossdoc.domain.extraction.dto.response.FactsExtractResponse;
+
+/**
+ * facts.json writer 진입점
+ *
+ * 외부에서는 writer에게 "S3 업로드 + 응답 생성"까지 한 번에 맡긴다.
+ */
+public interface FactsWriter {
+
+    FactsExtractResponse writeAndBuildResponse(FactsWriteContext context);
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/controller/GraphStoreController.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/controller/GraphStoreController.java
@@ -1,0 +1,33 @@
+package com.example.ossdoc.domain.graphstore.controller;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestRequest;
+import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestResponse;
+import com.example.ossdoc.domain.graphstore.service.GraphStoreIngestService;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/graphstore")
+public class GraphStoreController {
+
+    private final GraphStoreIngestService graphStoreIngestService;
+
+    @PostMapping("/ingest")
+    public ApiResponse<GraphStoreIngestResponse> ingest(@Valid @RequestBody GraphStoreIngestRequest request, @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
+
+        GraphStoreIngestResponse response =
+                graphStoreIngestService.ingest(request, authenticatedUser.getUserId());
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEdgeConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEdgeConverter.java
@@ -1,6 +1,6 @@
 package com.example.ossdoc.domain.graphstore.converter;
 
-import com.example.ossdoc.domain.graphstore.dto.facts.RelationFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedRelationFact;
 import com.example.ossdoc.domain.graphstore.entity.Edge;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
 import com.example.ossdoc.domain.graphstore.enums.EdgeType;
@@ -14,40 +14,48 @@ import org.springframework.stereotype.Component;
 @Component
 public class FactsEdgeConverter {
 
-    public Edge toEntity(RepoRun run, RelationFactDto dto, SymbolEntity fromSymbol, SymbolEntity toSymbol) {
+    public Edge toEntity(RepoRun run, NormalizedRelationFact dto, SymbolEntity fromSymbol, SymbolEntity toSymbol) {
         JsonNode toRawRef = resolveToRawRef(dto, toSymbol);
         ResolutionStatus resolutionStatus = resolveResolution(dto, toSymbol);
 
         return new Edge(
                 null,
                 run,
-                toEdgeType(dto.getKind()),
+                toEdgeType(dto.kind()),
                 fromSymbol,
                 toSymbol,
                 toRawRef,
-                toOriginKind(dto.getOrigin()),
+                toOriginKind(dto.origin()),
                 resolutionStatus,
-                dto.getConfidenceHint()
+                dto.confidenceHint()
         );
     }
 
-    private JsonNode resolveToRawRef(RelationFactDto dto, SymbolEntity toSymbol) {
-        if (toSymbol != null) return null;
-        if (dto.getDstTypeRef() != null && !dto.getDstTypeRef().isNull()) {
-            return dto.getDstTypeRef();
+    private JsonNode resolveToRawRef(NormalizedRelationFact dto, SymbolEntity toSymbol) {
+        if (toSymbol != null) {
+            return null;
         }
-        if (dto.getDstSymbol() != null && !dto.getDstSymbol().isBlank()) {
+
+        if (dto.dstRawRef() != null && !dto.dstRawRef().isBlank()) {
             var node = JsonNodeFactory.instance.objectNode();
-            node.put("raw", dto.getDstSymbol());
+            node.put("raw", dto.dstRawRef());
             node.put("unresolved", true);
             return node;
         }
+
+        if (dto.dstSymbol() != null && !dto.dstSymbol().isBlank()) {
+            var node = JsonNodeFactory.instance.objectNode();
+            node.put("raw", dto.dstSymbol());
+            node.put("unresolved", true);
+            return node;
+        }
+
         return null;
     }
 
-    private ResolutionStatus resolveResolution(RelationFactDto dto, SymbolEntity toSymbol) {
-        if (dto.getResolution() != null) {
-            return switch (dto.getResolution().trim().toUpperCase()) {
+    private ResolutionStatus resolveResolution(NormalizedRelationFact dto, SymbolEntity toSymbol) {
+        if (dto.resolutionStatus() != null) {
+            return switch (dto.resolutionStatus().trim().toUpperCase()) {
                 case "PARTIAL" -> ResolutionStatus.PARTIAL;
                 case "UNRESOLVED" -> ResolutionStatus.UNRESOLVED;
                 default -> ResolutionStatus.RESOLVED;
@@ -62,11 +70,13 @@ public class FactsEdgeConverter {
             case "CONTAINS" -> EdgeType.CONTAINS;
             case "EXTENDS" -> EdgeType.EXTENDS;
             case "IMPLEMENTS" -> EdgeType.IMPLEMENTS;
+            case "OVERRIDES" -> EdgeType.OVERRIDES;
+            case "ACCESSES_FIELD" -> EdgeType.ACCESSES_FIELD;
             case "HAS_FIELD", "FIELD_TYPE" -> EdgeType.HAS_FIELD;
             case "PARAM", "PARAM_TYPE" -> EdgeType.PARAM;
             case "RETURNS", "RETURN_TYPE" -> EdgeType.RETURNS;
             case "THROWS", "THROWS_TYPE" -> EdgeType.THROWS;
-            case "ANNOTATED_WITH" -> EdgeType.ANNOTATED_WITH;
+            case "ANNOTATED_WITH", "ANNOTATED_BY" -> EdgeType.ANNOTATED_WITH;
             default -> EdgeType.CALLS;
         };
     }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEdgeConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEdgeConverter.java
@@ -1,0 +1,83 @@
+package com.example.ossdoc.domain.graphstore.converter;
+
+import com.example.ossdoc.domain.graphstore.dto.facts.RelationFactDto;
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.EdgeType;
+import com.example.ossdoc.domain.graphstore.enums.OriginKind;
+import com.example.ossdoc.domain.graphstore.enums.ResolutionStatus;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FactsEdgeConverter {
+
+    public Edge toEntity(RepoRun run, RelationFactDto dto, SymbolEntity fromSymbol, SymbolEntity toSymbol) {
+        JsonNode toRawRef = resolveToRawRef(dto, toSymbol);
+        ResolutionStatus resolutionStatus = resolveResolution(dto, toSymbol);
+
+        return new Edge(
+                null,
+                run,
+                toEdgeType(dto.getKind()),
+                fromSymbol,
+                toSymbol,
+                toRawRef,
+                toOriginKind(dto.getOrigin()),
+                resolutionStatus,
+                dto.getConfidenceHint()
+        );
+    }
+
+    private JsonNode resolveToRawRef(RelationFactDto dto, SymbolEntity toSymbol) {
+        if (toSymbol != null) return null;
+        if (dto.getDstTypeRef() != null && !dto.getDstTypeRef().isNull()) {
+            return dto.getDstTypeRef();
+        }
+        if (dto.getDstSymbol() != null && !dto.getDstSymbol().isBlank()) {
+            var node = JsonNodeFactory.instance.objectNode();
+            node.put("raw", dto.getDstSymbol());
+            node.put("unresolved", true);
+            return node;
+        }
+        return null;
+    }
+
+    private ResolutionStatus resolveResolution(RelationFactDto dto, SymbolEntity toSymbol) {
+        if (dto.getResolution() != null) {
+            return switch (dto.getResolution().trim().toUpperCase()) {
+                case "PARTIAL" -> ResolutionStatus.PARTIAL;
+                case "UNRESOLVED" -> ResolutionStatus.UNRESOLVED;
+                default -> ResolutionStatus.RESOLVED;
+            };
+        }
+        return toSymbol == null ? ResolutionStatus.UNRESOLVED : ResolutionStatus.RESOLVED;
+    }
+
+    private EdgeType toEdgeType(String value) {
+        if (value == null) return EdgeType.CALLS;
+        return switch (value.trim().toUpperCase()) {
+            case "CONTAINS" -> EdgeType.CONTAINS;
+            case "EXTENDS" -> EdgeType.EXTENDS;
+            case "IMPLEMENTS" -> EdgeType.IMPLEMENTS;
+            case "HAS_FIELD", "FIELD_TYPE" -> EdgeType.HAS_FIELD;
+            case "PARAM", "PARAM_TYPE" -> EdgeType.PARAM;
+            case "RETURNS", "RETURN_TYPE" -> EdgeType.RETURNS;
+            case "THROWS", "THROWS_TYPE" -> EdgeType.THROWS;
+            case "ANNOTATED_WITH" -> EdgeType.ANNOTATED_WITH;
+            default -> EdgeType.CALLS;
+        };
+    }
+
+    private OriginKind toOriginKind(String value) {
+        if (value == null) return OriginKind.AST;
+        return switch (value.trim().toUpperCase()) {
+            case "BYTECODE" -> OriginKind.BYTECODE;
+            case "MERGED" -> OriginKind.MERGED;
+            case "CONTRACT" -> OriginKind.CONTRACT;
+            default -> OriginKind.AST;
+        };
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEvidenceConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEvidenceConverter.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.domain.graphstore.converter;
+
+import com.example.ossdoc.domain.graphstore.dto.facts.EvidenceFactDto;
+import com.example.ossdoc.domain.graphstore.entity.Evidence;
+import com.example.ossdoc.domain.graphstore.enums.EvidenceType;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FactsEvidenceConverter {
+
+    public Evidence toEntity(RepoRun run, EvidenceFactDto dto) {
+        return new Evidence(
+                null,
+                run,
+                toEvidenceType(dto.getType()),
+                null, // FileIndex 연동 전이라 null
+                dto.getStartLine(),
+                dto.getEndLine(),
+                dto.getSnippet(),
+                dto.getHash()
+        );
+    }
+
+    private EvidenceType toEvidenceType(String value) {
+        if (value == null) return EvidenceType.AST;
+        return switch (value.trim().toUpperCase()) {
+            case "BYTECODE" -> EvidenceType.BYTECODE;
+            case "RESOURCE" -> EvidenceType.RESOURCE;
+            case "README" -> EvidenceType.README;
+            case "TEST" -> EvidenceType.TEST;
+            case "SQL" -> EvidenceType.SQL;
+            default -> EvidenceType.AST;
+        };
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEvidenceConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsEvidenceConverter.java
@@ -1,6 +1,6 @@
 package com.example.ossdoc.domain.graphstore.converter;
 
-import com.example.ossdoc.domain.graphstore.dto.facts.EvidenceFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedEvidenceFact;
 import com.example.ossdoc.domain.graphstore.entity.Evidence;
 import com.example.ossdoc.domain.graphstore.enums.EvidenceType;
 import com.example.ossdoc.domain.run.entity.RepoRun;
@@ -9,16 +9,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class FactsEvidenceConverter {
 
-    public Evidence toEntity(RepoRun run, EvidenceFactDto dto) {
+    public Evidence toEntity(RepoRun run, NormalizedEvidenceFact dto) {
         return new Evidence(
                 null,
                 run,
-                toEvidenceType(dto.getType()),
+                toEvidenceType(dto.type()),
                 null, // FileIndex 연동 전이라 null
-                dto.getStartLine(),
-                dto.getEndLine(),
-                dto.getSnippet(),
-                dto.getHash()
+                dto.startLine(),
+                dto.endLine(),
+                dto.snippet(),
+                dto.hash()
         );
     }
 

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsSymbolConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsSymbolConverter.java
@@ -1,6 +1,6 @@
 package com.example.ossdoc.domain.graphstore.converter;
 
-import com.example.ossdoc.domain.graphstore.dto.facts.SymbolFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedSymbolFact;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
 import com.example.ossdoc.domain.graphstore.enums.AccessLevel;
 import com.example.ossdoc.domain.graphstore.enums.OriginKind;
@@ -8,13 +8,12 @@ import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FactsSymbolConverter {
 
-    public SymbolEntity toEntity(String symbolId, RepoRun run, SymbolFactDto dto) {
+    public SymbolEntity toEntity(String symbolId, RepoRun run, NormalizedSymbolFact dto) {
         JsonNode modifiers = buildModifiers(dto);
         JsonNode signature = buildSignature(dto);
 
@@ -22,40 +21,40 @@ public class FactsSymbolConverter {
                 symbolId,
                 run,
                 null, // module 미연동
-                toSymbolKind(dto.getKind()),
-                dto.getSymbol(),
+                toSymbolKind(dto.kind()),
+                dto.symbol(),
                 resolveSimpleName(dto),
-                toAccessLevel(dto.getAccess()),
+                toAccessLevel(dto.access()),
                 modifiers,
                 null, // owner는 2차 연결
                 signature,
-                null, // sourceFile 미연동
+                null, // sourceFile은 FileIndex 타입이라 현재는 null
                 null,
                 null,
-                toOriginKind(dto.getOrigin())
+                toOriginKind(dto.origin())
         );
     }
 
-    private JsonNode buildModifiers(SymbolFactDto dto) {
+    private JsonNode buildModifiers(NormalizedSymbolFact dto) {
         var array = JsonNodeFactory.instance.arrayNode();
-        if (dto.getModifiers() != null) {
-            dto.getModifiers().forEach(array::add);
+        if (dto.modifiers() != null) {
+            dto.modifiers().forEach(array::add);
         }
         return array;
     }
 
-    private JsonNode buildSignature(SymbolFactDto dto) {
-        if (dto.getSignature() != null && !dto.getSignature().isNull()) {
-            return dto.getSignature();
+    private JsonNode buildSignature(NormalizedSymbolFact dto) {
+        if (dto.signature() != null && !dto.signature().isNull()) {
+            return dto.signature();
         }
         return JsonNodeFactory.instance.objectNode();
     }
 
-    private String resolveSimpleName(SymbolFactDto dto) {
-        if (dto.getName() != null && !dto.getName().isBlank()) {
-            return dto.getName();
+    private String resolveSimpleName(NormalizedSymbolFact dto) {
+        if (dto.name() != null && !dto.name().isBlank()) {
+            return dto.name();
         }
-        String symbol = dto.getSymbol();
+        String symbol = dto.symbol();
         if (symbol == null || symbol.isBlank()) return null;
         int idx = Math.max(symbol.lastIndexOf('.'), symbol.lastIndexOf('#'));
         return idx >= 0 ? symbol.substring(idx + 1) : symbol;
@@ -66,6 +65,7 @@ public class FactsSymbolConverter {
         return switch (value.trim().toUpperCase()) {
             case "MODULE" -> SymbolKind.MODULE;
             case "PACKAGE" -> SymbolKind.PACKAGE;
+            case "CONSTRUCTOR" -> SymbolKind.CONSTRUCTOR;
             case "METHOD" -> SymbolKind.METHOD;
             case "FIELD" -> SymbolKind.FIELD;
             default -> SymbolKind.TYPE;

--- a/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsSymbolConverter.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/converter/FactsSymbolConverter.java
@@ -1,0 +1,95 @@
+package com.example.ossdoc.domain.graphstore.converter;
+
+import com.example.ossdoc.domain.graphstore.dto.facts.SymbolFactDto;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.AccessLevel;
+import com.example.ossdoc.domain.graphstore.enums.OriginKind;
+import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FactsSymbolConverter {
+
+    public SymbolEntity toEntity(String symbolId, RepoRun run, SymbolFactDto dto) {
+        JsonNode modifiers = buildModifiers(dto);
+        JsonNode signature = buildSignature(dto);
+
+        return new SymbolEntity(
+                symbolId,
+                run,
+                null, // module 미연동
+                toSymbolKind(dto.getKind()),
+                dto.getSymbol(),
+                resolveSimpleName(dto),
+                toAccessLevel(dto.getAccess()),
+                modifiers,
+                null, // owner는 2차 연결
+                signature,
+                null, // sourceFile 미연동
+                null,
+                null,
+                toOriginKind(dto.getOrigin())
+        );
+    }
+
+    private JsonNode buildModifiers(SymbolFactDto dto) {
+        var array = JsonNodeFactory.instance.arrayNode();
+        if (dto.getModifiers() != null) {
+            dto.getModifiers().forEach(array::add);
+        }
+        return array;
+    }
+
+    private JsonNode buildSignature(SymbolFactDto dto) {
+        if (dto.getSignature() != null && !dto.getSignature().isNull()) {
+            return dto.getSignature();
+        }
+        return JsonNodeFactory.instance.objectNode();
+    }
+
+    private String resolveSimpleName(SymbolFactDto dto) {
+        if (dto.getName() != null && !dto.getName().isBlank()) {
+            return dto.getName();
+        }
+        String symbol = dto.getSymbol();
+        if (symbol == null || symbol.isBlank()) return null;
+        int idx = Math.max(symbol.lastIndexOf('.'), symbol.lastIndexOf('#'));
+        return idx >= 0 ? symbol.substring(idx + 1) : symbol;
+    }
+
+    private SymbolKind toSymbolKind(String value) {
+        if (value == null) return SymbolKind.TYPE;
+        return switch (value.trim().toUpperCase()) {
+            case "MODULE" -> SymbolKind.MODULE;
+            case "PACKAGE" -> SymbolKind.PACKAGE;
+            case "METHOD" -> SymbolKind.METHOD;
+            case "FIELD" -> SymbolKind.FIELD;
+            default -> SymbolKind.TYPE;
+        };
+    }
+
+    private AccessLevel toAccessLevel(String value) {
+        if (value == null) return null;
+        return switch (value.trim().toLowerCase()) {
+            case "public" -> AccessLevel.PUBLIC;
+            case "protected" -> AccessLevel.PROTECTED;
+            case "package" -> AccessLevel.PACKAGE;
+            case "private" -> AccessLevel.PRIVATE;
+            default -> null;
+        };
+    }
+
+    private OriginKind toOriginKind(String value) {
+        if (value == null) return OriginKind.AST;
+        return switch (value.trim().toUpperCase()) {
+            case "BYTECODE" -> OriginKind.BYTECODE;
+            case "MERGED" -> OriginKind.MERGED;
+            case "CONTRACT" -> OriginKind.CONTRACT;
+            default -> OriginKind.AST;
+        };
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/GraphStoreIngestRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/GraphStoreIngestRequest.java
@@ -1,0 +1,11 @@
+package com.example.ossdoc.domain.graphstore.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class GraphStoreIngestRequest {
+    @NotBlank
+    private String runId;
+    private Long artifactId;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/GraphStoreIngestResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/GraphStoreIngestResponse.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.graphstore.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GraphStoreIngestResponse {
+    private String runId;
+    private Long artifactId;
+    private int evidencesSaved;
+    private int symbolsSaved;
+    private int edgesSaved;
+    private int edgeEvidenceSaved;
+    private int skippedRelations;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/EvidenceFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/EvidenceFactDto.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.graphstore.dto.facts;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EvidenceFactDto {
+
+    private String id;
+    private String type;
+    private String path;
+
+    @JsonProperty("start_line")
+    private Integer startLine;
+
+    @JsonProperty("end_line")
+    private Integer endLine;
+
+    private String symbol;
+    private String snippet;
+    private String hash;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/FactsDocumentDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/FactsDocumentDto.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.graphstore.dto.facts;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FactsDocumentDto {
+
+    @JsonProperty("schema_version")
+    private String schemaVersion;
+
+    private Map<String, EvidenceFactDto> evidence = new LinkedHashMap<>();
+
+    private List<SymbolFactDto> symbols = new ArrayList<>();
+
+    private List<RelationFactDto> relations = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/RelationFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/RelationFactDto.java
@@ -1,0 +1,38 @@
+package com.example.ossdoc.domain.graphstore.dto.facts;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RelationFactDto {
+
+    private String kind;
+
+    @JsonAlias({"src_symbol", "from_symbol"})
+    @JsonProperty("src_symbol")
+    private String srcSymbol;
+
+    @JsonAlias({"dst_symbol", "to_symbol"})
+    @JsonProperty("dst_symbol")
+    private String dstSymbol;
+
+    @JsonProperty("dst_type_ref")
+    private JsonNode dstTypeRef;
+
+    private String origin;
+    private String resolution;
+
+    @JsonProperty("confidence_hint")
+    private BigDecimal confidenceHint;
+
+    @JsonProperty("evidence_ids")
+    private List<String> evidenceIds = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/SymbolFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/SymbolFactDto.java
@@ -1,0 +1,33 @@
+package com.example.ossdoc.domain.graphstore.dto.facts;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SymbolFactDto {
+
+    private String symbol;
+    private String name;
+    private String kind;
+    private String access;
+    private List<String> modifiers = new ArrayList<>();
+    private String origin;
+
+    @JsonAlias({"owner_type_symbol", "ownerSymbol"})
+    @JsonProperty("owner_type_symbol")
+    private String ownerTypeSymbol;
+
+    @JsonProperty("source_file")
+    private String sourceFile;
+
+    @JsonProperty("evidence_ids")
+    private List<String> evidenceIds = new ArrayList<>();
+    private JsonNode signature; // facts가 signature를 직접 주면 사용, 아니면 빈 object로 저장
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedEvidenceFact.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedEvidenceFact.java
@@ -1,0 +1,15 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.normalized;
+
+public record NormalizedEvidenceFact(
+        String id,
+        String type,
+        String path,
+        Integer startLine,
+        Integer startCol,
+        Integer endLine,
+        Integer endCol,
+        String symbol,
+        String snippet,
+        String hash
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedFactsDocument.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedFactsDocument.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.normalized;
+
+import java.util.List;
+import java.util.Map;
+
+public record NormalizedFactsDocument(
+        String schemaVersion,
+        Map<String, NormalizedEvidenceFact> evidence,
+        List<NormalizedSymbolFact> symbols,
+        List<NormalizedRelationFact> relations
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedRelationFact.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedRelationFact.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.normalized;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record NormalizedRelationFact(
+        String kind,
+        String srcSymbol,
+        String dstSymbol,
+        String dstRawRef,
+        String origin,
+        String resolutionStatus,
+        String resolutionReason,
+        BigDecimal confidenceHint,
+        List<String> evidenceIds
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedSymbolFact.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/normalized/NormalizedSymbolFact.java
@@ -1,0 +1,22 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.normalized;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+public record NormalizedSymbolFact(
+        String symbol,
+        String name,
+        String kind,
+        String access,
+        List<String> modifiers,
+        String origin,
+        String qualifiedName,
+        String ownerTypeSymbol,
+        String packageSymbol,
+        String module,
+        String sourceFile,
+        List<String> evidenceIds,
+        JsonNode signature
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawEvidenceFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawEvidenceFactDto.java
@@ -1,0 +1,21 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawEvidenceFactDto {
+
+    private String id;
+    private String type;
+    private String path;
+    private RawSourceSpanDto span;
+    private String symbol;
+    private String snippet;
+    private String hash;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawFactsDocumentDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawFactsDocumentDto.java
@@ -1,0 +1,26 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawFactsDocumentDto {
+
+    @JsonProperty("schema_version")
+    private String schemaVersion;
+
+    private Map<String, RawEvidenceFactDto> evidence = new LinkedHashMap<>();
+
+    private RawSymbolTableDto symbols = new RawSymbolTableDto();
+
+    private RawRelationTableDto relations = new RawRelationTableDto();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationFactDto.java
@@ -1,0 +1,42 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawRelationFactDto {
+
+    private String kind;
+
+    @JsonAlias({"src_symbol", "from_symbol"})
+    @JsonProperty("src_symbol")
+    private String srcSymbol;
+
+    @JsonAlias({"dst_symbol", "to_symbol"})
+    @JsonProperty("dst_symbol")
+    private String dstSymbol;
+
+    @JsonProperty("dst_raw_ref")
+    private String dstRawRef;
+
+    private String origin;
+
+    private RawRelationResolutionDto resolution;
+
+    @JsonProperty("confidence_hint")
+    private BigDecimal confidenceHint;
+
+    @JsonProperty("evidence_ids")
+    private List<String> evidenceIds = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationResolutionDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationResolutionDto.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawRelationResolutionDto {
+
+    private String status;
+    private String reason;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationTableDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawRelationTableDto.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawRelationTableDto {
+
+    private List<RawRelationFactDto> contains = new ArrayList<>();
+
+    @JsonProperty("extends")
+    private List<RawRelationFactDto> extendsRelations = new ArrayList<>();
+
+    @JsonProperty("implements")
+    private List<RawRelationFactDto> implementsRelations = new ArrayList<>();
+
+    private List<RawRelationFactDto> overrides = new ArrayList<>();
+    private List<RawRelationFactDto> calls = new ArrayList<>();
+
+    @JsonProperty("accesses_field")
+    private List<RawRelationFactDto> accessesField = new ArrayList<>();
+
+    @JsonProperty("field_type")
+    private List<RawRelationFactDto> fieldType = new ArrayList<>();
+
+    @JsonProperty("param_type")
+    private List<RawRelationFactDto> paramType = new ArrayList<>();
+
+    @JsonProperty("return_type")
+    private List<RawRelationFactDto> returnType = new ArrayList<>();
+
+    @JsonProperty("throws_type")
+    private List<RawRelationFactDto> throwsType = new ArrayList<>();
+
+    @JsonProperty("annotated_by")
+    private List<RawRelationFactDto> annotatedBy = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSourceSpanDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSourceSpanDto.java
@@ -1,0 +1,26 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawSourceSpanDto {
+
+    @JsonProperty("start_line")
+    private Integer startLine;
+
+    @JsonProperty("start_col")
+    private Integer startCol;
+
+    @JsonProperty("end_line")
+    private Integer endLine;
+
+    @JsonProperty("end_col")
+    private Integer endCol;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSymbolFactDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSymbolFactDto.java
@@ -1,0 +1,47 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawSymbolFactDto {
+
+    private String symbol;
+    private String name;
+    private String kind;
+    private String access;
+    private String origin;
+
+    @JsonProperty("qualified_name")
+    private String qualifiedName;
+
+    @JsonAlias({"owner_type_symbol", "ownerSymbol"})
+    @JsonProperty("owner_type_symbol")
+    private String ownerTypeSymbol;
+
+    @JsonProperty("package_symbol")
+    private String packageSymbol;
+
+    private String module;
+
+    @JsonProperty("source_file")
+    private String sourceFile;
+
+    @JsonProperty("evidence_ids")
+    private List<String> evidenceIds = new ArrayList<>();
+
+    private List<String> modifiers = new ArrayList<>();
+
+    private JsonNode signature;
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSymbolTableDto.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/facts/raw/RawSymbolTableDto.java
@@ -1,0 +1,21 @@
+package com.example.ossdoc.domain.graphstore.dto.facts.raw;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawSymbolTableDto {
+
+    private List<RawSymbolFactDto> modules = new ArrayList<>();
+    private List<RawSymbolFactDto> packages = new ArrayList<>();
+    private List<RawSymbolFactDto> types = new ArrayList<>();
+    private List<RawSymbolFactDto> constructors = new ArrayList<>();
+    private List<RawSymbolFactDto> methods = new ArrayList<>();
+    private List<RawSymbolFactDto> fields = new ArrayList<>();
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/entity/SymbolEntity.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/entity/SymbolEntity.java
@@ -75,4 +75,13 @@ public class SymbolEntity extends BaseAuditedEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "origin", nullable = false)
     private OriginKind origin = OriginKind.AST;
+
+    public void assignOwner(SymbolEntity owner) {
+        this.owner = owner;
+    }
+
+    public void assignSourceSpan(Integer startLine, Integer endLine) {
+        this.sourceStartLine = startLine;
+        this.sourceEndLine = endLine;
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/enums/EdgeType.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/enums/EdgeType.java
@@ -1,7 +1,15 @@
 package com.example.ossdoc.domain.graphstore.enums;
 
 public enum EdgeType {
-    CONTAINS, EXTENDS, IMPLEMENTS,
-    HAS_FIELD, PARAM, RETURNS, THROWS,
-    CALLS, ANNOTATED_WITH
+    CONTAINS,
+    EXTENDS,
+    IMPLEMENTS,
+    OVERRIDES,
+    HAS_FIELD,
+    ACCESSES_FIELD,
+    PARAM,
+    RETURNS,
+    THROWS,
+    CALLS,
+    ANNOTATED_WITH
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/enums/SymbolKind.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/enums/SymbolKind.java
@@ -1,5 +1,10 @@
 package com.example.ossdoc.domain.graphstore.enums;
 
 public enum SymbolKind {
-    MODULE, PACKAGE, TYPE, METHOD, FIELD
+    MODULE,
+    PACKAGE,
+    TYPE,
+    CONSTRUCTOR,
+    METHOD,
+    FIELD
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/exception/GraphStoreException.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/exception/GraphStoreException.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.graphstore.exception;
+
+import com.example.ossdoc.domain.graphstore.exception.code.GraphStoreErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+import lombok.Getter;
+
+@Getter
+public class GraphStoreException extends GeneralException {
+
+    public GraphStoreException(GraphStoreErrorCode code) { super(code); }
+
+    public GraphStoreException(BaseCode code) { super(code); }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/exception/code/GraphStoreErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/exception/code/GraphStoreErrorCode.java
@@ -1,0 +1,41 @@
+package com.example.ossdoc.domain.graphstore.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GraphStoreErrorCode implements BaseCode {
+
+    RUN_NOT_FOUND(HttpStatus.NOT_FOUND, "GRAPH_404_001", "Repo run not found."),
+    RUN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GRAPH_403_001", "No permission to access this run."),
+    FACTS_ARTIFACT_NOT_FOUND(HttpStatus.NOT_FOUND, "GRAPH_404_002", "facts artifact not found."),
+    FACTS_READ_FAILED(HttpStatus.BAD_REQUEST, "GRAPH_400_001", "Failed to read facts artifact."),
+    INVALID_FACTS_SCHEMA(HttpStatus.BAD_REQUEST, "GRAPH_400_002", "Invalid facts schema.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeEvidenceRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeEvidenceRepository.java
@@ -1,0 +1,8 @@
+package com.example.ossdoc.domain.graphstore.repository;
+
+import com.example.ossdoc.domain.graphstore.entity.EdgeEvidence;
+import com.example.ossdoc.domain.graphstore.entity.EdgeEvidenceId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EdgeEvidenceRepository extends JpaRepository<EdgeEvidence, EdgeEvidenceId> {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
@@ -1,7 +1,24 @@
 package com.example.ossdoc.domain.graphstore.repository;
 
 import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.enums.EdgeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface EdgeRepository extends JpaRepository<Edge, Long> {
+
+    Optional<Edge> findFirstByRun_RunIdAndFromSymbol_SymbolIdAndTypeAndToSymbol_SymbolId(
+            String runId,
+            String fromSymbolId,
+            EdgeType type,
+            String toSymbolId
+    );
+
+    List<Edge> findByRun_RunIdAndFromSymbol_SymbolIdAndTypeAndToSymbolIsNull(
+            String runId,
+            String fromSymbolId,
+            EdgeType type
+    );
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
@@ -1,0 +1,7 @@
+package com.example.ossdoc.domain.graphstore.repository;
+
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EdgeRepository extends JpaRepository<Edge, Long> {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
@@ -1,7 +1,21 @@
 package com.example.ossdoc.domain.graphstore.repository;
 
 import com.example.ossdoc.domain.graphstore.entity.Evidence;
+import com.example.ossdoc.domain.graphstore.enums.EvidenceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface EvidenceRepository extends JpaRepository<Evidence, Long> {
+
+    Optional<Evidence> findFirstByRun_RunIdAndHash(String runId, String hash);
+
+    List<Evidence> findByRun_RunIdAndTypeAndStartLineAndEndLineAndSnippet(
+            String runId,
+            EvidenceType type,
+            Integer startLine,
+            Integer endLine,
+            String snippet
+    );
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
@@ -1,0 +1,7 @@
+package com.example.ossdoc.domain.graphstore.repository;
+
+import com.example.ossdoc.domain.graphstore.entity.Evidence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EvidenceRepository extends JpaRepository<Evidence, Long> {
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
@@ -1,0 +1,11 @@
+package com.example.ossdoc.domain.graphstore.repository;
+
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SymbolRepository extends JpaRepository<SymbolEntity, String> {
+
+    Optional<SymbolEntity> findByRun_RunIdAndQualifiedName(String runId, String qualifiedName);
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreFactsNormalizer.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreFactsNormalizer.java
@@ -1,0 +1,167 @@
+package com.example.ossdoc.domain.graphstore.service;
+
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedEvidenceFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedFactsDocument;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedRelationFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedSymbolFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawEvidenceFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawFactsDocumentDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawRelationFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawRelationResolutionDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawRelationTableDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawSourceSpanDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawSymbolFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawSymbolTableDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GraphStoreFactsNormalizer {
+
+    public NormalizedFactsDocument normalize(RawFactsDocumentDto raw) {
+        if (raw == null) {
+            return new NormalizedFactsDocument(null, Map.of(), List.of(), List.of());
+        }
+
+        return new NormalizedFactsDocument(
+                raw.getSchemaVersion(),
+                normalizeEvidence(raw.getEvidence()),
+                normalizeSymbols(raw.getSymbols()),
+                normalizeRelations(raw.getRelations())
+        );
+    }
+
+    private Map<String, NormalizedEvidenceFact> normalizeEvidence(Map<String, RawEvidenceFactDto> rawEvidence) {
+        Map<String, NormalizedEvidenceFact> result = new LinkedHashMap<>();
+        if (rawEvidence == null || rawEvidence.isEmpty()) {
+            return result;
+        }
+
+        for (Map.Entry<String, RawEvidenceFactDto> entry : rawEvidence.entrySet()) {
+            String evidenceId = entry.getKey();
+            RawEvidenceFactDto dto = entry.getValue();
+            if (dto == null) {
+                continue;
+            }
+
+            RawSourceSpanDto span = dto.getSpan();
+
+            result.put(evidenceId, new NormalizedEvidenceFact(
+                    firstNonBlank(dto.getId(), evidenceId),
+                    dto.getType(),
+                    dto.getPath(),
+                    span == null ? null : span.getStartLine(),
+                    span == null ? null : span.getStartCol(),
+                    span == null ? null : span.getEndLine(),
+                    span == null ? null : span.getEndCol(),
+                    dto.getSymbol(),
+                    dto.getSnippet(),
+                    dto.getHash()
+            ));
+        }
+
+        return result;
+    }
+
+    private List<NormalizedSymbolFact> normalizeSymbols(RawSymbolTableDto table) {
+        List<NormalizedSymbolFact> result = new ArrayList<>();
+        if (table == null) {
+            return result;
+        }
+
+        addSymbols(result, table.getModules());
+        addSymbols(result, table.getPackages());
+        addSymbols(result, table.getTypes());
+        addSymbols(result, table.getConstructors());
+        addSymbols(result, table.getMethods());
+        addSymbols(result, table.getFields());
+
+        return result;
+    }
+
+    private void addSymbols(List<NormalizedSymbolFact> target, List<RawSymbolFactDto> source) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+
+        for (RawSymbolFactDto dto : source) {
+            if (dto == null) {
+                continue;
+            }
+
+            target.add(new NormalizedSymbolFact(
+                    dto.getSymbol(),
+                    dto.getName(),
+                    dto.getKind(),
+                    dto.getAccess(),
+                    dto.getModifiers() == null ? List.of() : List.copyOf(dto.getModifiers()),
+                    dto.getOrigin(),
+                    dto.getQualifiedName(),
+                    dto.getOwnerTypeSymbol(),
+                    dto.getPackageSymbol(),
+                    dto.getModule(),
+                    dto.getSourceFile(),
+                    dto.getEvidenceIds() == null ? List.of() : List.copyOf(dto.getEvidenceIds()),
+                    dto.getSignature()
+            ));
+        }
+    }
+
+    private List<NormalizedRelationFact> normalizeRelations(RawRelationTableDto table) {
+        List<NormalizedRelationFact> result = new ArrayList<>();
+        if (table == null) {
+            return result;
+        }
+
+        addRelations(result, table.getContains());
+        addRelations(result, table.getExtendsRelations());
+        addRelations(result, table.getImplementsRelations());
+        addRelations(result, table.getOverrides());
+        addRelations(result, table.getCalls());
+        addRelations(result, table.getAccessesField());
+        addRelations(result, table.getFieldType());
+        addRelations(result, table.getParamType());
+        addRelations(result, table.getReturnType());
+        addRelations(result, table.getThrowsType());
+        addRelations(result, table.getAnnotatedBy());
+
+        return result;
+    }
+
+    private void addRelations(List<NormalizedRelationFact> target, List<RawRelationFactDto> source) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+
+        for (RawRelationFactDto dto : source) {
+            if (dto == null) {
+                continue;
+            }
+
+            RawRelationResolutionDto resolution = dto.getResolution();
+
+            target.add(new NormalizedRelationFact(
+                    dto.getKind(),
+                    dto.getSrcSymbol(),
+                    dto.getDstSymbol(),
+                    dto.getDstRawRef(),
+                    dto.getOrigin(),
+                    resolution == null ? null : resolution.getStatus(),
+                    resolution == null ? null : resolution.getReason(),
+                    dto.getConfidenceHint(),
+                    dto.getEvidenceIds() == null ? List.of() : List.copyOf(dto.getEvidenceIds())
+            ));
+        }
+    }
+
+    private String firstNonBlank(String left, String right) {
+        if (left != null && !left.isBlank()) {
+            return left;
+        }
+        return right;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
@@ -2,17 +2,17 @@ package com.example.ossdoc.domain.graphstore.service;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
-import com.example.ossdoc.domain.artifact.service.ArtifactContentReader;
-import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.graphstore.converter.FactsEdgeConverter;
 import com.example.ossdoc.domain.graphstore.converter.FactsEvidenceConverter;
 import com.example.ossdoc.domain.graphstore.converter.FactsSymbolConverter;
 import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestRequest;
 import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestResponse;
-import com.example.ossdoc.domain.graphstore.dto.facts.EvidenceFactDto;
-import com.example.ossdoc.domain.graphstore.dto.facts.FactsDocumentDto;
-import com.example.ossdoc.domain.graphstore.dto.facts.RelationFactDto;
-import com.example.ossdoc.domain.graphstore.dto.facts.SymbolFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedEvidenceFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedFactsDocument;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedRelationFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.normalized.NormalizedSymbolFact;
+import com.example.ossdoc.domain.graphstore.dto.facts.raw.RawFactsDocumentDto;
 import com.example.ossdoc.domain.graphstore.entity.Edge;
 import com.example.ossdoc.domain.graphstore.entity.EdgeEvidence;
 import com.example.ossdoc.domain.graphstore.entity.EdgeEvidenceId;
@@ -32,17 +32,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class GraphStoreIngestService {
 
     private final RepoRunRepository repoRunRepository;
-    private final ArtifactService artifactService;
-    private final ArtifactContentReader artifactContentReader;
+    private final ArtifactRepository artifactRepository;
 
     private final SymbolRepository symbolRepository;
     private final EdgeRepository edgeRepository;
@@ -53,6 +53,7 @@ public class GraphStoreIngestService {
     private final FactsSymbolConverter factsSymbolConverter;
     private final FactsEdgeConverter factsEdgeConverter;
     private final SymbolIdGenerator symbolIdGenerator;
+    private final GraphStoreFactsNormalizer graphStoreFactsNormalizer;
 
     private final ObjectMapper objectMapper;
 
@@ -66,154 +67,201 @@ public class GraphStoreIngestService {
         }
 
         Artifact factsArtifact = resolveFactsArtifact(request);
-        JsonNode root = artifactContentReader.readJson(factsArtifact);
 
-        FactsDocumentDto facts;
+        JsonNode root = factsArtifact.getMeta();
+        if (root == null || root.isNull()) {
+            throw new GraphStoreException(GraphStoreErrorCode.FACTS_READ_FAILED);
+        }
+
+        RawFactsDocumentDto rawFacts;
         try {
-            facts = objectMapper.treeToValue(root, FactsDocumentDto.class);
+            rawFacts = objectMapper.treeToValue(root, RawFactsDocumentDto.class);
         } catch (Exception e) {
             throw new GraphStoreException(GraphStoreErrorCode.INVALID_FACTS_SCHEMA);
         }
 
+        NormalizedFactsDocument facts = graphStoreFactsNormalizer.normalize(rawFacts);
         validateFacts(facts);
 
-        Map<String, Evidence> evidenceMap = saveEvidence(run, facts);
-        Map<String, SymbolEntity> symbolMap = saveSymbols(run, facts, evidenceMap);
-
-        EdgeSaveResult edgeSaveResult = saveEdges(run, facts, symbolMap, evidenceMap);
+        EvidenceSaveResult evidenceSaveResult = saveEvidence(run, facts);
+        SymbolSaveResult symbolSaveResult = saveSymbols(run, facts, evidenceSaveResult.evidenceMap());
+        EdgeSaveResult edgeSaveResult = saveEdges(run, facts, symbolSaveResult.symbolMap(), evidenceSaveResult.evidenceMap());
 
         return GraphStoreIngestResponse.builder()
                 .runId(run.getRunId())
                 .artifactId(factsArtifact.getArtifactId())
-                .evidencesSaved(evidenceMap.size())
-                .symbolsSaved(symbolMap.size())
-                .edgesSaved(edgeSaveResult.edgesSaved)
-                .edgeEvidenceSaved(edgeSaveResult.edgeEvidenceSaved)
-                .skippedRelations(edgeSaveResult.skippedRelations)
+                .evidencesSaved(evidenceSaveResult.savedCount())
+                .symbolsSaved(symbolSaveResult.savedCount())
+                .edgesSaved(edgeSaveResult.edgesSaved())
+                .edgeEvidenceSaved(edgeSaveResult.edgeEvidenceSaved())
+                .skippedRelations(edgeSaveResult.skippedRelations())
                 .build();
     }
 
     private Artifact resolveFactsArtifact(GraphStoreIngestRequest request) {
-        Artifact artifact;
         if (request.getArtifactId() != null) {
-            artifact = artifactService.getArtifact(request.getArtifactId());
-        } else {
-            artifact = artifactService.getLatestArtifact(request.getRunId(), ArtifactKind.FACTS_JSON);
+            return artifactRepository.findById(request.getArtifactId())
+                    .orElseThrow(() -> new GraphStoreException(GraphStoreErrorCode.FACTS_ARTIFACT_NOT_FOUND));
         }
 
-        if (artifact == null) {
-            throw new GraphStoreException(GraphStoreErrorCode.FACTS_ARTIFACT_NOT_FOUND);
-        }
-        return artifact;
+        return artifactRepository
+                .findTopByRun_RunIdAndKindOrderByCreatedAtDesc(request.getRunId(), ArtifactKind.FACTS_JSON)
+                .orElseThrow(() -> new GraphStoreException(GraphStoreErrorCode.FACTS_ARTIFACT_NOT_FOUND));
     }
 
-    private void validateFacts(FactsDocumentDto facts) {
+    private void validateFacts(NormalizedFactsDocument facts) {
         if (facts == null ||
-                facts.getSchemaVersion() == null ||
-                facts.getSymbols() == null ||
-                facts.getRelations() == null) {
+                facts.schemaVersion() == null ||
+                facts.symbols() == null ||
+                facts.relations() == null) {
             throw new GraphStoreException(GraphStoreErrorCode.INVALID_FACTS_SCHEMA);
         }
     }
 
-    private Map<String, Evidence> saveEvidence(RepoRun run, FactsDocumentDto facts) {
+    private EvidenceSaveResult saveEvidence(RepoRun run, NormalizedFactsDocument facts) {
         Map<String, Evidence> evidenceMap = new LinkedHashMap<>();
+        int savedCount = 0;
 
-        if (facts.getEvidence() == null) return evidenceMap;
-
-        for (Map.Entry<String, EvidenceFactDto> entry : facts.getEvidence().entrySet()) {
-            String factEvidenceId = entry.getKey();
-            EvidenceFactDto dto = entry.getValue();
-
-            Evidence saved = evidenceRepository.save(
-                    factsEvidenceConverter.toEntity(run, dto)
-            );
-            evidenceMap.put(factEvidenceId, saved);
+        if (facts.evidence() == null || facts.evidence().isEmpty()) {
+            return new EvidenceSaveResult(evidenceMap, savedCount);
         }
 
-        return evidenceMap;
+        for (Map.Entry<String, NormalizedEvidenceFact> entry : facts.evidence().entrySet()) {
+            String factEvidenceId = entry.getKey();
+            NormalizedEvidenceFact dto = entry.getValue();
+
+            Evidence candidate = factsEvidenceConverter.toEntity(run, dto);
+            Evidence existing = findExistingEvidence(run, candidate);
+
+            Evidence resolved;
+            if (existing != null) {
+                resolved = existing;
+            } else {
+                resolved = evidenceRepository.save(candidate);
+                savedCount++;
+            }
+
+            evidenceMap.put(factEvidenceId, resolved);
+        }
+
+        return new EvidenceSaveResult(evidenceMap, savedCount);
     }
 
-    private Map<String, SymbolEntity> saveSymbols(RepoRun run,
-                                                  FactsDocumentDto facts,
-                                                  Map<String, Evidence> evidenceMap) {
-        Map<String, SymbolEntity> symbolMap = new LinkedHashMap<>();
+    private Evidence findExistingEvidence(RepoRun run, Evidence candidate) {
+        if (candidate.getHash() != null && !candidate.getHash().isBlank()) {
+            return evidenceRepository.findFirstByRun_RunIdAndHash(run.getRunId(), candidate.getHash())
+                    .orElse(null);
+        }
 
-        for (SymbolFactDto dto : facts.getSymbols()) {
-            if (dto.getSymbol() == null || dto.getSymbol().isBlank()) {
+        List<Evidence> matches = evidenceRepository.findByRun_RunIdAndTypeAndStartLineAndEndLineAndSnippet(
+                run.getRunId(),
+                candidate.getEvidenceType(),
+                candidate.getStartLine(),
+                candidate.getEndLine(),
+                candidate.getSnippet()
+        );
+
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    private SymbolSaveResult saveSymbols(
+            RepoRun run,
+            NormalizedFactsDocument facts,
+            Map<String, Evidence> evidenceMap
+    ) {
+        Map<String, SymbolEntity> symbolMap = new LinkedHashMap<>();
+        int savedCount = 0;
+
+        for (NormalizedSymbolFact dto : facts.symbols()) {
+            if (dto.symbol() == null || dto.symbol().isBlank()) {
                 continue;
             }
 
-            SymbolEntity symbol = symbolRepository.findByRun_RunIdAndQualifiedName(run.getRunId(), dto.getSymbol())
-                    .orElseGet(() -> {
-                        String symbolId = symbolIdGenerator.generate(run.getRunId(), dto.getSymbol());
-                        SymbolEntity entity = factsSymbolConverter.toEntity(symbolId, run, dto);
-                        return symbolRepository.save(entity);
-                    });
+            SymbolEntity existing = symbolRepository.findByRun_RunIdAndQualifiedName(run.getRunId(), dto.symbol())
+                    .orElse(null);
 
-            symbolMap.put(dto.getSymbol(), symbol);
+            SymbolEntity symbol;
+            if (existing != null) {
+                symbol = existing;
+            } else {
+                String symbolId = symbolIdGenerator.generate(run.getRunId(), dto.symbol());
+                SymbolEntity entity = factsSymbolConverter.toEntity(symbolId, run, dto);
+                symbol = symbolRepository.save(entity);
+                savedCount++;
+            }
+
+            symbolMap.put(dto.symbol(), symbol);
         }
 
-        // owner / source span 2차 연결
-        for (SymbolFactDto dto : facts.getSymbols()) {
-            SymbolEntity current = symbolMap.get(dto.getSymbol());
+        for (NormalizedSymbolFact dto : facts.symbols()) {
+            SymbolEntity current = symbolMap.get(dto.symbol());
             if (current == null) continue;
 
-            if (dto.getOwnerTypeSymbol() != null) {
-                SymbolEntity owner = symbolMap.get(dto.getOwnerTypeSymbol());
+            if (dto.ownerTypeSymbol() != null && !dto.ownerTypeSymbol().isBlank()) {
+                SymbolEntity owner = symbolMap.get(dto.ownerTypeSymbol());
                 if (owner != null) {
                     current.assignOwner(owner);
                 }
             }
 
-            if (dto.getEvidenceIds() != null && !dto.getEvidenceIds().isEmpty()) {
-                Evidence sourceEvidence = evidenceMap.get(dto.getEvidenceIds().get(0));
+            if (dto.evidenceIds() != null && !dto.evidenceIds().isEmpty()) {
+                Evidence sourceEvidence = evidenceMap.get(dto.evidenceIds().get(0));
                 if (sourceEvidence != null) {
                     current.assignSourceSpan(sourceEvidence.getStartLine(), sourceEvidence.getEndLine());
                 }
             }
         }
 
-        return symbolMap;
+        return new SymbolSaveResult(symbolMap, savedCount);
     }
 
-    private EdgeSaveResult saveEdges(RepoRun run,
-                                     FactsDocumentDto facts,
-                                     Map<String, SymbolEntity> symbolMap,
-                                     Map<String, Evidence> evidenceMap) {
+    private EdgeSaveResult saveEdges(
+            RepoRun run,
+            NormalizedFactsDocument facts,
+            Map<String, SymbolEntity> symbolMap,
+            Map<String, Evidence> evidenceMap
+    ) {
         int edgesSaved = 0;
         int edgeEvidenceSaved = 0;
         int skippedRelations = 0;
 
-        for (RelationFactDto dto : facts.getRelations()) {
-            if (dto.getSrcSymbol() == null || dto.getSrcSymbol().isBlank()) {
+        for (NormalizedRelationFact dto : facts.relations()) {
+            if (dto.srcSymbol() == null || dto.srcSymbol().isBlank()) {
                 skippedRelations++;
                 continue;
             }
 
-            SymbolEntity from = symbolMap.get(dto.getSrcSymbol());
+            SymbolEntity from = symbolMap.get(dto.srcSymbol());
             if (from == null) {
                 skippedRelations++;
                 continue;
             }
 
             SymbolEntity to = null;
-            if (dto.getDstSymbol() != null) {
-                to = symbolMap.get(dto.getDstSymbol());
+            if (dto.dstSymbol() != null && !dto.dstSymbol().isBlank()) {
+                to = symbolMap.get(dto.dstSymbol());
             }
 
-            Edge edge = edgeRepository.save(
-                    factsEdgeConverter.toEntity(run, dto, from, to)
-            );
-            edgesSaved++;
+            Edge candidate = factsEdgeConverter.toEntity(run, dto, from, to);
+            Edge edge = findExistingEdge(run, from, to, candidate);
 
-            if (dto.getEvidenceIds() != null) {
-                for (String factEvidenceId : dto.getEvidenceIds()) {
+            if (edge == null) {
+                edge = edgeRepository.save(candidate);
+                edgesSaved++;
+            }
+
+            if (dto.evidenceIds() != null) {
+                for (String factEvidenceId : dto.evidenceIds()) {
                     Evidence evidence = evidenceMap.get(factEvidenceId);
                     if (evidence == null) continue;
 
+                    EdgeEvidenceId edgeEvidenceId = new EdgeEvidenceId(edge.getEdgeId(), evidence.getEvidenceId());
+                    if (edgeEvidenceRepository.existsById(edgeEvidenceId)) {
+                        continue;
+                    }
+
                     EdgeEvidence edgeEvidence = new EdgeEvidence(
-                            new EdgeEvidenceId(edge.getEdgeId(), evidence.getEvidenceId()),
+                            edgeEvidenceId,
                             edge,
                             evidence
                     );
@@ -224,6 +272,50 @@ public class GraphStoreIngestService {
         }
 
         return new EdgeSaveResult(edgesSaved, edgeEvidenceSaved, skippedRelations);
+    }
+
+    private Edge findExistingEdge(RepoRun run, SymbolEntity from, SymbolEntity to, Edge candidate) {
+        if (to != null) {
+            return edgeRepository.findFirstByRun_RunIdAndFromSymbol_SymbolIdAndTypeAndToSymbol_SymbolId(
+                    run.getRunId(),
+                    from.getSymbolId(),
+                    candidate.getEdgeType(),
+                    to.getSymbolId()
+            ).orElse(null);
+        }
+
+        List<Edge> matches = edgeRepository.findByRun_RunIdAndFromSymbol_SymbolIdAndTypeAndToSymbolIsNull(
+                run.getRunId(),
+                from.getSymbolId(),
+                candidate.getEdgeType()
+        );
+
+        String candidateRawRef = canonicalJson(candidate.getToRawRef());
+
+        for (Edge existing : matches) {
+            if (Objects.equals(candidateRawRef, canonicalJson(existing.getToRawRef()))) {
+                return existing;
+            }
+        }
+
+        return null;
+    }
+
+    private String canonicalJson(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (Exception e) {
+            return node.toString();
+        }
+    }
+
+    private record EvidenceSaveResult(Map<String, Evidence> evidenceMap, int savedCount) {
+    }
+
+    private record SymbolSaveResult(Map<String, SymbolEntity> symbolMap, int savedCount) {
     }
 
     private record EdgeSaveResult(int edgesSaved, int edgeEvidenceSaved, int skippedRelations) {

--- a/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
@@ -1,0 +1,231 @@
+package com.example.ossdoc.domain.graphstore.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.service.ArtifactContentReader;
+import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.graphstore.converter.FactsEdgeConverter;
+import com.example.ossdoc.domain.graphstore.converter.FactsEvidenceConverter;
+import com.example.ossdoc.domain.graphstore.converter.FactsSymbolConverter;
+import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestRequest;
+import com.example.ossdoc.domain.graphstore.dto.GraphStoreIngestResponse;
+import com.example.ossdoc.domain.graphstore.dto.facts.EvidenceFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.FactsDocumentDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.RelationFactDto;
+import com.example.ossdoc.domain.graphstore.dto.facts.SymbolFactDto;
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.entity.EdgeEvidence;
+import com.example.ossdoc.domain.graphstore.entity.EdgeEvidenceId;
+import com.example.ossdoc.domain.graphstore.entity.Evidence;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.exception.GraphStoreException;
+import com.example.ossdoc.domain.graphstore.exception.code.GraphStoreErrorCode;
+import com.example.ossdoc.domain.graphstore.repository.EdgeEvidenceRepository;
+import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.graphstore.repository.EvidenceRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolRepository;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class GraphStoreIngestService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final ArtifactService artifactService;
+    private final ArtifactContentReader artifactContentReader;
+
+    private final SymbolRepository symbolRepository;
+    private final EdgeRepository edgeRepository;
+    private final EvidenceRepository evidenceRepository;
+    private final EdgeEvidenceRepository edgeEvidenceRepository;
+
+    private final FactsEvidenceConverter factsEvidenceConverter;
+    private final FactsSymbolConverter factsSymbolConverter;
+    private final FactsEdgeConverter factsEdgeConverter;
+    private final SymbolIdGenerator symbolIdGenerator;
+
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public GraphStoreIngestResponse ingest(GraphStoreIngestRequest request, Long userId) {
+        RepoRun run = repoRunRepository.findById(request.getRunId())
+                .orElseThrow(() -> new GraphStoreException(GraphStoreErrorCode.RUN_NOT_FOUND));
+
+        if (run.getOwner() == null || !run.getOwner().getId().equals(userId)) {
+            throw new GraphStoreException(GraphStoreErrorCode.RUN_ACCESS_DENIED);
+        }
+
+        Artifact factsArtifact = resolveFactsArtifact(request);
+        JsonNode root = artifactContentReader.readJson(factsArtifact);
+
+        FactsDocumentDto facts;
+        try {
+            facts = objectMapper.treeToValue(root, FactsDocumentDto.class);
+        } catch (Exception e) {
+            throw new GraphStoreException(GraphStoreErrorCode.INVALID_FACTS_SCHEMA);
+        }
+
+        validateFacts(facts);
+
+        Map<String, Evidence> evidenceMap = saveEvidence(run, facts);
+        Map<String, SymbolEntity> symbolMap = saveSymbols(run, facts, evidenceMap);
+
+        EdgeSaveResult edgeSaveResult = saveEdges(run, facts, symbolMap, evidenceMap);
+
+        return GraphStoreIngestResponse.builder()
+                .runId(run.getRunId())
+                .artifactId(factsArtifact.getArtifactId())
+                .evidencesSaved(evidenceMap.size())
+                .symbolsSaved(symbolMap.size())
+                .edgesSaved(edgeSaveResult.edgesSaved)
+                .edgeEvidenceSaved(edgeSaveResult.edgeEvidenceSaved)
+                .skippedRelations(edgeSaveResult.skippedRelations)
+                .build();
+    }
+
+    private Artifact resolveFactsArtifact(GraphStoreIngestRequest request) {
+        Artifact artifact;
+        if (request.getArtifactId() != null) {
+            artifact = artifactService.getArtifact(request.getArtifactId());
+        } else {
+            artifact = artifactService.getLatestArtifact(request.getRunId(), ArtifactKind.FACTS_JSON);
+        }
+
+        if (artifact == null) {
+            throw new GraphStoreException(GraphStoreErrorCode.FACTS_ARTIFACT_NOT_FOUND);
+        }
+        return artifact;
+    }
+
+    private void validateFacts(FactsDocumentDto facts) {
+        if (facts == null ||
+                facts.getSchemaVersion() == null ||
+                facts.getSymbols() == null ||
+                facts.getRelations() == null) {
+            throw new GraphStoreException(GraphStoreErrorCode.INVALID_FACTS_SCHEMA);
+        }
+    }
+
+    private Map<String, Evidence> saveEvidence(RepoRun run, FactsDocumentDto facts) {
+        Map<String, Evidence> evidenceMap = new LinkedHashMap<>();
+
+        if (facts.getEvidence() == null) return evidenceMap;
+
+        for (Map.Entry<String, EvidenceFactDto> entry : facts.getEvidence().entrySet()) {
+            String factEvidenceId = entry.getKey();
+            EvidenceFactDto dto = entry.getValue();
+
+            Evidence saved = evidenceRepository.save(
+                    factsEvidenceConverter.toEntity(run, dto)
+            );
+            evidenceMap.put(factEvidenceId, saved);
+        }
+
+        return evidenceMap;
+    }
+
+    private Map<String, SymbolEntity> saveSymbols(RepoRun run,
+                                                  FactsDocumentDto facts,
+                                                  Map<String, Evidence> evidenceMap) {
+        Map<String, SymbolEntity> symbolMap = new LinkedHashMap<>();
+
+        for (SymbolFactDto dto : facts.getSymbols()) {
+            if (dto.getSymbol() == null || dto.getSymbol().isBlank()) {
+                continue;
+            }
+
+            SymbolEntity symbol = symbolRepository.findByRun_RunIdAndQualifiedName(run.getRunId(), dto.getSymbol())
+                    .orElseGet(() -> {
+                        String symbolId = symbolIdGenerator.generate(run.getRunId(), dto.getSymbol());
+                        SymbolEntity entity = factsSymbolConverter.toEntity(symbolId, run, dto);
+                        return symbolRepository.save(entity);
+                    });
+
+            symbolMap.put(dto.getSymbol(), symbol);
+        }
+
+        // owner / source span 2차 연결
+        for (SymbolFactDto dto : facts.getSymbols()) {
+            SymbolEntity current = symbolMap.get(dto.getSymbol());
+            if (current == null) continue;
+
+            if (dto.getOwnerTypeSymbol() != null) {
+                SymbolEntity owner = symbolMap.get(dto.getOwnerTypeSymbol());
+                if (owner != null) {
+                    current.assignOwner(owner);
+                }
+            }
+
+            if (dto.getEvidenceIds() != null && !dto.getEvidenceIds().isEmpty()) {
+                Evidence sourceEvidence = evidenceMap.get(dto.getEvidenceIds().get(0));
+                if (sourceEvidence != null) {
+                    current.assignSourceSpan(sourceEvidence.getStartLine(), sourceEvidence.getEndLine());
+                }
+            }
+        }
+
+        return symbolMap;
+    }
+
+    private EdgeSaveResult saveEdges(RepoRun run,
+                                     FactsDocumentDto facts,
+                                     Map<String, SymbolEntity> symbolMap,
+                                     Map<String, Evidence> evidenceMap) {
+        int edgesSaved = 0;
+        int edgeEvidenceSaved = 0;
+        int skippedRelations = 0;
+
+        for (RelationFactDto dto : facts.getRelations()) {
+            if (dto.getSrcSymbol() == null || dto.getSrcSymbol().isBlank()) {
+                skippedRelations++;
+                continue;
+            }
+
+            SymbolEntity from = symbolMap.get(dto.getSrcSymbol());
+            if (from == null) {
+                skippedRelations++;
+                continue;
+            }
+
+            SymbolEntity to = null;
+            if (dto.getDstSymbol() != null) {
+                to = symbolMap.get(dto.getDstSymbol());
+            }
+
+            Edge edge = edgeRepository.save(
+                    factsEdgeConverter.toEntity(run, dto, from, to)
+            );
+            edgesSaved++;
+
+            if (dto.getEvidenceIds() != null) {
+                for (String factEvidenceId : dto.getEvidenceIds()) {
+                    Evidence evidence = evidenceMap.get(factEvidenceId);
+                    if (evidence == null) continue;
+
+                    EdgeEvidence edgeEvidence = new EdgeEvidence(
+                            new EdgeEvidenceId(edge.getEdgeId(), evidence.getEvidenceId()),
+                            edge,
+                            evidence
+                    );
+                    edgeEvidenceRepository.save(edgeEvidence);
+                    edgeEvidenceSaved++;
+                }
+            }
+        }
+
+        return new EdgeSaveResult(edgesSaved, edgeEvidenceSaved, skippedRelations);
+    }
+
+    private record EdgeSaveResult(int edgesSaved, int edgeEvidenceSaved, int skippedRelations) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/graphstore/service/SymbolIdGenerator.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/service/SymbolIdGenerator.java
@@ -1,0 +1,25 @@
+package com.example.ossdoc.domain.graphstore.service;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+@Component
+public class SymbolIdGenerator {
+    public String generate(String runId, String qualifiedName) {
+        try {
+            String input = runId + ":" + qualifiedName;
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder sb = new StringBuilder("sym_");
+            for (int i = 0; i < 16; i++) {
+                sb.append(String.format("%02x", digest[i]));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate symbol id", e);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/dto/RepoRunCreateResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/RepoRunCreateResponse.java
@@ -1,4 +1,3 @@
-// domain/run/dto/RepoRunCreateResponse.java
 package com.example.ossdoc.domain.run.dto;
 
 import com.example.ossdoc.domain.run.enums.RunStatus;
@@ -12,5 +11,4 @@ public class RepoRunCreateResponse {
     private RunStatus status;
     private String commitSha;
     private String workspaceRoot;
-    private String jobManifestPath;
 }

--- a/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
@@ -13,7 +13,7 @@ public enum RunErrorCode implements BaseCode {
     GITHUB_API_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_001", "Failed to resolve repo info from GitHub."),
     DOWNLOAD_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_002", "Failed to download repository zip."),
     UNZIP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_001", "Failed to unzip repository."),
-    MANIFEST_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_002", "Failed to write job_manifest.json.");
+    JOB_MANIFEST_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_002", "Failed to write job_manifest.json");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -1,4 +1,3 @@
-// domain/run/service/RepoRunService.java
 package com.example.ossdoc.domain.run.service;
 
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
@@ -10,12 +9,18 @@ import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
-import com.example.ossdoc.domain.run.support.*;
+import com.example.ossdoc.domain.run.support.GithubClient;
+import com.example.ossdoc.domain.run.support.GithubRepoRef;
+import com.example.ossdoc.domain.run.support.GithubUrlParser;
+import com.example.ossdoc.domain.run.support.JobManifestWriter;
+import com.example.ossdoc.domain.run.support.WorkspaceManager;
+import com.example.ossdoc.domain.run.support.ZipUtils;
 import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +28,7 @@ import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RepoRunService {
@@ -30,49 +36,52 @@ public class RepoRunService {
     private final RepoRunRepository repoRunRepository;
     private final UserRepository userRepository;
     private final ArtifactService artifactService;
-
     private final GithubClient githubClient;
     private final WorkspaceManager workspaceManager;
+    private final JobManifestWriter jobManifestWriter;
     private final ObjectMapper objectMapper;
 
     @Transactional
     public RepoRunCreateResponse createRun(RepoRunCreateRequest req, Long userId) {
-        User owner= userRepository.findById(userId)
+        User owner = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
-
-        // 1) URL 파싱
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
+        log.info(
+                "Create run requested userId={}, owner={}, repo={}, requestedRef={}",
+                userId,
+                parsed.getOwner(),
+                parsed.getRepo(),
+                req.getRef()
+        );
 
-        // 2) ref 결정 (없으면 default_branch)
         String ref = parsed.getRef();
         if (ref == null || ref.isBlank()) {
             ref = githubClient.resolveDefaultBranch(parsed.getOwner(), parsed.getRepo());
+            log.info("Resolved default branch owner={}, repo={}, ref={}", parsed.getOwner(), parsed.getRepo(), ref);
         }
 
-        // 3) commit SHA 확정 (재현성 핵심)
         String commitSha = githubClient.resolveCommitSha(parsed.getOwner(), parsed.getRepo(), ref);
+        log.info(
+                "Resolved commit SHA owner={}, repo={}, ref={}, sha={}",
+                parsed.getOwner(),
+                parsed.getRepo(),
+                ref,
+                abbreviateSha(commitSha)
+        );
 
-        // 4) runId / workspace 경로
-        String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "") + "_" + UUID.randomUUID().toString().substring(0, 8);
+        String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "")
+                + "_" + UUID.randomUUID().toString().substring(0, 8);
         Path wsRoot = workspaceManager.workspaceRoot(runId);
+        log.info("Workspace prepared runId={}, workspaceRoot={}", runId, wsRoot);
 
-        // 5) zip 다운로드 → unzip
         Path zipPath = wsRoot.resolve("repo.zip");
         githubClient.downloadZip(parsed.getOwner(), parsed.getRepo(), commitSha, zipPath);
 
-        // GitHub zip은 보통 최상위 폴더가 "{repo}-{sha}" 형태로 한 번 감싸져 있음
         Path unzipRoot = wsRoot.resolve("repo");
         ZipUtils.unzip(zipPath, unzipRoot);
+        log.info("Repository snapshot ready runId={}, zipPath={}, unzipRoot={}", runId, zipPath, unzipRoot);
 
-        // 6) job_manifest.json 생성
-        Path manifestPath = workspaceManager.writeJobManifest(
-                wsRoot, runId, req.getRepoUrl(),
-                parsed.getOwner(), parsed.getRepo(),
-                ref, commitSha, unzipRoot
-        );
-
-        // 7) DB 저장 (RepoRun)
         RepoRun run = new RepoRun(
                 runId,
                 owner,
@@ -87,20 +96,30 @@ public class RepoRunService {
         );
         repoRunRepository.save(run);
 
-        // 8) DB 저장 (Artifact - job_manifest)
         ObjectNode meta = objectMapper.createObjectNode();
         meta.put("ref", ref);
         meta.put("commitSha", commitSha);
         meta.put("generatedAt", OffsetDateTime.now().toString());
 
-        artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1", manifestPath.toString(), meta);
+        Path artifactsDir = workspaceManager.artifactsDir(wsRoot);
+        jobManifestWriter.write(artifactsDir, meta);
+
+        artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1",
+                "job_manifest.json", meta);
+        log.info("Run queued runId={}, status={}, sha={}", runId, run.getStatus(), abbreviateSha(commitSha));
 
         return RepoRunCreateResponse.builder()
                 .runId(runId)
                 .status(run.getStatus())
                 .commitSha(commitSha)
                 .workspaceRoot(wsRoot.toString())
-                .jobManifestPath(manifestPath.toString())
                 .build();
+    }
+
+    private String abbreviateSha(String sha) {
+        if (sha == null || sha.isBlank()) {
+            return "<empty>";
+        }
+        return sha.length() <= 8 ? sha : sha.substring(0, 8);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/support/GithubClient.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/GithubClient.java
@@ -1,41 +1,45 @@
 package com.example.ossdoc.domain.run.support;
 
-import com.example.ossdoc.domain.build.exception.BuildException;
-import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
-import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
 import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GithubClient {
 
+    private static final Duration API_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ZIP_TIMEOUT = Duration.ofSeconds(120);
+    private static final int ERROR_BODY_PREVIEW_LEN = 300;
+
     private final ObjectMapper objectMapper;
 
-    // GitHub API 호출용 HTTP 클라이언트
-    // GitHub API 호출용 HTTP 클라이언트
     private final WebClient webClient = WebClient.builder()
             .defaultHeader(HttpHeaders.USER_AGENT, "ossdoc")
             .build();
 
-    // 저장소의 기본 브랜치가 뭔지 알아냄
     public String resolveDefaultBranch(String owner, String repo) {
         try {
             String json = webClient.get()
                     .uri("https://api.github.com/repos/{owner}/{repo}", owner, repo)
                     .retrieve()
-                    .bodyToMono(String.class)   // ✅ String으로 받기
-                    .block();
+                    .bodyToMono(String.class)
+                    .block(API_TIMEOUT);
 
             if (json == null || json.isBlank()) {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
@@ -47,20 +51,35 @@ public class GithubClient {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
             }
             return branch.asText();
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "GitHub default-branch API failed owner={}, repo={}, status={}, body={}",
+                    owner,
+                    repo,
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         } catch (Exception e) {
-            log.debug("git fail error={}", e.getMessage());
+            log.error(
+                    "GitHub default-branch API failed owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
             throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         }
     }
 
-    // ref(브랜치/태그/커밋)를 실제 commit SHA로 변환하는 메서드
     public String resolveCommitSha(String owner, String repo, String ref) {
         try {
             String json = webClient.get()
                     .uri("https://api.github.com/repos/{owner}/{repo}/commits/{ref}", owner, repo, ref)
                     .retrieve()
-                    .bodyToMono(String.class)   // ✅ 여기도 String으로 받기 (중요)
-                    .block();
+                    .bodyToMono(String.class)
+                    .block(API_TIMEOUT);
 
             if (json == null || json.isBlank()) {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
@@ -72,31 +91,169 @@ public class GithubClient {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
             }
             return sha.asText();
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "GitHub commit API failed owner={}, repo={}, ref={}, status={}, body={}",
+                    owner,
+                    repo,
+                    ref,
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         } catch (Exception e) {
-            log.debug("git fail error={}", e.getMessage());
+            log.error(
+                    "GitHub commit API failed owner={}, repo={}, ref={}, cause={}",
+                    owner,
+                    repo,
+                    ref,
+                    e.toString(),
+                    e
+            );
             throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         }
     }
 
-    // 특정 ref 상태의 저장소를 ZIP으로 다운로드
     public Path downloadZip(String owner, String repo, String commitSha, Path targetZip) {
-        try {
-            byte[] bytes = webClient.get()
-                    .uri("https://codeload.github.com/{owner}/{repo}/zip/{commitSha}", owner, repo, commitSha)
-                    .retrieve()
-                    .bodyToMono(byte[].class)
-                    .block();
+        ensureParentDir(targetZip);
 
-            if (bytes == null || bytes.length == 0) {
-                throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
-            }
+        boolean downloaded = tryDownloadZipToFile(
+                owner,
+                repo,
+                commitSha,
+                "codeload",
+                "https://codeload.github.com/{owner}/{repo}/zip/{commitSha}",
+                targetZip
+        );
 
-            Files.createDirectories(targetZip.getParent());
-            Files.write(targetZip, bytes);
-            return targetZip;
-        } catch (Exception e) {
-            log.debug("download fail error={}", e.getMessage());
+        if (!downloaded) {
+            log.warn(
+                    "Primary zip download failed owner={}, repo={}, sha={}. Trying GitHub API zipball fallback.",
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha)
+            );
+            downloaded = tryDownloadZipToFile(
+                    owner,
+                    repo,
+                    commitSha,
+                    "api-zipball",
+                    "https://api.github.com/repos/{owner}/{repo}/zipball/{commitSha}",
+                    targetZip
+            );
+        }
+
+        if (!downloaded) {
             throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
         }
+        return targetZip;
+    }
+
+    private boolean tryDownloadZipToFile(
+            String owner,
+            String repo,
+            String commitSha,
+            String source,
+            String uriTemplate,
+            Path targetZip
+    ) {
+        try {
+            Files.deleteIfExists(targetZip);
+
+            DataBufferUtils.write(
+                    webClient.get()
+                            .uri(uriTemplate, owner, repo, commitSha)
+                            .retrieve()
+                            .bodyToFlux(DataBuffer.class),
+                    targetZip,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE
+            ).block(ZIP_TIMEOUT);
+
+            if (!Files.exists(targetZip)) {
+                log.warn(
+                        "Zip file not created source={}, owner={}, repo={}, sha={}",
+                        source,
+                        owner,
+                        repo,
+                        abbreviateSha(commitSha)
+                );
+                return false;
+            }
+
+            long size = Files.size(targetZip);
+            if (size <= 0) {
+                log.warn(
+                        "Zip file is empty source={}, owner={}, repo={}, sha={}",
+                        source,
+                        owner,
+                        repo,
+                        abbreviateSha(commitSha)
+                );
+                Files.deleteIfExists(targetZip);
+                return false;
+            }
+            return true;
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "Zip download failed source={}, owner={}, repo={}, sha={}, status={}, body={}",
+                    source,
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha),
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            deleteQuietly(targetZip);
+            return false;
+        } catch (Exception e) {
+            log.error(
+                    "Zip download failed source={}, owner={}, repo={}, sha={}, cause={}",
+                    source,
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha),
+                    e.toString(),
+                    e
+            );
+            deleteQuietly(targetZip);
+            return false;
+        }
+    }
+
+    private void ensureParentDir(Path targetZip) {
+        try {
+            Path parent = targetZip.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+        } catch (Exception e) {
+            log.error("Failed to create parent directory for zip path={}, cause={}", targetZip, e.toString(), e);
+            throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
+        }
+    }
+
+    private void deleteQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (Exception ignored) {
+        }
+    }
+
+    private String previewBody(String body) {
+        if (body == null || body.isBlank()) {
+            return "<empty>";
+        }
+        return body.length() > ERROR_BODY_PREVIEW_LEN ? body.substring(0, ERROR_BODY_PREVIEW_LEN) + "..." : body;
+    }
+
+    private String abbreviateSha(String sha) {
+        if (sha == null || sha.isBlank()) {
+            return "<empty>";
+        }
+        return sha.length() <= 8 ? sha : sha.substring(0, 8);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/support/JobManifestWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/JobManifestWriter.java
@@ -1,0 +1,32 @@
+package com.example.ossdoc.domain.run.support;
+
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobManifestWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public Path write(Path artifactsDir, JsonNode jobManifest) {
+        try {
+            Files.createDirectories(artifactsDir);
+            Path out = artifactsDir.resolve("job_manifest.json");
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), jobManifest);
+            return out;
+        } catch (Exception e) {
+            log.debug("JobManifestWriter error={}", e.toString(), e);
+            throw new RunException(RunErrorCode.JOB_MANIFEST_WRITE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
@@ -1,85 +1,26 @@
-// domain/run/support/WorkspaceManager.java
 package com.example.ossdoc.domain.run.support;
 
-import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
-import com.example.ossdoc.domain.run.exception.RunException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.example.ossdoc.global.properties.WorkspaceProperties;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.OffsetDateTime;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WorkspaceManager {
 
-    private final ObjectMapper objectMapper;
+    private final WorkspaceProperties workspaceProperties;
 
-    // TODO: application.yml로 빼는 걸 추천 (ex. ossdoc.workspace.base-dir=/data/ossdoc)
-    // 모든 Run 작업이 저장되는 루트 경로
-    private final String baseDir = "/data/ossdoc";
-
-    // 특정 Run의 최상위 작업 디렉토리 경로 반환
-    /**
-     이 디렉토리 안에: unzip된 소스,
-     artifacts,
-     facts.json,
-     graph.json,
-     build 결과,
-     전부 들어가게 됨
-     **/
+    /** 특정 Run의 최상위 작업 디렉토리 경로 반환 */
     public Path workspaceRoot(String runId) {
-        return Path.of(baseDir, runId);
+        return Path.of(workspaceProperties.getBaseDir(), runId)
+                .toAbsolutePath()
+                .normalize();
     }
 
-    // 분석 결과물이 저장될 폴더 경로 반환 (job_manifest.json, build_manifest.json, facts.json, graph_stats.json, rule_candidates.json, rendered diagrams)
+    /** 분석 결과물이 저장될 폴더 경로 반환 */
     public Path artifactsDir(Path workspaceRoot) {
         return workspaceRoot.resolve("artifacts");
-    }
-
-    // Run이 어떤 코드 스냅샷을 분석했는지 기록하는 공식 선언문 생성 (job_manifest.json)
-    public Path writeJobManifest(
-            Path workspaceRoot,
-            String runId,
-            String repoUrl,
-            String owner,
-            String repo,
-            String ref,
-            String commitSha,
-            Path unzipRoot
-    ) {
-        try {
-            Files.createDirectories(artifactsDir(workspaceRoot));
-            Path manifestPath = artifactsDir(workspaceRoot).resolve("job_manifest.json");
-
-            ObjectNode root = objectMapper.createObjectNode();
-            ObjectNode repoRun = root.putObject("repoRun");
-            repoRun.put("runId", runId);
-
-            ObjectNode source = repoRun.putObject("source");
-            source.put("type", "github");
-            source.put("url", repoUrl);
-            source.put("owner", owner);
-            source.put("repo", repo);
-            source.put("ref", ref);
-            source.put("commitSha", commitSha);
-
-            ObjectNode paths = repoRun.putObject("paths");
-            paths.put("workspaceRoot", workspaceRoot.toString());
-            paths.put("repoRoot", unzipRoot.toString());
-
-            repoRun.put("generatedAt", OffsetDateTime.now().toString());
-
-            Files.writeString(manifestPath, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(root));
-            return manifestPath;
-        } catch (Exception e) {
-            log.debug("manifest write fail error={}", e.getMessage());
-            throw new RunException(RunErrorCode.MANIFEST_WRITE_FAILED);
-        }
     }
 }

--- a/src/main/java/com/example/ossdoc/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/ossdoc/global/apiPayload/exception/ExceptionAdvice.java
@@ -120,7 +120,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(value = GeneralException.class)
     public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
-        return handleExceptionInternal(generalException, generalException.getCode(), null, request);
+        return handleExceptionInternal(generalException, generalException.getCode(), generalException.getDetailMessage(), null, request);
     }
 
     /**
@@ -134,11 +134,10 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      * @return ApiResponse 형식의 에러 응답
      */
     private ResponseEntity<Object> handleExceptionInternal(Exception e, BaseCode code,
-                                                           HttpHeaders headers, HttpServletRequest request) {
+                                                           Object detail, HttpHeaders headers, HttpServletRequest request) {
 
         // BaseCode를 사용하여 실패 응답 생성
-        ApiResponse<Object> body = ApiResponse.onFailure(code, null);
-//        e.printStackTrace();
+        ApiResponse<Object> body = ApiResponse.onFailure(code, detail);
 
         // BaseCode에서 HttpStatus 정보 추출
         ReasonDTO reason = code.getReasonHttpStatus();

--- a/src/main/java/com/example/ossdoc/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/example/ossdoc/global/apiPayload/exception/GeneralException.java
@@ -2,14 +2,35 @@ package com.example.ossdoc.global.apiPayload.exception;
 
 import com.example.ossdoc.global.apiPayload.code.BaseCode;
 import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-    private BaseCode code;
+    private final BaseCode code;
+    private final String detailMessage;
+
+    public GeneralException(BaseCode code) {
+        this.code = code;
+        this.detailMessage = null;
+    }
+
+    public GeneralException(BaseCode code, String detailMessage) {
+        this.code = code;
+        this.detailMessage = detailMessage;
+    }
+
+    public GeneralException(BaseCode code, Throwable cause) {
+        super(cause);
+        this.code = code;
+        this.detailMessage = null;
+    }
+
+    public GeneralException(BaseCode code, String detailMessage, Throwable cause) {
+        super(cause);
+        this.code = code;
+        this.detailMessage = detailMessage;
+    }
 
     public ReasonDTO getErrorReason() {
         return this.code.getReason();

--- a/src/main/java/com/example/ossdoc/global/config/BuildCommandProperties.java
+++ b/src/main/java/com/example/ossdoc/global/config/BuildCommandProperties.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @Component
@@ -12,15 +15,32 @@ import org.springframework.stereotype.Component;
 public class BuildCommandProperties {
 
     /**
-     * mvnw / mvnw.cmd 가 없을 때 사용할 Maven 실행 명령어
-     * 예: mvn
-     * 예: C:\\tools\\apache-maven-3.9.13\\bin\\mvn.cmd
+     * Maven command used when mvnw/mvnw.cmd is not present in the target repository.
      */
     private String mavenCommand = "mvn";
 
     /**
-     * gradlew / gradlew.bat 가 없을 때 사용할 Gradle 실행 명령어
-     * 예: gradle
+     * Gradle command used when gradlew/gradlew.bat is not present in the target repository.
      */
     private String gradleCommand = "gradle";
+
+    /**
+     * Ordered JAVA_HOME candidates for Gradle compatibility fallback retries.
+     */
+    private List<String> javaHomes = new ArrayList<>();
+
+    /**
+     * Enables isolated execution directories per run workspace.
+     */
+    private boolean isolatedExecution = true;
+
+    /**
+     * Relative directory (from workspace root) used as GRADLE_USER_HOME.
+     */
+    private String gradleUserHomeDir = ".gradle-home";
+
+    /**
+     * Relative directory (from workspace root) used as Maven local repository.
+     */
+    private String mavenLocalRepoDir = ".m2/repository";
 }

--- a/src/main/java/com/example/ossdoc/global/config/S3Config.java
+++ b/src/main/java/com/example/ossdoc/global/config/S3Config.java
@@ -1,0 +1,66 @@
+package com.example.ossdoc.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key:#{null}}")
+    private String accessKeyId;
+
+    @Value("${cloud.aws.credentials.secret-key:#{null}}")
+    private String secretAccessKey;
+
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket:ossdoc-artifact-storage}")
+    private String bucketName;
+
+    @Bean
+    public S3Client s3Client() {
+        Region awsRegion = Region.of(region);
+
+        // 우선순위: yml → 환경변수 → IAM Role(DefaultCredentialsProvider)
+        String keyId     = firstNonBlank(accessKeyId,     System.getenv("AWS_ACCESS_KEY_ID"));
+        String secretKey = firstNonBlank(secretAccessKey, System.getenv("AWS_SECRET_ACCESS_KEY"));
+
+        AwsCredentialsProvider credentialsProvider;
+        if (keyId != null && secretKey != null) {
+            credentialsProvider = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(keyId, secretKey));
+        } else {
+            credentialsProvider = DefaultCredentialsProvider.create();
+        }
+
+        log.info("S3Client initialized — region: {}, bucket: {}", awsRegion, bucketName);
+
+        return S3Client.builder()
+                .region(awsRegion)
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    /** S3 버킷 이름을 Bean으로 노출 — 다른 컴포넌트에서 @Qualifier 없이 주입 가능 */
+    @Bean(name = "s3BucketName")
+    public String s3BucketName() {
+        return bucketName;
+    }
+
+    private String firstNonBlank(String... candidates) {
+        for (String c : candidates) {
+            if (c != null && !c.isBlank()) return c.trim();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/config/WebConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/WebConfig.java
@@ -18,7 +18,6 @@ public class WebConfig {
     private final CorsProperties corsProperties;
 
     @Bean
-    @Primary
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 

--- a/src/main/java/com/example/ossdoc/global/config/WebConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.example.ossdoc.global.properties.CorsProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -17,6 +18,7 @@ public class WebConfig {
     private final CorsProperties corsProperties;
 
     @Bean
+    @Primary
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 

--- a/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ossdoc.workspace")
+public class WorkspaceProperties {
+
+    /**
+     * Base directory where per-run workspaces are created.
+     * Example: C:/data/ossdoc
+     */
+    private String baseDir = "C:/data/ossdoc";
+}

--- a/src/main/java/com/example/ossdoc/global/s3/exception/S3Exception.java
+++ b/src/main/java/com/example/ossdoc/global/s3/exception/S3Exception.java
@@ -1,0 +1,11 @@
+package com.example.ossdoc.global.s3.exception;
+
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+
+public class S3Exception extends GeneralException {
+
+    public S3Exception(S3ErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/s3/exception/code/S3ErrorCode.java
+++ b/src/main/java/com/example/ossdoc/global/s3/exception/code/S3ErrorCode.java
@@ -1,0 +1,51 @@
+package com.example.ossdoc.global.s3.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3ErrorCode implements BaseCode {
+
+    // 업로드 실패
+    UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_001", "S3 파일 업로드에 실패했습니다."),
+
+    // 삭제 실패
+    DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_002", "S3 파일 삭제에 실패했습니다."),
+
+    // JSON 직렬화 실패 (업로드 전처리 단계)
+    JSON_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_500_003", "Artifact JSON 직렬화에 실패했습니다."),
+
+    // 잘못된 S3 키/URL
+    INVALID_S3_KEY(HttpStatus.BAD_REQUEST,
+            "S3_400_001", "유효하지 않은 S3 경로입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/s3/util/S3Util.java
+++ b/src/main/java/com/example/ossdoc/global/s3/util/S3Util.java
@@ -1,0 +1,137 @@
+package com.example.ossdoc.global.s3.util;
+
+import com.example.ossdoc.global.s3.exception.S3Exception;
+import com.example.ossdoc.global.s3.exception.code.S3ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * S3 업로드 / 삭제 헬퍼.
+ *
+ * <p>주요 사용처: ArtifactService — LLM이 생성한 JSON을 S3에 저장하고
+ * 반환된 URL을 Artifact.path 컬럼에 기록한다.
+ *
+ * <p>S3 키 규칙:
+ * <pre>
+ *   artifacts/{runId}/{relativePath}
+ *   예) artifacts/run_20260315_abc12345/llm/refined_rules.json
+ * </pre>
+ *
+ * <p>예외: 모든 S3 오류는 {@link S3Exception}으로 변환되어
+ * {@link com.example.ossdoc.global.apiPayload.exception.ExceptionAdvice}에서
+ * 공통 응답 포맷으로 처리된다.
+ */
+@Slf4j
+@Component
+public class S3Util {
+
+    private final S3Client s3Client;
+    private final String   bucketName;
+
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
+    private String region;
+
+    public S3Util(S3Client s3Client,
+                  @Qualifier("s3BucketName") String bucketName) {
+        this.s3Client   = s3Client;
+        this.bucketName = bucketName;
+    }
+
+    // ── Upload ────────────────────────────────────────────────────────────────
+
+    /**
+     * JSON 문자열을 S3에 업로드한다.
+     *
+     * @param key      S3 객체 키 (예: "artifacts/run_xxx/llm/refined_rules.json")
+     * @param jsonBody 업로드할 JSON 문자열
+     * @return         업로드된 객체의 Public HTTPS URL
+     * @throws S3Exception S3_500_001 — 업로드 중 AWS SDK 오류 발생 시
+     */
+    public String uploadJson(String key, String jsonBody) {
+        if (key == null || key.isBlank()) {
+            throw new S3Exception(S3ErrorCode.INVALID_S3_KEY);
+        }
+
+        try {
+            byte[] bytes = jsonBody.getBytes(StandardCharsets.UTF_8);
+
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType("application/json")
+                    .contentLength((long) bytes.length)
+                    .build();
+
+            PutObjectResponse response = s3Client.putObject(request, RequestBody.fromBytes(bytes));
+            log.info("S3 업로드 완료 — key: {}, eTag: {}", key, response.eTag());
+
+            return buildUrl(key);
+
+        } catch (SdkException e) {
+            log.error("S3 업로드 실패 — key: {}, 원인: {}", key, e.getMessage());
+            throw new S3Exception(S3ErrorCode.UPLOAD_FAILED);
+        }
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    /**
+     * S3 URL 또는 키로 객체를 삭제한다.
+     *
+     * @param s3UrlOrKey 전체 S3 URL 또는 키 문자열 모두 허용
+     * @throws S3Exception S3_500_002 — 삭제 중 AWS SDK 오류 발생 시
+     */
+    public void delete(String s3UrlOrKey) {
+        String key = extractKey(s3UrlOrKey);
+        if (key == null || key.isBlank()) {
+            log.warn("S3 삭제 건너뜀 — 키를 추출할 수 없습니다. 입력값: {}", s3UrlOrKey);
+            return;
+        }
+
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build());
+            log.info("S3 삭제 완료 — key: {}", key);
+
+        } catch (SdkException e) {
+            log.error("S3 삭제 실패 — key: {}, 원인: {}", key, e.getMessage());
+            throw new S3Exception(S3ErrorCode.DELETE_FAILED);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * S3 키로부터 HTTPS URL을 조립한다.
+     * 형식: https://{bucket}.s3.{region}.amazonaws.com/{key}
+     */
+    public String buildUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    /**
+     * S3 URL에서 키를 추출한다. 이미 키 형태이면 그대로 반환한다.
+     */
+    public String extractKey(String s3UrlOrKey) {
+        if (s3UrlOrKey == null || s3UrlOrKey.isBlank()) return null;
+
+        String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+        if (s3UrlOrKey.startsWith(prefix)) {
+            return s3UrlOrKey.substring(prefix.length());
+        }
+
+        return s3UrlOrKey;
+    }
+}


### PR DESCRIPTION
앞단계에서 AST/JDT 및 ASM 기반 정적 분석 결과를 facts.json 형태로 생성하면, 이를 서버가 읽어 의미 그래프(GraphStore) 로 적재하는 기능을 구현

Symbol / Edge / Evidence 구조의 질의 가능한 그래프 형태로 DB(PostgreSQL)에 저장하여 이후 API Map, Rule Mining, LLM Meaning Refinement, 시각화 등의 후속 단계에서 재사용할 수 있도록 설계

앞단 산출물의 실제 저장 위치가 로컬 파일시스템일 수도 있고 향후 AWS S3일 수도 있는 상황을 고려하여, graphstore 도메인이 파일 경로에 직접 의존하지 않도록 artifact 기반 조회 구조로 구현

이번 작업에서는 graphstore 적재 범위를 1차적으로 다음과 같이 한정했다.

facts.json의 evidence → Evidence
facts.json의 symbols → SymbolEntity
facts.json의 relations → Edge
relations[].evidence_ids → EdgeEvidence

반면 아래 항목은 2차 작업으로 분리했다.

observation 계열 저장
FileIndex / ModuleEntity 정식 연동
symbol evidence 직접 연결
contract edge 승격(BINDS / PROVIDES_SPI / SUBSCRIBES 등)

이번 구현은 그래프의 최소 핵심 단위인 Symbol / Edge / Evidence 중심의 1차 ingest 에 집중