### PR TITLE
[#16] Refactor: 빌드 도메인 및 런 도메인 코드 리펙토링 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ src/main/generated/
 workspace/
 
 /AGENTS.md
+.gradle-home/

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ out/
 /dist/
 /nbdist/
 /.nb-gradle/
-
+s
 ### VS Code ###
 .vscode/
 
@@ -47,3 +47,5 @@ src/main/generated/
 
 #workspace
 workspace/
+
+/AGENTS.md

--- a/src/main/java/com/example/ossdoc/domain/build/dto/response/BuildResolveResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/build/dto/response/BuildResolveResponse.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 public class BuildResolveResponse {
     private String runId;
     private BuildMode buildMode;
-    private String buildManifestPath; // build_manifest.json 저장 경로
+    private String buildManifestPath; // build_manifest.json S3 URL
 }

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildDetector.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildDetector.java
@@ -1,29 +1,64 @@
 package com.example.ossdoc.domain.build.service;
 
-import com.example.ossdoc.domain.build.enums.BuildToolKind;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+/**
+ * 역할:
+ * 저장소 루트를 검사해 사용 가능한 빌드 도구(Gradle/Maven)를 감지한다.
+ *
+ * 책임:
+ * 1) 빌드 파일 존재 여부 판단
+ * 2) wrapper 존재 여부 판단
+ * 3) 감지 결과를 Detected 레코드로 반환
+ */
 @Component
 public class BuildDetector {
 
+    /**
+     * 역할:
+     * 저장소의 빌드 도구/wrapper 존재 상태를 계산한다.
+     *
+     * 책임:
+     * settings/build/pom/mvnw/gradlew 파일 존재 여부를 조합해 실행 분기 근거를 제공한다.
+     */
     public Detected detect(Path repoRoot) {
+        // Gradle 관련 빌드 파일 존재 여부
         boolean hasGradle = Files.exists(repoRoot.resolve("settings.gradle"))
                 || Files.exists(repoRoot.resolve("settings.gradle.kts"))
                 || Files.exists(repoRoot.resolve("build.gradle"))
                 || Files.exists(repoRoot.resolve("build.gradle.kts"));
 
+        // Maven 관련 빌드 파일 존재 여부
         boolean hasMaven = Files.exists(repoRoot.resolve("pom.xml"));
 
-        boolean gradleWrapper = Files.exists(repoRoot.resolve("gradlew")) || Files.exists(repoRoot.resolve("gradlew.bat"));
-        boolean mavenWrapper = Files.exists(repoRoot.resolve("mvnw")) || Files.exists(repoRoot.resolve("mvnw.cmd"));
+        // 각 도구의 wrapper 존재 여부 (실행 우선순위 판단에 사용)
+        boolean gradleWrapper = Files.exists(repoRoot.resolve("gradlew"))
+                || Files.exists(repoRoot.resolve("gradlew.bat"));
+        boolean mavenWrapper = Files.exists(repoRoot.resolve("mvnw"))
+                || Files.exists(repoRoot.resolve("mvnw.cmd"));
 
-        if (hasGradle) return new Detected(BuildToolKind.GRADLE, gradleWrapper);
-        if (hasMaven)  return new Detected(BuildToolKind.MAVEN, mavenWrapper);
-        return new Detected(BuildToolKind.NONE, false);
+        return new Detected(hasGradle, gradleWrapper, hasMaven, mavenWrapper);
     }
 
-    public record Detected(BuildToolKind tool, boolean wrapperExists) {}
+    public record Detected(
+            boolean hasGradle,
+            boolean gradleWrapperExists,
+            boolean hasMaven,
+            boolean mavenWrapperExists
+    ) {
+        /**
+         * 역할:
+         * 최소 1개 이상의 빌드 도구 존재 여부를 반환한다.
+         *
+         * 책임:
+         * 상위 오케스트레이터가 즉시 실패 처리할지 계속 진행할지 판단할 수 있도록 한다.
+         */
+        // 하나라도 있으면 빌드 도구가 존재하는 것으로 간주
+        public boolean hasAnyBuildTool() {
+            return hasGradle || hasMaven;
+        }
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
@@ -11,6 +11,7 @@ import com.example.ossdoc.domain.build.enums.BuildToolKind;
 import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
 import com.example.ossdoc.domain.build.support.*;
+import com.example.ossdoc.global.config.BuildCommandProperties;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,12 +20,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Function;
 
 @Slf4j
 @Service
@@ -42,6 +47,9 @@ public class BuildResolveService {
     private final SourceOnlyModuleScanner sourceOnlyModuleScanner;
     private final PomModuleScanner pomModuleScanner;
     private final MavenBuildSupport mavenBuildSupport;
+    private final MavenJavaVersionResolver mavenJavaVersionResolver;
+    private final BuildPathNormalizer buildPathNormalizer;
+    private final BuildCommandProperties buildCommandProperties;
 
     private final ObjectMapper objectMapper;
 
@@ -55,7 +63,6 @@ public class BuildResolveService {
             throw new BuildException(BuildErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        // 너희 run에서 repo를 어디에 풀어두는지에 맞춰 여기만 맞추면 됨
         Path repoRoot = workspaceRoot.resolve("repo");
         Path actualRepoRoot = repoRootResolver.resolveActualRoot(repoRoot);
 
@@ -70,8 +77,8 @@ public class BuildResolveService {
         BuildDetector.Detected detected = buildDetector.detect(actualRepoRoot);
 
         BuildManifest manifest = switch (detected.tool()) {
-            case GRADLE -> resolveGradle(runId, actualRepoRoot, detected.wrapperExists(), tmpDir);
-            case MAVEN -> resolveMaven(runId, actualRepoRoot, detected.wrapperExists(), tmpDir);
+            case GRADLE -> resolveGradle(runId, actualRepoRoot, workspaceRoot, detected.wrapperExists(), tmpDir);
+            case MAVEN -> resolveMaven(runId, actualRepoRoot, workspaceRoot, detected.wrapperExists(), tmpDir);
             case NONE -> BuildManifest.builder()
                     .runId(runId)
                     .detectedAt(OffsetDateTime.now())
@@ -87,27 +94,18 @@ public class BuildResolveService {
 
         Path buildManifestPath = buildManifestWriter.write(artifactsDir, manifest);
 
-        JsonNode meta = objectMapper.createObjectNode()
-                .put("buildTool", manifest.getBuildTool().name())
-                .put("buildMode", manifest.getBuildMode().name())
-                .put("moduleCount", manifest.getModules().size())
-                .put("failureCount", manifest.getFailures().size())
-                .put("hasClassesDirs",
-                        manifest.getModules().stream()
-                                .anyMatch(m -> m.getClassesDirs() != null && !m.getClassesDirs().isEmpty()));
+        JsonNode manifestJson = objectMapper.valueToTree(manifest);
 
-        // Artifact 등록(너희 artifact 도메인에 이미 있으니 재사용)
         artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
-                "build_manifest.json", meta);
+                "build_manifest.json", manifestJson);
 
-        return new BuildResolveResponse(runId, manifest.getBuildMode(), buildManifestPath.toString());
+        return new BuildResolveResponse(runId, manifest.getBuildMode(), buildPathNormalizer.normalize(buildManifestPath));
     }
 
-    private BuildManifest resolveGradle(String runId, Path repoRoot, boolean wrapperUsed, Path tmpDir) {
+    private BuildManifest resolveGradle(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildModuleManifest> modules = new ArrayList<>();
         List<BuildFailure> failures = new ArrayList<>();
 
-        // 1) 덤프(모듈/소스루트/classesDirs/classpath) — 빌드가 깨져도 성공하는 경우가 많아서 핵심
         Path init = gradleInitScriptWriter.write(tmpDir);
 
         List<String> dumpCmd = List.of(
@@ -118,11 +116,10 @@ public class BuildResolveService {
                 "--no-daemon"
         );
 
-        ProcessRunner.Result dump = processRunner.run(repoRoot, dumpCmd, Duration.ofMinutes(10));
+        ProcessRunner.Result dump = runGradleWithJavaFallback(repoRoot, workspaceRoot, dumpCmd, Duration.ofMinutes(10), "dump");
         if (dump.getExitCode() == 0) {
-            modules.addAll(parseGradleDump(dump.getOutput(), failures));
+            modules.addAll(parseGradleDump(repoRoot, dump.getOutput(), failures));
 
-            // dump는 성공했는데 실제 모듈 추출 결과가 없으면 SOURCE_ONLY 폴백
             if (modules.isEmpty()) {
                 failures.add(BuildFailure.builder()
                         .code("SOURCE_ONLY")
@@ -139,11 +136,9 @@ public class BuildResolveService {
                     .logHint(hint(dump))
                     .build());
 
-            // dump 실패해도 AST가 돌 수 있게 source-only 폴백
             modules.addAll(sourceOnlyModuleScanner.scan(repoRoot));
         }
 
-        // 2) 컴파일 시도(성공률 우선: 테스트/체크 스킵)
         List<String> compileCmd = List.of(
                 selectGradleCmd(repoRoot),
                 "classes",
@@ -152,7 +147,7 @@ public class BuildResolveService {
                 "--no-daemon"
         );
 
-        ProcessRunner.Result compile = processRunner.run(repoRoot, compileCmd, Duration.ofMinutes(20));
+        ProcessRunner.Result compile = runGradleWithJavaFallback(repoRoot, workspaceRoot, compileCmd, Duration.ofMinutes(20), "compile");
 
         BuildMode mode = decideBuildMode(modules, compile);
         if (compile.getExitCode() != 0 && mode != BuildMode.FAILED) {
@@ -198,10 +193,521 @@ public class BuildResolveService {
     }
 
     private String selectGradleCmd(Path repoRoot) {
-        // Windows 개발 환경이면 gradlew.bat 우선
+        // Windows   gradlew.bat 
         if (Files.exists(repoRoot.resolve("gradlew.bat"))) return "gradlew.bat";
         if (Files.exists(repoRoot.resolve("gradlew"))) return "./gradlew";
-        return "gradle";
+        return buildCommandProperties.getGradleCommand();
+    }
+
+    private ProcessRunner.Result runGradleWithJavaFallback(Path repoRoot,
+                                                           Path workspaceRoot,
+                                                           List<String> command,
+                                                           Duration timeout,
+                                                           String stage) {
+        Map<String, String> baseEnvironment = resolveGradleBaseEnvironment(workspaceRoot);
+        List<String> candidates = resolveJavaHomeCandidates(repoRoot);
+
+        ProcessRunner.Result first;
+        String selectedJavaHome = null;
+        if (candidates.isEmpty()) {
+            first = processRunner.run(repoRoot, command, timeout, baseEnvironment);
+        } else {
+            selectedJavaHome = candidates.get(0);
+            first = processRunner.run(repoRoot, command, timeout, buildEnvironment(baseEnvironment, selectedJavaHome));
+            log.info("[BUILD] Gradle {} initial JAVA_HOME={} (version-aware selection)", stage, selectedJavaHome);
+        }
+
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        Optional<String> compatibilityReason = detectJavaCompatibilityReason(BuildToolKind.GRADLE, first);
+        if (compatibilityReason.isEmpty()) {
+            if (selectedJavaHome != null && !isCurrentRuntimeJavaHome(selectedJavaHome)) {
+                ProcessRunner.Result baseline = processRunner.run(repoRoot, command, timeout, baseEnvironment);
+                if (baseline.getExitCode() == 0) {
+                    log.info("[BUILD] Gradle {} fallback to current runtime JVM succeeded", stage);
+                    return baseline;
+                }
+            }
+            return first;
+        }
+        log.info("[BUILD] Gradle {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
+
+        ProcessRunner.Result last = first;
+        for (String javaHome : candidates) {
+            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
+                continue;
+            }
+
+            log.info("[BUILD] Gradle {} retry with JAVA_HOME={}", stage, javaHome);
+            ProcessRunner.Result retry = processRunner.run(
+                    repoRoot,
+                    command,
+                    timeout,
+                    buildEnvironment(baseEnvironment, javaHome)
+            );
+            if (retry.getExitCode() == 0) {
+                return retry;
+            }
+            last = retry;
+        }
+
+        return last;
+    }
+
+    private ProcessRunner.Result runMavenWithJavaFallback(Path mavenLocalRepoPath,
+                                                          MavenJavaSelection selection,
+                                                          String stage,
+                                                          Function<Map<String, String>, ProcessRunner.Result> runner) {
+        List<String> candidates = selection.javaHomes();
+
+        ProcessRunner.Result first;
+        String selectedJavaHome = null;
+        if (candidates.isEmpty()) {
+            first = runner.apply(Map.of());
+        } else {
+            selectedJavaHome = candidates.get(0);
+            first = runner.apply(buildEnvironment(Map.of(), selectedJavaHome));
+            log.info(
+                    "[BUILD] Maven {} initial JAVA_HOME={} (requiredJava={}, repoLocal={})",
+                    stage,
+                    selectedJavaHome,
+                    selection.requiredJavaMajor().orElse(null),
+                    mavenLocalRepoPath
+            );
+        }
+
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        Optional<String> compatibilityReason = detectJavaCompatibilityReason(BuildToolKind.MAVEN, first);
+        if (compatibilityReason.isEmpty()) {
+            if (selectedJavaHome != null && !isCurrentRuntimeJavaHome(selectedJavaHome)) {
+                ProcessRunner.Result baseline = runner.apply(Map.of());
+                if (baseline.getExitCode() == 0) {
+                    log.info("[BUILD] Maven {} fallback to current runtime JVM succeeded", stage);
+                    return baseline;
+                }
+            }
+            return first;
+        }
+        log.info("[BUILD] Maven {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
+
+        ProcessRunner.Result last = first;
+        for (String javaHome : candidates) {
+            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
+                continue;
+            }
+            log.info("[BUILD] Maven {} retry with JAVA_HOME={}", stage, javaHome);
+            ProcessRunner.Result retry = runner.apply(buildEnvironment(Map.of(), javaHome));
+            if (retry.getExitCode() == 0) {
+                return retry;
+            }
+            last = retry;
+        }
+
+        return last;
+    }
+
+    private MavenJavaSelection resolveMavenJavaSelection(Path repoRoot) {
+        Optional<Integer> requiredJavaMajor = mavenJavaVersionResolver.resolveRequiredJavaMajor(repoRoot);
+        List<String> javaHomes = resolveJavaHomeCandidatesForMaven(requiredJavaMajor);
+        return new MavenJavaSelection(requiredJavaMajor, javaHomes);
+    }
+
+    private Optional<String> detectJavaCompatibilityReason(BuildToolKind buildToolKind, ProcessRunner.Result result) {
+        String text = ((result.getOutput() == null ? "" : result.getOutput()) + "\n"
+                + (result.getError() == null ? "" : result.getError())).toLowerCase(Locale.ROOT);
+
+        List<String> commonSignals = List.of(
+                "unsupported class file major version",
+                "unsupported major.minor version",
+                "has been compiled by a more recent version",
+                "could not determine java version"
+        );
+        for (String signal : commonSignals) {
+            if (text.contains(signal)) {
+                return Optional.of(signal);
+            }
+        }
+
+        if (buildToolKind == BuildToolKind.GRADLE) {
+            List<String> gradleSignals = List.of(
+                    "this version of gradle supports java",
+                    "minimum supported gradle version"
+            );
+            for (String signal : gradleSignals) {
+                if (text.contains(signal)) {
+                    return Optional.of(signal);
+                }
+            }
+            return Optional.empty();
+        }
+
+        if (buildToolKind == BuildToolKind.MAVEN) {
+            List<String> mavenSignals = List.of(
+                    "invalid target release",
+                    "invalid source release",
+                    "release version",
+                    "source option",
+                    "target option",
+                    "no toolchain found for type jdk",
+                    "cannot find matching toolchain definitions for the following toolchain types",
+                    "error: source release",
+                    "error: target release"
+            );
+            for (String signal : mavenSignals) {
+                if (!text.contains(signal)) {
+                    continue;
+                }
+
+                if ("release version".equals(signal) && !text.contains("not supported")) {
+                    continue;
+                }
+                if (("source option".equals(signal) || "target option".equals(signal))
+                        && !text.contains("is no longer supported")) {
+                    continue;
+                }
+                return Optional.of(signal);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean isCurrentRuntimeJavaHome(String javaHome) {
+        String normalized = normalizePathString(javaHome);
+        if (normalized == null) {
+            return false;
+        }
+        String currentJavaHome = normalizePathString(System.getenv("JAVA_HOME"));
+        String currentRuntimeHome = normalizePathString(System.getProperty("java.home"));
+        return normalized.equalsIgnoreCase(currentJavaHome) || normalized.equalsIgnoreCase(currentRuntimeHome);
+    }
+
+    private List<String> resolveJavaHomeCandidates(Path repoRoot) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        Optional<GradleVersion> gradleVersion = parseGradleVersionFromWrapper(repoRoot);
+        if (gradleVersion.isPresent()) {
+            GradleVersion version = gradleVersion.get();
+            int preferredJava = preferredJavaMajor(version);
+
+            candidates.sort((left, right) -> {
+                int tierCompare = Integer.compare(
+                        compatibilityTier(version, right.major()),
+                        compatibilityTier(version, left.major())
+                );
+                if (tierCompare != 0) {
+                    return tierCompare;
+                }
+
+                int leftDistance = Math.abs(left.major() - preferredJava);
+                int rightDistance = Math.abs(right.major() - preferredJava);
+                int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                if (distanceCompare != 0) {
+                    return distanceCompare;
+                }
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+        return toJavaHomePaths(candidates);
+    }
+
+    private List<String> resolveJavaHomeCandidatesForMaven(Optional<Integer> requiredJavaMajor) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        if (requiredJavaMajor.isPresent()) {
+            int requiredMajor = requiredJavaMajor.get();
+            candidates.sort((left, right) -> {
+                boolean leftAdequate = left.major() >= requiredMajor;
+                boolean rightAdequate = right.major() >= requiredMajor;
+
+                if (leftAdequate != rightAdequate) {
+                    return Boolean.compare(rightAdequate, leftAdequate);
+                }
+
+                if (leftAdequate) {
+                    int leftDistance = Math.abs(left.major() - requiredMajor);
+                    int rightDistance = Math.abs(right.major() - requiredMajor);
+                    int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                    if (distanceCompare != 0) {
+                        return distanceCompare;
+                    }
+                    return Integer.compare(left.major(), right.major());
+                }
+
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+
+        return toJavaHomePaths(candidates);
+    }
+
+    private List<JavaHomeCandidate> loadConfiguredJavaHomeCandidates() {
+        List<String> configured = buildCommandProperties.getJavaHomes();
+        if (configured == null || configured.isEmpty()) {
+            return List.of();
+        }
+
+        List<JavaHomeCandidate> candidates = new ArrayList<>();
+        for (String candidate : configured) {
+            String normalized = normalizePathString(candidate);
+            if (normalized == null) {
+                continue;
+            }
+            Path javaHomePath = Path.of(normalized);
+            if (!Files.exists(javaHomePath) || !Files.isDirectory(javaHomePath)) {
+                continue;
+            }
+
+            Integer javaMajor = parseJavaMajorFromHome(javaHomePath);
+            if (javaMajor == null) {
+                continue;
+            }
+            candidates.add(new JavaHomeCandidate(normalized, javaMajor));
+        }
+        return candidates;
+    }
+
+    private List<String> toJavaHomePaths(List<JavaHomeCandidate> candidates) {
+        List<String> result = new ArrayList<>();
+        for (JavaHomeCandidate candidate : candidates) {
+            result.add(candidate.path());
+        }
+        return result;
+    }
+
+    private Map<String, String> resolveGradleBaseEnvironment(Path workspaceRoot) {
+        Map<String, String> env = new HashMap<>();
+        if (!buildCommandProperties.isIsolatedExecution()) {
+            return env;
+        }
+
+        Path gradleUserHome = workspaceRoot.resolve(buildCommandProperties.getGradleUserHomeDir())
+                .toAbsolutePath()
+                .normalize();
+        try {
+            Files.createDirectories(gradleUserHome);
+            env.put("GRADLE_USER_HOME", gradleUserHome.toString());
+        } catch (IOException e) {
+            log.warn("[BUILD] Failed to create GRADLE_USER_HOME directory. path={}", gradleUserHome, e);
+        }
+        return env;
+    }
+
+    private Path resolveMavenLocalRepoPath(Path workspaceRoot) {
+        if (!buildCommandProperties.isIsolatedExecution()) {
+            return null;
+        }
+        Path mavenLocalRepo = workspaceRoot.resolve(buildCommandProperties.getMavenLocalRepoDir())
+                .toAbsolutePath()
+                .normalize();
+        try {
+            Files.createDirectories(mavenLocalRepo);
+            return mavenLocalRepo;
+        } catch (IOException e) {
+            log.warn("[BUILD] Failed to create Maven local repository path. path={}", mavenLocalRepo, e);
+            return null;
+        }
+    }
+
+    private Map<String, String> buildEnvironment(Map<String, String> baseEnvironment, String javaHome) {
+        Map<String, String> env = new HashMap<>(baseEnvironment);
+        env.put("JAVA_HOME", javaHome);
+
+        String binPath = javaHome + File.separator + "bin";
+        String currentPath = Optional.ofNullable(System.getenv("PATH")).orElse("");
+        String mergedPath = currentPath.isBlank() ? binPath : binPath + File.pathSeparator + currentPath;
+
+        env.put("PATH", mergedPath);
+        env.put("Path", mergedPath);
+        return env;
+    }
+
+    private Optional<GradleVersion> parseGradleVersionFromWrapper(Path repoRoot) {
+        Path wrapperProperties = repoRoot.resolve("gradle").resolve("wrapper").resolve("gradle-wrapper.properties");
+        if (!Files.exists(wrapperProperties)) {
+            return Optional.empty();
+        }
+
+        Pattern distributionPattern = Pattern.compile("gradle-([0-9]+(?:\\.[0-9]+){0,2})-(?:bin|all)\\.zip");
+        try {
+            for (String line : Files.readAllLines(wrapperProperties, StandardCharsets.UTF_8)) {
+                String trimmed = line == null ? "" : line.trim();
+                if (!trimmed.startsWith("distributionUrl=")) {
+                    continue;
+                }
+                Matcher matcher = distributionPattern.matcher(trimmed);
+                if (!matcher.find()) {
+                    return Optional.empty();
+                }
+
+                String rawVersion = matcher.group(1);
+                String[] parts = rawVersion.split("\\.");
+                int major = parseIntOrZero(parts, 0);
+                int minor = parseIntOrZero(parts, 1);
+                int patch = parseIntOrZero(parts, 2);
+
+                if (major <= 0) {
+                    return Optional.empty();
+                }
+                return Optional.of(new GradleVersion(major, minor, patch));
+            }
+        } catch (Exception e) {
+            log.debug("[BUILD] Failed to parse gradle wrapper version. repoRoot={}", repoRoot, e);
+        }
+        return Optional.empty();
+    }
+
+    private int parseIntOrZero(String[] parts, int index) {
+        if (parts == null || index >= parts.length) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(parts[index]);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Integer parseJavaMajorFromHome(Path javaHome) {
+        Path releaseFile = javaHome.resolve("release");
+        if (Files.exists(releaseFile)) {
+            try {
+                for (String line : Files.readAllLines(releaseFile, StandardCharsets.UTF_8)) {
+                    String trimmed = line == null ? "" : line.trim();
+                    if (!trimmed.startsWith("JAVA_VERSION=")) {
+                        continue;
+                    }
+                    int firstQuote = trimmed.indexOf('"');
+                    int lastQuote = trimmed.lastIndexOf('"');
+                    if (firstQuote >= 0 && lastQuote > firstQuote) {
+                        String versionString = trimmed.substring(firstQuote + 1, lastQuote);
+                        Integer parsed = toMajorVersion(versionString);
+                        if (parsed != null) {
+                            return parsed;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("[BUILD] Failed to read JDK release file. javaHome={}", javaHome, e);
+            }
+        }
+
+        String fallback = javaHome.toString();
+        Matcher matcher = Pattern.compile("(?:jdk|java)[-_]?([0-9]{1,2})", Pattern.CASE_INSENSITIVE).matcher(fallback);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer toMajorVersion(String rawVersion) {
+        if (rawVersion == null || rawVersion.isBlank()) {
+            return null;
+        }
+
+        String version = rawVersion.trim();
+        if (version.startsWith("1.")) {
+            String[] parts = version.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        int dot = version.indexOf('.');
+        String majorPart = dot >= 0 ? version.substring(0, dot) : version;
+        try {
+            return Integer.parseInt(majorPart);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private int preferredJavaMajor(GradleVersion version) {
+        if (version.major() <= 6) {
+            return 11;
+        }
+        if (version.major() == 7) {
+            return version.minor() < 3 ? 11 : 17;
+        }
+        if (version.major() == 8) {
+            return version.minor() < 5 ? 17 : 21;
+        }
+        return 21;
+    }
+
+    private int compatibilityTier(GradleVersion version, int javaMajor) {
+        if (version.major() <= 6) {
+            if (javaMajor <= 11) return 4;
+            if (javaMajor <= 16) return 3;
+            return 1;
+        }
+
+        if (version.major() == 7) {
+            if (version.minor() < 3) {
+                if (javaMajor <= 11) return 4;
+                if (javaMajor <= 16) return 3;
+                if (javaMajor == 17) return 2;
+                return 1;
+            }
+            if (javaMajor <= 17) return 4;
+            if (javaMajor <= 20) return 3;
+            return 1;
+        }
+
+        if (version.major() == 8) {
+            if (version.minor() < 5) {
+                if (javaMajor <= 17) return 4;
+                if (javaMajor <= 20) return 3;
+                return 2;
+            }
+            if (javaMajor <= 21) return 4;
+            if (javaMajor <= 23) return 3;
+            return 2;
+        }
+
+        if (javaMajor >= 21) return 4;
+        if (javaMajor >= 17) return 3;
+        return 2;
+    }
+
+    private String normalizePathString(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+        try {
+            return Path.of(rawPath.trim()).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return rawPath.trim();
+        }
+    }
+
+    private record MavenJavaSelection(Optional<Integer> requiredJavaMajor, List<String> javaHomes) {
+    }
+
+    private record JavaHomeCandidate(String path, int major) {
+    }
+
+    private record GradleVersion(int major, int minor, int patch) {
     }
 
     private BuildMode decideBuildMode(List<BuildModuleManifest> modules, ProcessRunner.Result compile) {
@@ -221,27 +727,26 @@ public class BuildResolveService {
         return base.substring(0, Math.min(600, base.length()));
     }
 
-    private List<BuildModuleManifest> parseGradleDump(String output, List<BuildFailure> failures) {
+    private List<BuildModuleManifest> parseGradleDump(Path repoRoot, String output, List<BuildFailure> failures) {
         Pattern p = Pattern.compile("^OSS_DOC_DUMP=(\\{.*\\})$", Pattern.MULTILINE);
         Matcher m = p.matcher(output);
 
         List<BuildModuleManifest> modules = new ArrayList<>();
         while (m.find()) {
             try {
-                @SuppressWarnings("unchecked")
                 Map<String, Object> map = objectMapper.readValue(m.group(1), Map.class);
 
-                List<String> sourceRoots = (List<String>) map.getOrDefault("sourceRoots", List.of());
-                List<String> testRoots = (List<String>) map.getOrDefault("testRoots", List.of());
-                List<String> resourceRoots = (List<String>) map.getOrDefault("resourceRoots", List.of());
-                List<String> classesDirs = (List<String>) map.getOrDefault("classesDirs", List.of());
-                List<String> compileClasspath = (List<String>) map.getOrDefault("compileClasspath", List.of());
-                List<String> runtimeClasspath = (List<String>) map.getOrDefault("runtimeClasspath", List.of());
+                List<String> sourceRoots = readPathList(map, "sourceRoots", repoRoot);
+                List<String> testRoots = readPathList(map, "testRoots", repoRoot);
+                List<String> resourceRoots = readPathList(map, "resourceRoots", repoRoot);
+                List<String> classesDirs = readPathList(map, "classesDirs", repoRoot);
+                List<String> compileClasspath = readPathList(map, "compileClasspath", repoRoot);
+                List<String> runtimeClasspath = readPathList(map, "runtimeClasspath", repoRoot);
 
                 /**
-                 * OK → classesDirs까지 있음 → ASM 기대 가능
-                 * PARTIAL → sourceRoots는 있음 → AST 가능
-                 * FAILED → 실질 정보 없음
+                 * OK ??classesDirs? ? ??ASM ? ??
+                 * PARTIAL ??sourceRoots??? ??AST ??
+                 * FAILED ??? ? ?
                  */
                 String status;
                 if (!classesDirs.isEmpty()) {
@@ -274,15 +779,29 @@ public class BuildResolveService {
         return modules;
     }
 
-    private BuildManifest resolveMaven(String runId, Path repoRoot, boolean wrapperUsed, Path tmpDir) {
+    private List<String> readPathList(Map<String, Object> map, String key, Path repoRoot) {
+        Object rawValue = map.get(key);
+        if (!(rawValue instanceof List<?> values)) {
+            return List.of();
+        }
+
+        List<String> pathValues = new ArrayList<>();
+        for (Object value : values) {
+            if (value instanceof String path && !path.isBlank()) {
+                pathValues.add(path);
+            }
+        }
+
+        return buildPathNormalizer.toAbsolutePaths(repoRoot, pathValues);
+    }
+
+    private BuildManifest resolveMaven(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildFailure> failures = new ArrayList<>();
         List<BuildModuleManifest> modules = new ArrayList<>();
 
         try {
-            // 1) 모듈 루트 파악
             List<Path> moduleRoots = pomModuleScanner.scanModuleRoots(repoRoot);
 
-            // 모듈 루트조차 못 찾으면 SOURCE_ONLY 폴백
             if (moduleRoots.isEmpty()) {
                 return resolveMavenSourceOnly(
                         runId,
@@ -293,13 +812,19 @@ public class BuildResolveService {
                 );
             }
 
-            // 2) classpath 확보 시도
             Path classpathFile = tmpDir.resolve("maven-classpath.txt");
-            ProcessRunner.Result cpResult = mavenBuildSupport.buildClasspath(repoRoot, classpathFile);
+            Path mavenLocalRepoPath = resolveMavenLocalRepoPath(workspaceRoot);
+            MavenJavaSelection mavenJavaSelection = resolveMavenJavaSelection(repoRoot);
+            ProcessRunner.Result cpResult = runMavenWithJavaFallback(
+                    mavenLocalRepoPath,
+                    mavenJavaSelection,
+                    "classpath",
+                    env -> mavenBuildSupport.buildClasspath(repoRoot, classpathFile, mavenLocalRepoPath, env)
+            );
 
             List<String> classpath = List.of();
             if (cpResult.getExitCode() == 0) {
-                classpath = mavenBuildSupport.readClasspathFile(classpathFile);
+                classpath = mavenBuildSupport.readClasspathFile(repoRoot, classpathFile);
             } else {
                 failures.add(BuildFailure.builder()
                         .code("MAVEN_CLASSPATH_FAILED")
@@ -308,15 +833,17 @@ public class BuildResolveService {
                         .build());
             }
 
-            // 3) 컴파일 시도
-            ProcessRunner.Result compileResult = mavenBuildSupport.compile(repoRoot);
+            ProcessRunner.Result compileResult = runMavenWithJavaFallback(
+                    mavenLocalRepoPath,
+                    mavenJavaSelection,
+                    "compile",
+                    env -> mavenBuildSupport.compile(repoRoot, mavenLocalRepoPath, env)
+            );
 
-            // 4) 모듈별 manifest 생성
             for (Path moduleRoot : moduleRoots) {
                 modules.add(mavenBuildSupport.toModuleManifest(repoRoot, moduleRoot, classpath));
             }
 
-            // 모듈 manifest 자체가 비면 SOURCE_ONLY 폴백
             if (modules.isEmpty()) {
                 return resolveMavenSourceOnly(
                         runId,
@@ -327,12 +854,8 @@ public class BuildResolveService {
                 );
             }
 
-            // 5) buildMode 결정
             BuildMode mode = decideBuildMode(modules, compileResult);
 
-            // 6) compile 실패 시:
-            //    이미 만든 modules가 있으면 그걸 유지하고 SOURCE_ONLY로 반환
-            //    (scanner로 다시 덮어쓰지 않음)
             if (compileResult.getExitCode() != 0) {
                 failures.add(BuildFailure.builder()
                         .code("MAVEN_COMPILE_FAILED")
@@ -351,7 +874,6 @@ public class BuildResolveService {
                         .build();
             }
 
-            // 7) 성공 케이스
             return BuildManifest.builder()
                     .runId(runId)
                     .detectedAt(OffsetDateTime.now())
@@ -373,3 +895,4 @@ public class BuildResolveService {
         }
     }
 }
+

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
@@ -12,7 +12,6 @@ import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
 import com.example.ossdoc.domain.build.support.BuildManifestSelector;
 import com.example.ossdoc.domain.build.support.BuildManifestWriter;
-import com.example.ossdoc.domain.build.support.BuildPathNormalizer;
 import com.example.ossdoc.domain.build.support.BuildToolchainSupport;
 import com.example.ossdoc.domain.build.support.GradleBuildSupport;
 import com.example.ossdoc.domain.build.support.GradleDumpParser;
@@ -26,8 +25,8 @@ import com.example.ossdoc.domain.build.support.SourceOnlyModuleScanner;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.global.config.BuildCommandProperties;
+import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -70,15 +69,12 @@ public class BuildResolveService {
     private final PomModuleScanner pomModuleScanner;
     private final MavenBuildSupport mavenBuildSupport;
     private final MavenJavaVersionResolver mavenJavaVersionResolver;
-    private final BuildPathNormalizer buildPathNormalizer;
     private final BuildCommandProperties buildCommandProperties;
     private final BuildToolchainSupport buildToolchainSupport;
     private final BuildManifestSelector buildManifestSelector;
     private final GradleBuildSupport gradleBuildSupport;
     private final GradleInitScriptWriter gradleInitScriptWriter;
     private final GradleDumpParser gradleDumpParser;
-
-    private final ObjectMapper objectMapper;
 
     /**
      * 역할:
@@ -157,13 +153,12 @@ public class BuildResolveService {
             manifest = resolveMaven(runId, actualRepoRoot, workspaceRoot, detected.mavenWrapperExists(), tmpDir.resolve("maven"));
         }
 
-        Path buildManifestPath = buildManifestWriter.write(artifactsDir, manifest);
-        JsonNode manifestJson = objectMapper.valueToTree(manifest);
-
-        artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
+        JsonNode manifestJson = buildManifestWriter.toJson(manifest);
+        buildManifestWriter.write(artifactsDir, manifestJson);
+        Artifact savedManifest = artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
                 "build_manifest.json", manifestJson);
 
-        return new BuildResolveResponse(runId, manifest.getBuildMode(), buildPathNormalizer.normalize(buildManifestPath));
+        return new BuildResolveResponse(runId, manifest.getBuildMode(), savedManifest.getPath());
     }
 
     /**

--- a/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
+++ b/src/main/java/com/example/ossdoc/domain/build/service/BuildResolveService.java
@@ -10,27 +10,51 @@ import com.example.ossdoc.domain.build.enums.BuildMode;
 import com.example.ossdoc.domain.build.enums.BuildToolKind;
 import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
-import com.example.ossdoc.domain.build.support.*;
-import com.example.ossdoc.global.config.BuildCommandProperties;
+import com.example.ossdoc.domain.build.support.BuildManifestSelector;
+import com.example.ossdoc.domain.build.support.BuildManifestWriter;
+import com.example.ossdoc.domain.build.support.BuildPathNormalizer;
+import com.example.ossdoc.domain.build.support.BuildToolchainSupport;
+import com.example.ossdoc.domain.build.support.GradleBuildSupport;
+import com.example.ossdoc.domain.build.support.GradleDumpParser;
+import com.example.ossdoc.domain.build.support.GradleInitScriptWriter;
+import com.example.ossdoc.domain.build.support.MavenBuildSupport;
+import com.example.ossdoc.domain.build.support.MavenJavaVersionResolver;
+import com.example.ossdoc.domain.build.support.PomModuleScanner;
+import com.example.ossdoc.domain.build.support.ProcessRunner;
+import com.example.ossdoc.domain.build.support.RepoRootResolver;
+import com.example.ossdoc.domain.build.support.SourceOnlyModuleScanner;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.global.config.BuildCommandProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
+/**
+ * 역할:
+ * 빌드 리졸브 전체 흐름을 오케스트레이션한다.
+ *
+ * 책임:
+ * 1) Run/Workspace/Repo 유효성 검증
+ * 2) 빌드 도구 감지 후 Gradle/Maven 실행 분기
+ * 3) 빌드 매니페스트 산출물 저장 및 응답 반환
+ *
+ * 비책임:
+ * 세부 실행 정책(Gradle 재시도, dump 파싱, 결과 점수화)은 support 클래스로 위임한다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -41,8 +65,6 @@ public class BuildResolveService {
     private final RepoRootResolver repoRootResolver;
 
     private final BuildDetector buildDetector;
-    private final ProcessRunner processRunner;
-    private final GradleInitScriptWriter gradleInitScriptWriter;
     private final BuildManifestWriter buildManifestWriter;
     private final SourceOnlyModuleScanner sourceOnlyModuleScanner;
     private final PomModuleScanner pomModuleScanner;
@@ -50,16 +72,30 @@ public class BuildResolveService {
     private final MavenJavaVersionResolver mavenJavaVersionResolver;
     private final BuildPathNormalizer buildPathNormalizer;
     private final BuildCommandProperties buildCommandProperties;
+    private final BuildToolchainSupport buildToolchainSupport;
+    private final BuildManifestSelector buildManifestSelector;
+    private final GradleBuildSupport gradleBuildSupport;
+    private final GradleInitScriptWriter gradleInitScriptWriter;
+    private final GradleDumpParser gradleDumpParser;
 
     private final ObjectMapper objectMapper;
 
+    /**
+     * 역할:
+     * Build Resolve 유스케이스의 단일 진입점.
+     *
+     * 책임:
+     * 1) 경로/도구 상태 검증
+     * 2) Gradle/Maven 단일 혹은 경쟁 실행
+     * 3) build_manifest 생성/저장 후 API 응답 생성
+     */
     public BuildResolveResponse resolve(String runId) {
         RepoRun run = repoRunRepository.findById(runId)
                 .orElseThrow(() -> new BuildException(BuildErrorCode.RUN_NOT_FOUND));
 
         Path workspaceRoot = Path.of(run.getWorkspaceRoot());
         if (!Files.exists(workspaceRoot)) {
-            log.debug("workspeaceRoot={}", workspaceRoot.toString());
+            log.debug("workspeaceRoot={}", workspaceRoot);
             throw new BuildException(BuildErrorCode.WORKSPACE_NOT_FOUND);
         }
 
@@ -67,7 +103,7 @@ public class BuildResolveService {
         Path actualRepoRoot = repoRootResolver.resolveActualRoot(repoRoot);
 
         if (!Files.exists(actualRepoRoot)) {
-            log.debug("actualRepoRoot={}", actualRepoRoot.toString());
+            log.debug("actualRepoRoot={}", actualRepoRoot);
             throw new BuildException(BuildErrorCode.REPO_ROOT_NOT_FOUND);
         }
 
@@ -76,10 +112,10 @@ public class BuildResolveService {
 
         BuildDetector.Detected detected = buildDetector.detect(actualRepoRoot);
 
-        BuildManifest manifest = switch (detected.tool()) {
-            case GRADLE -> resolveGradle(runId, actualRepoRoot, workspaceRoot, detected.wrapperExists(), tmpDir);
-            case MAVEN -> resolveMaven(runId, actualRepoRoot, workspaceRoot, detected.wrapperExists(), tmpDir);
-            case NONE -> BuildManifest.builder()
+        BuildManifest manifest;
+        if (!detected.hasAnyBuildTool()) {
+            // 빌드 도구 자체가 없으면 즉시 FAILED
+            manifest = BuildManifest.builder()
                     .runId(runId)
                     .detectedAt(OffsetDateTime.now())
                     .buildTool(BuildToolKind.NONE)
@@ -90,10 +126,38 @@ public class BuildResolveService {
                             .message(BuildErrorCode.BUILD_TOOL_NOT_FOUND.getMessage())
                             .build()))
                     .build();
-        };
+        } else if (detected.hasGradle() && detected.hasMaven()) {
+            // 혼합 프로젝트(Gradle+Maven)는 둘 다 실행 후 더 좋은 결과를 선택한다.
+            log.info("[BUILD] Both Gradle and Maven detected. Running competitive resolve. repoRoot={}", actualRepoRoot);
+            BuildManifest gradleManifest = resolveGradle(
+                    runId,
+                    actualRepoRoot,
+                    workspaceRoot,
+                    detected.gradleWrapperExists(),
+                    tmpDir.resolve("gradle")
+            );
+            BuildManifest mavenManifest = resolveMaven(
+                    runId,
+                    actualRepoRoot,
+                    workspaceRoot,
+                    detected.mavenWrapperExists(),
+                    tmpDir.resolve("maven")
+            );
+            manifest = buildManifestSelector.selectBetter(gradleManifest, mavenManifest);
+            log.info(
+                    "[BUILD] Competitive resolve selected tool={} mode={} (gradleMode={}, mavenMode={})",
+                    manifest.getBuildTool(),
+                    manifest.getBuildMode(),
+                    gradleManifest.getBuildMode(),
+                    mavenManifest.getBuildMode()
+            );
+        } else if (detected.hasGradle()) {
+            manifest = resolveGradle(runId, actualRepoRoot, workspaceRoot, detected.gradleWrapperExists(), tmpDir.resolve("gradle"));
+        } else {
+            manifest = resolveMaven(runId, actualRepoRoot, workspaceRoot, detected.mavenWrapperExists(), tmpDir.resolve("maven"));
+        }
 
         Path buildManifestPath = buildManifestWriter.write(artifactsDir, manifest);
-
         JsonNode manifestJson = objectMapper.valueToTree(manifest);
 
         artifactService.saveJsonArtifact(run, ArtifactKind.BUILD_MANIFEST, "0.1",
@@ -102,6 +166,15 @@ public class BuildResolveService {
         return new BuildResolveResponse(runId, manifest.getBuildMode(), buildPathNormalizer.normalize(buildManifestPath));
     }
 
+    /**
+     * 역할:
+     * Gradle 기반 빌드/리졸브를 수행한다.
+     *
+     * 책임:
+     * 1) ossdocDump 실행 후 모듈 메타데이터 수집
+     * 2) classes 컴파일 결과를 반영해 BuildMode 결정
+     * 3) 실패 시 SOURCE_ONLY 폴백 정보를 failures에 기록
+     */
     private BuildManifest resolveGradle(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildModuleManifest> modules = new ArrayList<>();
         List<BuildFailure> failures = new ArrayList<>();
@@ -109,16 +182,22 @@ public class BuildResolveService {
         Path init = gradleInitScriptWriter.write(tmpDir);
 
         List<String> dumpCmd = List.of(
-                selectGradleCmd(repoRoot),
+                gradleBuildSupport.selectGradleCmd(repoRoot),
                 "-I", init.toString(),
                 "ossdocDump",
                 "-q",
                 "--no-daemon"
         );
 
-        ProcessRunner.Result dump = runGradleWithJavaFallback(repoRoot, workspaceRoot, dumpCmd, Duration.ofMinutes(10), "dump");
+        ProcessRunner.Result dump = gradleBuildSupport.runWithJavaFallback(
+                repoRoot,
+                workspaceRoot,
+                dumpCmd,
+                Duration.ofMinutes(10),
+                "dump"
+        );
         if (dump.getExitCode() == 0) {
-            modules.addAll(parseGradleDump(repoRoot, dump.getOutput(), failures));
+            modules.addAll(gradleDumpParser.parse(repoRoot, dump.getOutput(), failures));
 
             if (modules.isEmpty()) {
                 failures.add(BuildFailure.builder()
@@ -140,14 +219,20 @@ public class BuildResolveService {
         }
 
         List<String> compileCmd = List.of(
-                selectGradleCmd(repoRoot),
+                gradleBuildSupport.selectGradleCmd(repoRoot),
                 "classes",
                 "-x", "test",
                 "-x", "check",
                 "--no-daemon"
         );
 
-        ProcessRunner.Result compile = runGradleWithJavaFallback(repoRoot, workspaceRoot, compileCmd, Duration.ofMinutes(20), "compile");
+        ProcessRunner.Result compile = gradleBuildSupport.runWithJavaFallback(
+                repoRoot,
+                workspaceRoot,
+                compileCmd,
+                Duration.ofMinutes(20),
+                "compile"
+        );
 
         BuildMode mode = decideBuildMode(modules, compile);
         if (compile.getExitCode() != 0 && mode != BuildMode.FAILED) {
@@ -169,6 +254,14 @@ public class BuildResolveService {
                 .build();
     }
 
+    /**
+     * 역할:
+     * Maven 실행 불가/예외 상황에서 source-only 결과를 생성한다.
+     *
+     * 책임:
+     * 1) 소스 루트 스캔 결과만으로 최소 매니페스트 구성
+     * 2) 실패 원인을 BuildFailure로 명시
+     */
     private BuildManifest resolveMavenSourceOnly(String runId, Path repoRoot, boolean wrapperUsed, String reason, String logHint) {
         List<BuildModuleManifest> modules = sourceOnlyModuleScanner.scan(repoRoot);
 
@@ -192,70 +285,15 @@ public class BuildResolveService {
                 .build();
     }
 
-    private String selectGradleCmd(Path repoRoot) {
-        // Windows   gradlew.bat 
-        if (Files.exists(repoRoot.resolve("gradlew.bat"))) return "gradlew.bat";
-        if (Files.exists(repoRoot.resolve("gradlew"))) return "./gradlew";
-        return buildCommandProperties.getGradleCommand();
-    }
-
-    private ProcessRunner.Result runGradleWithJavaFallback(Path repoRoot,
-                                                           Path workspaceRoot,
-                                                           List<String> command,
-                                                           Duration timeout,
-                                                           String stage) {
-        Map<String, String> baseEnvironment = resolveGradleBaseEnvironment(workspaceRoot);
-        List<String> candidates = resolveJavaHomeCandidates(repoRoot);
-
-        ProcessRunner.Result first;
-        String selectedJavaHome = null;
-        if (candidates.isEmpty()) {
-            first = processRunner.run(repoRoot, command, timeout, baseEnvironment);
-        } else {
-            selectedJavaHome = candidates.get(0);
-            first = processRunner.run(repoRoot, command, timeout, buildEnvironment(baseEnvironment, selectedJavaHome));
-            log.info("[BUILD] Gradle {} initial JAVA_HOME={} (version-aware selection)", stage, selectedJavaHome);
-        }
-
-        if (first.getExitCode() == 0) {
-            return first;
-        }
-
-        Optional<String> compatibilityReason = detectJavaCompatibilityReason(BuildToolKind.GRADLE, first);
-        if (compatibilityReason.isEmpty()) {
-            if (selectedJavaHome != null && !isCurrentRuntimeJavaHome(selectedJavaHome)) {
-                ProcessRunner.Result baseline = processRunner.run(repoRoot, command, timeout, baseEnvironment);
-                if (baseline.getExitCode() == 0) {
-                    log.info("[BUILD] Gradle {} fallback to current runtime JVM succeeded", stage);
-                    return baseline;
-                }
-            }
-            return first;
-        }
-        log.info("[BUILD] Gradle {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
-
-        ProcessRunner.Result last = first;
-        for (String javaHome : candidates) {
-            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
-                continue;
-            }
-
-            log.info("[BUILD] Gradle {} retry with JAVA_HOME={}", stage, javaHome);
-            ProcessRunner.Result retry = processRunner.run(
-                    repoRoot,
-                    command,
-                    timeout,
-                    buildEnvironment(baseEnvironment, javaHome)
-            );
-            if (retry.getExitCode() == 0) {
-                return retry;
-            }
-            last = retry;
-        }
-
-        return last;
-    }
-
+    /**
+     * 역할:
+     * Maven 실행 시 JAVA_HOME 후보를 순차 적용해 재시도한다.
+     *
+     * 책임:
+     * 1) 1순위 JDK로 실행
+     * 2) 호환성 에러 감지 시 후보 JDK 순차 재시도
+     * 3) 필요 시 현재 런타임 JVM으로 baseline 폴백
+     */
     private ProcessRunner.Result runMavenWithJavaFallback(Path mavenLocalRepoPath,
                                                           MavenJavaSelection selection,
                                                           String stage,
@@ -268,7 +306,7 @@ public class BuildResolveService {
             first = runner.apply(Map.of());
         } else {
             selectedJavaHome = candidates.get(0);
-            first = runner.apply(buildEnvironment(Map.of(), selectedJavaHome));
+            first = runner.apply(buildToolchainSupport.buildEnvironment(Map.of(), selectedJavaHome));
             log.info(
                     "[BUILD] Maven {} initial JAVA_HOME={} (requiredJava={}, repoLocal={})",
                     stage,
@@ -282,9 +320,9 @@ public class BuildResolveService {
             return first;
         }
 
-        Optional<String> compatibilityReason = detectJavaCompatibilityReason(BuildToolKind.MAVEN, first);
+        Optional<String> compatibilityReason = buildToolchainSupport.detectJavaCompatibilityReason(BuildToolKind.MAVEN, first);
         if (compatibilityReason.isEmpty()) {
-            if (selectedJavaHome != null && !isCurrentRuntimeJavaHome(selectedJavaHome)) {
+            if (selectedJavaHome != null && !buildToolchainSupport.isCurrentRuntimeJavaHome(selectedJavaHome)) {
                 ProcessRunner.Result baseline = runner.apply(Map.of());
                 if (baseline.getExitCode() == 0) {
                     log.info("[BUILD] Maven {} fallback to current runtime JVM succeeded", stage);
@@ -301,7 +339,7 @@ public class BuildResolveService {
                 continue;
             }
             log.info("[BUILD] Maven {} retry with JAVA_HOME={}", stage, javaHome);
-            ProcessRunner.Result retry = runner.apply(buildEnvironment(Map.of(), javaHome));
+            ProcessRunner.Result retry = runner.apply(buildToolchainSupport.buildEnvironment(Map.of(), javaHome));
             if (retry.getExitCode() == 0) {
                 return retry;
             }
@@ -313,197 +351,18 @@ public class BuildResolveService {
 
     private MavenJavaSelection resolveMavenJavaSelection(Path repoRoot) {
         Optional<Integer> requiredJavaMajor = mavenJavaVersionResolver.resolveRequiredJavaMajor(repoRoot);
-        List<String> javaHomes = resolveJavaHomeCandidatesForMaven(requiredJavaMajor);
+        List<String> javaHomes = buildToolchainSupport.resolveJavaHomeCandidatesForMaven(requiredJavaMajor);
         return new MavenJavaSelection(requiredJavaMajor, javaHomes);
     }
 
-    private Optional<String> detectJavaCompatibilityReason(BuildToolKind buildToolKind, ProcessRunner.Result result) {
-        String text = ((result.getOutput() == null ? "" : result.getOutput()) + "\n"
-                + (result.getError() == null ? "" : result.getError())).toLowerCase(Locale.ROOT);
-
-        List<String> commonSignals = List.of(
-                "unsupported class file major version",
-                "unsupported major.minor version",
-                "has been compiled by a more recent version",
-                "could not determine java version"
-        );
-        for (String signal : commonSignals) {
-            if (text.contains(signal)) {
-                return Optional.of(signal);
-            }
-        }
-
-        if (buildToolKind == BuildToolKind.GRADLE) {
-            List<String> gradleSignals = List.of(
-                    "this version of gradle supports java",
-                    "minimum supported gradle version"
-            );
-            for (String signal : gradleSignals) {
-                if (text.contains(signal)) {
-                    return Optional.of(signal);
-                }
-            }
-            return Optional.empty();
-        }
-
-        if (buildToolKind == BuildToolKind.MAVEN) {
-            List<String> mavenSignals = List.of(
-                    "invalid target release",
-                    "invalid source release",
-                    "release version",
-                    "source option",
-                    "target option",
-                    "no toolchain found for type jdk",
-                    "cannot find matching toolchain definitions for the following toolchain types",
-                    "error: source release",
-                    "error: target release"
-            );
-            for (String signal : mavenSignals) {
-                if (!text.contains(signal)) {
-                    continue;
-                }
-
-                if ("release version".equals(signal) && !text.contains("not supported")) {
-                    continue;
-                }
-                if (("source option".equals(signal) || "target option".equals(signal))
-                        && !text.contains("is no longer supported")) {
-                    continue;
-                }
-                return Optional.of(signal);
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    private boolean isCurrentRuntimeJavaHome(String javaHome) {
-        String normalized = normalizePathString(javaHome);
-        if (normalized == null) {
-            return false;
-        }
-        String currentJavaHome = normalizePathString(System.getenv("JAVA_HOME"));
-        String currentRuntimeHome = normalizePathString(System.getProperty("java.home"));
-        return normalized.equalsIgnoreCase(currentJavaHome) || normalized.equalsIgnoreCase(currentRuntimeHome);
-    }
-
-    private List<String> resolveJavaHomeCandidates(Path repoRoot) {
-        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
-        if (candidates.isEmpty()) {
-            return List.of();
-        }
-
-        Optional<GradleVersion> gradleVersion = parseGradleVersionFromWrapper(repoRoot);
-        if (gradleVersion.isPresent()) {
-            GradleVersion version = gradleVersion.get();
-            int preferredJava = preferredJavaMajor(version);
-
-            candidates.sort((left, right) -> {
-                int tierCompare = Integer.compare(
-                        compatibilityTier(version, right.major()),
-                        compatibilityTier(version, left.major())
-                );
-                if (tierCompare != 0) {
-                    return tierCompare;
-                }
-
-                int leftDistance = Math.abs(left.major() - preferredJava);
-                int rightDistance = Math.abs(right.major() - preferredJava);
-                int distanceCompare = Integer.compare(leftDistance, rightDistance);
-                if (distanceCompare != 0) {
-                    return distanceCompare;
-                }
-                return Integer.compare(right.major(), left.major());
-            });
-        }
-        return toJavaHomePaths(candidates);
-    }
-
-    private List<String> resolveJavaHomeCandidatesForMaven(Optional<Integer> requiredJavaMajor) {
-        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
-        if (candidates.isEmpty()) {
-            return List.of();
-        }
-
-        if (requiredJavaMajor.isPresent()) {
-            int requiredMajor = requiredJavaMajor.get();
-            candidates.sort((left, right) -> {
-                boolean leftAdequate = left.major() >= requiredMajor;
-                boolean rightAdequate = right.major() >= requiredMajor;
-
-                if (leftAdequate != rightAdequate) {
-                    return Boolean.compare(rightAdequate, leftAdequate);
-                }
-
-                if (leftAdequate) {
-                    int leftDistance = Math.abs(left.major() - requiredMajor);
-                    int rightDistance = Math.abs(right.major() - requiredMajor);
-                    int distanceCompare = Integer.compare(leftDistance, rightDistance);
-                    if (distanceCompare != 0) {
-                        return distanceCompare;
-                    }
-                    return Integer.compare(left.major(), right.major());
-                }
-
-                return Integer.compare(right.major(), left.major());
-            });
-        }
-
-        return toJavaHomePaths(candidates);
-    }
-
-    private List<JavaHomeCandidate> loadConfiguredJavaHomeCandidates() {
-        List<String> configured = buildCommandProperties.getJavaHomes();
-        if (configured == null || configured.isEmpty()) {
-            return List.of();
-        }
-
-        List<JavaHomeCandidate> candidates = new ArrayList<>();
-        for (String candidate : configured) {
-            String normalized = normalizePathString(candidate);
-            if (normalized == null) {
-                continue;
-            }
-            Path javaHomePath = Path.of(normalized);
-            if (!Files.exists(javaHomePath) || !Files.isDirectory(javaHomePath)) {
-                continue;
-            }
-
-            Integer javaMajor = parseJavaMajorFromHome(javaHomePath);
-            if (javaMajor == null) {
-                continue;
-            }
-            candidates.add(new JavaHomeCandidate(normalized, javaMajor));
-        }
-        return candidates;
-    }
-
-    private List<String> toJavaHomePaths(List<JavaHomeCandidate> candidates) {
-        List<String> result = new ArrayList<>();
-        for (JavaHomeCandidate candidate : candidates) {
-            result.add(candidate.path());
-        }
-        return result;
-    }
-
-    private Map<String, String> resolveGradleBaseEnvironment(Path workspaceRoot) {
-        Map<String, String> env = new HashMap<>();
-        if (!buildCommandProperties.isIsolatedExecution()) {
-            return env;
-        }
-
-        Path gradleUserHome = workspaceRoot.resolve(buildCommandProperties.getGradleUserHomeDir())
-                .toAbsolutePath()
-                .normalize();
-        try {
-            Files.createDirectories(gradleUserHome);
-            env.put("GRADLE_USER_HOME", gradleUserHome.toString());
-        } catch (IOException e) {
-            log.warn("[BUILD] Failed to create GRADLE_USER_HOME directory. path={}", gradleUserHome, e);
-        }
-        return env;
-    }
-
+    /**
+     * 역할:
+     * 격리 실행 모드에서 Run 전용 Maven local repository 경로를 준비한다.
+     *
+     * 책임:
+     * 1) 디렉터리 생성 보장
+     * 2) 생성 실패 시 경고 로그 후 null 반환
+     */
     private Path resolveMavenLocalRepoPath(Path workspaceRoot) {
         if (!buildCommandProperties.isIsolatedExecution()) {
             return null;
@@ -518,196 +377,6 @@ public class BuildResolveService {
             log.warn("[BUILD] Failed to create Maven local repository path. path={}", mavenLocalRepo, e);
             return null;
         }
-    }
-
-    private Map<String, String> buildEnvironment(Map<String, String> baseEnvironment, String javaHome) {
-        Map<String, String> env = new HashMap<>(baseEnvironment);
-        env.put("JAVA_HOME", javaHome);
-
-        String binPath = javaHome + File.separator + "bin";
-        String currentPath = Optional.ofNullable(System.getenv("PATH")).orElse("");
-        String mergedPath = currentPath.isBlank() ? binPath : binPath + File.pathSeparator + currentPath;
-
-        env.put("PATH", mergedPath);
-        env.put("Path", mergedPath);
-        return env;
-    }
-
-    private Optional<GradleVersion> parseGradleVersionFromWrapper(Path repoRoot) {
-        Path wrapperProperties = repoRoot.resolve("gradle").resolve("wrapper").resolve("gradle-wrapper.properties");
-        if (!Files.exists(wrapperProperties)) {
-            return Optional.empty();
-        }
-
-        Pattern distributionPattern = Pattern.compile("gradle-([0-9]+(?:\\.[0-9]+){0,2})-(?:bin|all)\\.zip");
-        try {
-            for (String line : Files.readAllLines(wrapperProperties, StandardCharsets.UTF_8)) {
-                String trimmed = line == null ? "" : line.trim();
-                if (!trimmed.startsWith("distributionUrl=")) {
-                    continue;
-                }
-                Matcher matcher = distributionPattern.matcher(trimmed);
-                if (!matcher.find()) {
-                    return Optional.empty();
-                }
-
-                String rawVersion = matcher.group(1);
-                String[] parts = rawVersion.split("\\.");
-                int major = parseIntOrZero(parts, 0);
-                int minor = parseIntOrZero(parts, 1);
-                int patch = parseIntOrZero(parts, 2);
-
-                if (major <= 0) {
-                    return Optional.empty();
-                }
-                return Optional.of(new GradleVersion(major, minor, patch));
-            }
-        } catch (Exception e) {
-            log.debug("[BUILD] Failed to parse gradle wrapper version. repoRoot={}", repoRoot, e);
-        }
-        return Optional.empty();
-    }
-
-    private int parseIntOrZero(String[] parts, int index) {
-        if (parts == null || index >= parts.length) {
-            return 0;
-        }
-        try {
-            return Integer.parseInt(parts[index]);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    private Integer parseJavaMajorFromHome(Path javaHome) {
-        Path releaseFile = javaHome.resolve("release");
-        if (Files.exists(releaseFile)) {
-            try {
-                for (String line : Files.readAllLines(releaseFile, StandardCharsets.UTF_8)) {
-                    String trimmed = line == null ? "" : line.trim();
-                    if (!trimmed.startsWith("JAVA_VERSION=")) {
-                        continue;
-                    }
-                    int firstQuote = trimmed.indexOf('"');
-                    int lastQuote = trimmed.lastIndexOf('"');
-                    if (firstQuote >= 0 && lastQuote > firstQuote) {
-                        String versionString = trimmed.substring(firstQuote + 1, lastQuote);
-                        Integer parsed = toMajorVersion(versionString);
-                        if (parsed != null) {
-                            return parsed;
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                log.debug("[BUILD] Failed to read JDK release file. javaHome={}", javaHome, e);
-            }
-        }
-
-        String fallback = javaHome.toString();
-        Matcher matcher = Pattern.compile("(?:jdk|java)[-_]?([0-9]{1,2})", Pattern.CASE_INSENSITIVE).matcher(fallback);
-        if (matcher.find()) {
-            try {
-                return Integer.parseInt(matcher.group(1));
-            } catch (NumberFormatException ignored) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    private Integer toMajorVersion(String rawVersion) {
-        if (rawVersion == null || rawVersion.isBlank()) {
-            return null;
-        }
-
-        String version = rawVersion.trim();
-        if (version.startsWith("1.")) {
-            String[] parts = version.split("\\.");
-            if (parts.length > 1) {
-                try {
-                    return Integer.parseInt(parts[1]);
-                } catch (NumberFormatException ignored) {
-                    return null;
-                }
-            }
-            return null;
-        }
-
-        int dot = version.indexOf('.');
-        String majorPart = dot >= 0 ? version.substring(0, dot) : version;
-        try {
-            return Integer.parseInt(majorPart);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private int preferredJavaMajor(GradleVersion version) {
-        if (version.major() <= 6) {
-            return 11;
-        }
-        if (version.major() == 7) {
-            return version.minor() < 3 ? 11 : 17;
-        }
-        if (version.major() == 8) {
-            return version.minor() < 5 ? 17 : 21;
-        }
-        return 21;
-    }
-
-    private int compatibilityTier(GradleVersion version, int javaMajor) {
-        if (version.major() <= 6) {
-            if (javaMajor <= 11) return 4;
-            if (javaMajor <= 16) return 3;
-            return 1;
-        }
-
-        if (version.major() == 7) {
-            if (version.minor() < 3) {
-                if (javaMajor <= 11) return 4;
-                if (javaMajor <= 16) return 3;
-                if (javaMajor == 17) return 2;
-                return 1;
-            }
-            if (javaMajor <= 17) return 4;
-            if (javaMajor <= 20) return 3;
-            return 1;
-        }
-
-        if (version.major() == 8) {
-            if (version.minor() < 5) {
-                if (javaMajor <= 17) return 4;
-                if (javaMajor <= 20) return 3;
-                return 2;
-            }
-            if (javaMajor <= 21) return 4;
-            if (javaMajor <= 23) return 3;
-            return 2;
-        }
-
-        if (javaMajor >= 21) return 4;
-        if (javaMajor >= 17) return 3;
-        return 2;
-    }
-
-    private String normalizePathString(String rawPath) {
-        if (rawPath == null || rawPath.isBlank()) {
-            return null;
-        }
-        try {
-            return Path.of(rawPath.trim()).toAbsolutePath().normalize().toString();
-        } catch (Exception e) {
-            return rawPath.trim();
-        }
-    }
-
-    private record MavenJavaSelection(Optional<Integer> requiredJavaMajor, List<String> javaHomes) {
-    }
-
-    private record JavaHomeCandidate(String path, int major) {
-    }
-
-    private record GradleVersion(int major, int minor, int patch) {
     }
 
     private BuildMode decideBuildMode(List<BuildModuleManifest> modules, ProcessRunner.Result compile) {
@@ -727,79 +396,22 @@ public class BuildResolveService {
         return base.substring(0, Math.min(600, base.length()));
     }
 
-    private List<BuildModuleManifest> parseGradleDump(Path repoRoot, String output, List<BuildFailure> failures) {
-        Pattern p = Pattern.compile("^OSS_DOC_DUMP=(\\{.*\\})$", Pattern.MULTILINE);
-        Matcher m = p.matcher(output);
-
-        List<BuildModuleManifest> modules = new ArrayList<>();
-        while (m.find()) {
-            try {
-                Map<String, Object> map = objectMapper.readValue(m.group(1), Map.class);
-
-                List<String> sourceRoots = readPathList(map, "sourceRoots", repoRoot);
-                List<String> testRoots = readPathList(map, "testRoots", repoRoot);
-                List<String> resourceRoots = readPathList(map, "resourceRoots", repoRoot);
-                List<String> classesDirs = readPathList(map, "classesDirs", repoRoot);
-                List<String> compileClasspath = readPathList(map, "compileClasspath", repoRoot);
-                List<String> runtimeClasspath = readPathList(map, "runtimeClasspath", repoRoot);
-
-                /**
-                 * OK ??classesDirs? ? ??ASM ? ??
-                 * PARTIAL ??sourceRoots??? ??AST ??
-                 * FAILED ??? ? ?
-                 */
-                String status;
-                if (!classesDirs.isEmpty()) {
-                    status = "OK";
-                } else if (!sourceRoots.isEmpty() || !testRoots.isEmpty() || !resourceRoots.isEmpty()) {
-                    status = "PARTIAL";
-                } else {
-                    status = "FAILED";
-                }
-
-                modules.add(BuildModuleManifest.builder()
-                        .moduleId((String) map.getOrDefault("projectPath", ""))
-                        .name((String) map.getOrDefault("name", ""))
-                        .sourceRoots(sourceRoots)
-                        .testRoots(testRoots)
-                        .resourceRoots(resourceRoots)
-                        .classesDirs(classesDirs)
-                        .compileClasspath(compileClasspath)
-                        .runtimeClasspath(runtimeClasspath)
-                        .status(status)
-                        .build());
-
-            } catch (Exception e) {
-                failures.add(BuildFailure.builder()
-                        .code(BuildErrorCode.GRADLE_DUMP_FAILED.getCode())
-                        .message("Failed to parse OSS_DOC_DUMP - " + e.getMessage())
-                        .build());
-            }
-        }
-        return modules;
-    }
-
-    private List<String> readPathList(Map<String, Object> map, String key, Path repoRoot) {
-        Object rawValue = map.get(key);
-        if (!(rawValue instanceof List<?> values)) {
-            return List.of();
-        }
-
-        List<String> pathValues = new ArrayList<>();
-        for (Object value : values) {
-            if (value instanceof String path && !path.isBlank()) {
-                pathValues.add(path);
-            }
-        }
-
-        return buildPathNormalizer.toAbsolutePaths(repoRoot, pathValues);
-    }
-
+    /**
+     * 역할:
+     * Maven 기반 빌드/리졸브를 수행한다.
+     *
+     * 책임:
+     * 1) 모듈 스캔 + classpath 생성
+     * 2) compile 수행 후 BuildMode 결정
+     * 3) 실패 시 SOURCE_ONLY로 안전 폴백
+     */
     private BuildManifest resolveMaven(String runId, Path repoRoot, Path workspaceRoot, boolean wrapperUsed, Path tmpDir) {
         List<BuildFailure> failures = new ArrayList<>();
         List<BuildModuleManifest> modules = new ArrayList<>();
 
         try {
+            Files.createDirectories(tmpDir);
+
             List<Path> moduleRoots = pomModuleScanner.scanModuleRoots(repoRoot);
 
             if (moduleRoots.isEmpty()) {
@@ -894,5 +506,7 @@ public class BuildResolveService {
             );
         }
     }
-}
 
+    private record MavenJavaSelection(Optional<Integer> requiredJavaMajor, List<String> javaHomes) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestSelector.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestSelector.java
@@ -1,0 +1,100 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.dto.json.BuildManifest;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.build.enums.BuildMode;
+import org.springframework.stereotype.Component;
+
+/**
+ * 역할:
+ * Gradle/Maven 빌드 결과 중 더 품질이 높은 매니페스트를 선택한다.
+ *
+ * 책임:
+ * 1) BuildMode 우선 비교(FULL > COMPILE_ONLY > SOURCE_ONLY > FAILED)
+ * 2) 동점 시 classesDirs/모듈 수/실패 수 순으로 비교
+ * 3) 완전 동점 시 기존 정책(Gradle 우선) 유지
+ */
+@Component
+public class BuildManifestSelector {
+
+    /**
+     * 역할:
+     * 두 매니페스트 중 최종 채택 대상을 반환한다.
+     *
+     * 책임:
+     * 내부 품질 점수 비교 결과를 정책에 맞게 해석해 반환한다.
+     */
+    public BuildManifest selectBetter(BuildManifest gradleManifest, BuildManifest mavenManifest) {
+        // 점수 비교 결과가 0 이상이면 left(Gradle) 선택: 동률 시 기존 우선순위 유지
+        int comparison = compareQuality(gradleManifest, mavenManifest);
+        return comparison >= 0 ? gradleManifest : mavenManifest;
+    }
+
+    private int compareQuality(BuildManifest left, BuildManifest right) {
+        // 1순위: buildMode
+        int modeComparison = Integer.compare(buildModeScore(left.getBuildMode()), buildModeScore(right.getBuildMode()));
+        if (modeComparison != 0) {
+            return modeComparison;
+        }
+
+        // 2순위: classesDirs 확보량(바이트코드 분석 가능성)
+        int leftClasses = classesDirCount(left);
+        int rightClasses = classesDirCount(right);
+        int classesComparison = Integer.compare(leftClasses, rightClasses);
+        if (classesComparison != 0) {
+            return classesComparison;
+        }
+
+        // 3순위: 모듈 수
+        int leftModules = moduleCount(left);
+        int rightModules = moduleCount(right);
+        int moduleComparison = Integer.compare(leftModules, rightModules);
+        if (moduleComparison != 0) {
+            return moduleComparison;
+        }
+
+        // 4순위: 실패 수(적을수록 우수)
+        int leftFailureCount = failureCount(left);
+        int rightFailureCount = failureCount(right);
+        int failureComparison = Integer.compare(rightFailureCount, leftFailureCount);
+        if (failureComparison != 0) {
+            return failureComparison;
+        }
+
+        // 동률이면 기존 우선순위(Gradle 우선)를 유지한다.
+        return 0;
+    }
+
+    private int buildModeScore(BuildMode mode) {
+        if (mode == null) return 0;
+        return switch (mode) {
+            case FULL -> 4;
+            case COMPILE_ONLY -> 3;
+            case SOURCE_ONLY -> 2;
+            case FAILED -> 1;
+        };
+    }
+
+    private int classesDirCount(BuildManifest manifest) {
+        if (manifest == null || manifest.getModules() == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (BuildModuleManifest module : manifest.getModules()) {
+            if (module == null || module.getClassesDirs() == null) {
+                continue;
+            }
+            count += module.getClassesDirs().size();
+        }
+        return count;
+    }
+
+    private int moduleCount(BuildManifest manifest) {
+        return manifest == null || manifest.getModules() == null ? 0 : manifest.getModules().size();
+    }
+
+    private int failureCount(BuildManifest manifest) {
+        return manifest == null || manifest.getFailures() == null ? 0 : manifest.getFailures().size();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildManifestWriter.java
@@ -3,6 +3,7 @@ package com.example.ossdoc.domain.build.support;
 import com.example.ossdoc.domain.build.dto.json.BuildManifest;
 import com.example.ossdoc.domain.build.exception.BuildException;
 import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +19,20 @@ public class BuildManifestWriter {
 
     private final ObjectMapper objectMapper;
 
-    public Path write(Path artifactsDir, BuildManifest manifest) {
+    public JsonNode toJson(BuildManifest manifest) {
+        try {
+            return objectMapper.valueToTree(manifest);
+        } catch (Exception e) {
+            log.debug("BuildManifestWriter error={}", e);
+            throw new BuildException(BuildErrorCode.BUILD_MANIFEST_WRITE_FAILED);
+        }
+    }
+
+    public Path write(Path artifactsDir, JsonNode buildManifest) {
         try {
             Files.createDirectories(artifactsDir);
             Path out = artifactsDir.resolve("build_manifest.json");
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), manifest);
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), buildManifest);
             return out;
         } catch (Exception e) {
             log.debug("BuildManifestWriter error={}", e);

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildPathNormalizer.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildPathNormalizer.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.build.support;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BuildPathNormalizer {
+
+    public List<String> toAbsolutePaths(Path baseDir, List<String> rawPaths) {
+        if (rawPaths == null || rawPaths.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> normalized = new ArrayList<>();
+        for (String rawPath : rawPaths) {
+            String resolved = toAbsolutePath(baseDir, rawPath);
+            if (resolved != null) {
+                normalized.add(resolved);
+            }
+        }
+        return normalized;
+    }
+
+    public String toAbsolutePath(Path baseDir, String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+
+        try {
+            Path path = Path.of(rawPath.trim());
+            Path resolved = path.isAbsolute() ? path : baseDir.resolve(path);
+            return normalize(resolved);
+        } catch (InvalidPathException e) {
+            return rawPath.trim().replace("\\", "/");
+        }
+    }
+
+    public String normalize(Path path) {
+        return path.toAbsolutePath().normalize().toString().replace("\\", "/");
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/BuildToolchainSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/BuildToolchainSupport.java
@@ -1,0 +1,433 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.enums.BuildToolKind;
+import com.example.ossdoc.global.config.BuildCommandProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 역할:
+ * 빌드 실행에 필요한 JDK 선택/호환성 판단 규칙을 제공한다.
+ *
+ * 책임:
+ * 1) 설정된 JAVA_HOME 후보 로드 및 버전 파싱
+ * 2) Gradle/Maven별 우선순위에 따라 후보 정렬
+ * 3) 빌드 로그에서 Java 호환성 실패 신호 감지
+ * 4) JAVA_HOME/PATH 실행 환경 맵 구성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuildToolchainSupport {
+
+    private final BuildCommandProperties buildCommandProperties;
+
+    /**
+     * 역할:
+     * Gradle 실행용 JAVA_HOME 후보 목록을 우선순위대로 반환한다.
+     *
+     * 책임:
+     * gradle-wrapper 버전을 참고해 호환성이 높은 JDK가 먼저 오도록 정렬한다.
+     */
+    public List<String> resolveJavaHomeCandidatesForGradle(Path repoRoot) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        Optional<GradleVersion> gradleVersion = parseGradleVersionFromWrapper(repoRoot);
+        if (gradleVersion.isPresent()) {
+            GradleVersion version = gradleVersion.get();
+            int preferredJava = preferredJavaMajor(version);
+
+            candidates.sort((left, right) -> {
+                int tierCompare = Integer.compare(
+                        compatibilityTier(version, right.major()),
+                        compatibilityTier(version, left.major())
+                );
+                if (tierCompare != 0) {
+                    return tierCompare;
+                }
+
+                int leftDistance = Math.abs(left.major() - preferredJava);
+                int rightDistance = Math.abs(right.major() - preferredJava);
+                int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                if (distanceCompare != 0) {
+                    return distanceCompare;
+                }
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+        return toJavaHomePaths(candidates);
+    }
+
+    /**
+     * 역할:
+     * Maven 실행용 JAVA_HOME 후보 목록을 우선순위대로 반환한다.
+     *
+     * 책임:
+     * pom 분석으로 얻은 requiredJava를 기준으로 적합한 JDK를 앞쪽에 배치한다.
+     */
+    public List<String> resolveJavaHomeCandidatesForMaven(Optional<Integer> requiredJavaMajor) {
+        List<JavaHomeCandidate> candidates = loadConfiguredJavaHomeCandidates();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        if (requiredJavaMajor.isPresent()) {
+            int requiredMajor = requiredJavaMajor.get();
+            candidates.sort((left, right) -> {
+                boolean leftAdequate = left.major() >= requiredMajor;
+                boolean rightAdequate = right.major() >= requiredMajor;
+
+                if (leftAdequate != rightAdequate) {
+                    return Boolean.compare(rightAdequate, leftAdequate);
+                }
+
+                if (leftAdequate) {
+                    int leftDistance = Math.abs(left.major() - requiredMajor);
+                    int rightDistance = Math.abs(right.major() - requiredMajor);
+                    int distanceCompare = Integer.compare(leftDistance, rightDistance);
+                    if (distanceCompare != 0) {
+                        return distanceCompare;
+                    }
+                    return Integer.compare(left.major(), right.major());
+                }
+
+                return Integer.compare(right.major(), left.major());
+            });
+        }
+
+        return toJavaHomePaths(candidates);
+    }
+
+    /**
+     * 역할:
+     * 실행 로그에서 Java 버전 불일치/호환성 문제 신호를 탐지한다.
+     *
+     * 책임:
+     * 공통 신호 + Gradle 전용 + Maven 전용 문구를 종합해 재시도 여부 판단 근거를 제공한다.
+     */
+    public Optional<String> detectJavaCompatibilityReason(BuildToolKind buildToolKind, ProcessRunner.Result result) {
+        String text = ((result.getOutput() == null ? "" : result.getOutput()) + "\n"
+                + (result.getError() == null ? "" : result.getError())).toLowerCase(Locale.ROOT);
+
+        List<String> commonSignals = List.of(
+                "unsupported class file major version",
+                "unsupported major.minor version",
+                "has been compiled by a more recent version",
+                "could not determine java version"
+        );
+        for (String signal : commonSignals) {
+            if (text.contains(signal)) {
+                return Optional.of(signal);
+            }
+        }
+
+        if (buildToolKind == BuildToolKind.GRADLE) {
+            // Gradle toolchain/JDK 미스매치에서 자주 나오는 문구를 재시도 신호로 사용
+            List<String> gradleSignals = List.of(
+                    "this version of gradle supports java",
+                    "minimum supported gradle version",
+                    "cannot find a java installation on your machine matching",
+                    "toolchain download repositories have not been configured",
+                    "no matching toolchains found for requested specification"
+            );
+            for (String signal : gradleSignals) {
+                if (text.contains(signal)) {
+                    return Optional.of(signal);
+                }
+            }
+            return Optional.empty();
+        }
+
+        if (buildToolKind == BuildToolKind.MAVEN) {
+            List<String> mavenSignals = List.of(
+                    "invalid target release",
+                    "invalid source release",
+                    "release version",
+                    "source option",
+                    "target option",
+                    "no toolchain found for type jdk",
+                    "cannot find matching toolchain definitions for the following toolchain types",
+                    "error: source release",
+                    "error: target release"
+            );
+            for (String signal : mavenSignals) {
+                if (!text.contains(signal)) {
+                    continue;
+                }
+
+                if ("release version".equals(signal) && !text.contains("not supported")) {
+                    continue;
+                }
+                if (("source option".equals(signal) || "target option".equals(signal))
+                        && !text.contains("is no longer supported")) {
+                    continue;
+                }
+                return Optional.of(signal);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * 역할:
+     * 전달된 JAVA_HOME이 현재 런타임 JVM 경로와 동일한지 판단한다.
+     *
+     * 책임:
+     * JAVA_HOME/System java.home 기준으로 baseline 폴백 필요 여부를 지원한다.
+     */
+    public boolean isCurrentRuntimeJavaHome(String javaHome) {
+        String normalized = normalizePathString(javaHome);
+        if (normalized == null) {
+            return false;
+        }
+        String currentJavaHome = normalizePathString(System.getenv("JAVA_HOME"));
+        String currentRuntimeHome = normalizePathString(System.getProperty("java.home"));
+        return normalized.equalsIgnoreCase(currentJavaHome) || normalized.equalsIgnoreCase(currentRuntimeHome);
+    }
+
+    /**
+     * 역할:
+     * 특정 JAVA_HOME으로 프로세스를 실행하기 위한 환경변수 맵을 구성한다.
+     *
+     * 책임:
+     * JAVA_HOME 설정과 함께 PATH/Path에 해당 JDK bin을 우선 주입한다.
+     */
+    public Map<String, String> buildEnvironment(Map<String, String> baseEnvironment, String javaHome) {
+        Map<String, String> env = new HashMap<>(baseEnvironment);
+        env.put("JAVA_HOME", javaHome);
+
+        String binPath = javaHome + File.separator + "bin";
+        String currentPath = Optional.ofNullable(System.getenv("PATH")).orElse("");
+        String mergedPath = currentPath.isBlank() ? binPath : binPath + File.pathSeparator + currentPath;
+
+        env.put("PATH", mergedPath);
+        env.put("Path", mergedPath);
+        return env;
+    }
+
+    private List<JavaHomeCandidate> loadConfiguredJavaHomeCandidates() {
+        List<String> configured = buildCommandProperties.getJavaHomes();
+        if (configured == null || configured.isEmpty()) {
+            return List.of();
+        }
+
+        List<JavaHomeCandidate> candidates = new ArrayList<>();
+        for (String candidate : configured) {
+            String normalized = normalizePathString(candidate);
+            if (normalized == null) {
+                continue;
+            }
+            Path javaHomePath = Path.of(normalized);
+            if (!Files.exists(javaHomePath) || !Files.isDirectory(javaHomePath)) {
+                continue;
+            }
+
+            Integer javaMajor = parseJavaMajorFromHome(javaHomePath);
+            if (javaMajor == null) {
+                continue;
+            }
+            candidates.add(new JavaHomeCandidate(normalized, javaMajor));
+        }
+        return candidates;
+    }
+
+    private List<String> toJavaHomePaths(List<JavaHomeCandidate> candidates) {
+        List<String> result = new ArrayList<>();
+        for (JavaHomeCandidate candidate : candidates) {
+            result.add(candidate.path());
+        }
+        return result;
+    }
+
+    private Optional<GradleVersion> parseGradleVersionFromWrapper(Path repoRoot) {
+        Path wrapperProperties = repoRoot.resolve("gradle").resolve("wrapper").resolve("gradle-wrapper.properties");
+        if (!Files.exists(wrapperProperties)) {
+            return Optional.empty();
+        }
+
+        Pattern distributionPattern = Pattern.compile("gradle-([0-9]+(?:\\.[0-9]+){0,2})-(?:bin|all)\\.zip");
+        try {
+            for (String line : Files.readAllLines(wrapperProperties, StandardCharsets.UTF_8)) {
+                String trimmed = line == null ? "" : line.trim();
+                if (!trimmed.startsWith("distributionUrl=")) {
+                    continue;
+                }
+                Matcher matcher = distributionPattern.matcher(trimmed);
+                if (!matcher.find()) {
+                    return Optional.empty();
+                }
+
+                String rawVersion = matcher.group(1);
+                String[] parts = rawVersion.split("\\.");
+                int major = parseIntOrZero(parts, 0);
+                int minor = parseIntOrZero(parts, 1);
+                int patch = parseIntOrZero(parts, 2);
+
+                if (major <= 0) {
+                    return Optional.empty();
+                }
+                return Optional.of(new GradleVersion(major, minor, patch));
+            }
+        } catch (Exception e) {
+            log.debug("[BUILD] Failed to parse gradle wrapper version. repoRoot={}", repoRoot, e);
+        }
+        return Optional.empty();
+    }
+
+    private int parseIntOrZero(String[] parts, int index) {
+        if (parts == null || index >= parts.length) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(parts[index]);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Integer parseJavaMajorFromHome(Path javaHome) {
+        Path releaseFile = javaHome.resolve("release");
+        if (Files.exists(releaseFile)) {
+            try {
+                for (String line : Files.readAllLines(releaseFile, StandardCharsets.UTF_8)) {
+                    String trimmed = line == null ? "" : line.trim();
+                    if (!trimmed.startsWith("JAVA_VERSION=")) {
+                        continue;
+                    }
+                    int firstQuote = trimmed.indexOf('"');
+                    int lastQuote = trimmed.lastIndexOf('"');
+                    if (firstQuote >= 0 && lastQuote > firstQuote) {
+                        String versionString = trimmed.substring(firstQuote + 1, lastQuote);
+                        Integer parsed = toMajorVersion(versionString);
+                        if (parsed != null) {
+                            return parsed;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("[BUILD] Failed to read JDK release file. javaHome={}", javaHome, e);
+            }
+        }
+
+        String fallback = javaHome.toString();
+        Matcher matcher = Pattern.compile("(?:jdk|java)[-_]?([0-9]{1,2})", Pattern.CASE_INSENSITIVE).matcher(fallback);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer toMajorVersion(String rawVersion) {
+        if (rawVersion == null || rawVersion.isBlank()) {
+            return null;
+        }
+
+        String version = rawVersion.trim();
+        if (version.startsWith("1.")) {
+            String[] parts = version.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        int dot = version.indexOf('.');
+        String majorPart = dot >= 0 ? version.substring(0, dot) : version;
+        try {
+            return Integer.parseInt(majorPart);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private int preferredJavaMajor(GradleVersion version) {
+        if (version.major() <= 6) {
+            return 11;
+        }
+        if (version.major() == 7) {
+            return version.minor() < 3 ? 11 : 17;
+        }
+        if (version.major() == 8) {
+            return version.minor() < 5 ? 17 : 21;
+        }
+        return 21;
+    }
+
+    private int compatibilityTier(GradleVersion version, int javaMajor) {
+        if (version.major() <= 6) {
+            if (javaMajor <= 11) return 4;
+            if (javaMajor <= 16) return 3;
+            return 1;
+        }
+
+        if (version.major() == 7) {
+            if (version.minor() < 3) {
+                if (javaMajor <= 11) return 4;
+                if (javaMajor <= 16) return 3;
+                if (javaMajor == 17) return 2;
+                return 1;
+            }
+            if (javaMajor <= 17) return 4;
+            if (javaMajor <= 20) return 3;
+            return 1;
+        }
+
+        if (version.major() == 8) {
+            if (version.minor() < 5) {
+                if (javaMajor <= 17) return 4;
+                if (javaMajor <= 20) return 3;
+                return 2;
+            }
+            if (javaMajor <= 21) return 4;
+            if (javaMajor <= 23) return 3;
+            return 2;
+        }
+
+        if (javaMajor >= 21) return 4;
+        if (javaMajor >= 17) return 3;
+        return 2;
+    }
+
+    private String normalizePathString(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+        try {
+            return Path.of(rawPath.trim()).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return rawPath.trim();
+        }
+    }
+
+    private record JavaHomeCandidate(String path, int major) {
+    }
+
+    private record GradleVersion(int major, int minor, int patch) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleBuildSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleBuildSupport.java
@@ -1,0 +1,200 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.enums.BuildToolKind;
+import com.example.ossdoc.global.config.BuildCommandProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 역할:
+ * Gradle 실행 전략(명령 선택, 재시도, wrapper 폴백)을 담당한다.
+ *
+ * 책임:
+ * 1) wrapper 우선/절대경로 기반 명령 결정
+ * 2) JAVA_HOME 후보 재시도 실행
+ * 3) wrapper 부트스트랩 실패 시 시스템 gradle 1회 폴백
+ * 4) 격리 실행 환경(GRADLE_USER_HOME) 구성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GradleBuildSupport {
+
+    private final ProcessRunner processRunner;
+    private final BuildCommandProperties buildCommandProperties;
+    private final BuildToolchainSupport buildToolchainSupport;
+
+    /**
+     * 역할:
+     * 현재 저장소에서 사용할 Gradle 실행 명령을 결정한다.
+     *
+     * 책임:
+     * gradlew(.bat) 존재 시 절대경로 wrapper를 우선 사용하고, 없으면 시스템 gradle을 사용한다.
+     */
+    public String selectGradleCmd(Path repoRoot) {
+        // wrapper는 절대경로로 호출해 ProcessBuilder 경로 탐색 이슈를 줄인다.
+        Path gradlewBat = repoRoot.resolve("gradlew.bat");
+        if (Files.exists(gradlewBat)) return gradlewBat.toAbsolutePath().normalize().toString();
+
+        Path gradlew = repoRoot.resolve("gradlew");
+        if (Files.exists(gradlew)) return gradlew.toAbsolutePath().normalize().toString();
+
+        return buildCommandProperties.getGradleCommand();
+    }
+
+    /**
+     * 역할:
+     * Gradle 명령을 실행하고 Java 호환성 문제 시 후보 JDK로 재시도한다.
+     *
+     * 책임:
+     * 1) 1순위 JAVA_HOME 실행
+     * 2) 호환성 신호 감지 시 순차 재시도
+     * 3) 필요 시 현재 런타임 JVM baseline 폴백
+     */
+    public ProcessRunner.Result runWithJavaFallback(Path repoRoot,
+                                                    Path workspaceRoot,
+                                                    List<String> command,
+                                                    Duration timeout,
+                                                    String stage) {
+        Map<String, String> baseEnvironment = resolveGradleBaseEnvironment(workspaceRoot);
+        List<String> candidates = buildToolchainSupport.resolveJavaHomeCandidatesForGradle(repoRoot);
+
+        ProcessRunner.Result first;
+        String selectedJavaHome = null;
+        if (candidates.isEmpty()) {
+            first = runGradleCommand(repoRoot, command, timeout, baseEnvironment);
+        } else {
+            selectedJavaHome = candidates.get(0);
+            first = runGradleCommand(
+                    repoRoot,
+                    command,
+                    timeout,
+                    buildToolchainSupport.buildEnvironment(baseEnvironment, selectedJavaHome)
+            );
+            log.info("[BUILD] Gradle {} initial JAVA_HOME={} (version-aware selection)", stage, selectedJavaHome);
+        }
+
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        Optional<String> compatibilityReason = buildToolchainSupport.detectJavaCompatibilityReason(BuildToolKind.GRADLE, first);
+        if (compatibilityReason.isEmpty()) {
+            if (selectedJavaHome != null && !buildToolchainSupport.isCurrentRuntimeJavaHome(selectedJavaHome)) {
+                ProcessRunner.Result baseline = runGradleCommand(repoRoot, command, timeout, baseEnvironment);
+                if (baseline.getExitCode() == 0) {
+                    log.info("[BUILD] Gradle {} fallback to current runtime JVM succeeded", stage);
+                    return baseline;
+                }
+            }
+            return first;
+        }
+        log.info("[BUILD] Gradle {} detected Java compatibility issue: {}", stage, compatibilityReason.get());
+
+        ProcessRunner.Result last = first;
+        for (String javaHome : candidates) {
+            if (javaHome.equalsIgnoreCase(selectedJavaHome)) {
+                continue;
+            }
+
+            log.info("[BUILD] Gradle {} retry with JAVA_HOME={}", stage, javaHome);
+            ProcessRunner.Result retry = runGradleCommand(
+                    repoRoot,
+                    command,
+                    timeout,
+                    buildToolchainSupport.buildEnvironment(baseEnvironment, javaHome)
+            );
+            if (retry.getExitCode() == 0) {
+                return retry;
+            }
+            last = retry;
+        }
+
+        return last;
+    }
+
+    private ProcessRunner.Result runGradleCommand(Path repoRoot,
+                                                  List<String> command,
+                                                  Duration timeout,
+                                                  Map<String, String> environmentOverrides) {
+        ProcessRunner.Result first = processRunner.run(repoRoot, command, timeout, environmentOverrides);
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        if (command == null || command.isEmpty()) {
+            return first;
+        }
+
+        String primaryCommand = command.get(0);
+        if (!isGradleWrapperCommand(primaryCommand) || !isWrapperBootstrapFailure(first)) {
+            return first;
+        }
+
+        // wrapper 부트스트랩 실패(파일 탐색/실행 실패 등)면 시스템 gradle로 1회 폴백
+        String fallbackCommand = buildCommandProperties.getGradleCommand();
+        if (fallbackCommand == null || fallbackCommand.isBlank() || fallbackCommand.equals(primaryCommand)) {
+            return first;
+        }
+
+        List<String> fallback = new ArrayList<>(command);
+        fallback.set(0, fallbackCommand);
+
+        log.warn("[BUILD] Gradle wrapper command failed to bootstrap. fallbackCommand={}", fallbackCommand);
+        ProcessRunner.Result fallbackResult = processRunner.run(repoRoot, fallback, timeout, environmentOverrides);
+        if (fallbackResult.getExitCode() == 0) {
+            log.info("[BUILD] Gradle fallback command succeeded. command={}", fallbackCommand);
+        }
+        return fallbackResult;
+    }
+
+    private boolean isGradleWrapperCommand(String command) {
+        String normalized = command == null ? "" : command.replace("\\", "/").toLowerCase(Locale.ROOT);
+        return normalized.endsWith("/gradlew")
+                || normalized.endsWith("/gradlew.bat")
+                || normalized.equals("gradlew")
+                || normalized.equals("gradlew.bat")
+                || normalized.equals("./gradlew");
+    }
+
+    private boolean isWrapperBootstrapFailure(ProcessRunner.Result result) {
+        String joined = ((result.getError() == null ? "" : result.getError()) + "\n"
+                + (result.getOutput() == null ? "" : result.getOutput())).toLowerCase(Locale.ROOT);
+
+        return joined.contains("cannot run program")
+                || joined.contains("createprocess error=2")
+                || joined.contains("is not recognized as an internal or external command")
+                || joined.contains("command not found")
+                || joined.contains("no such file or directory");
+    }
+
+    private Map<String, String> resolveGradleBaseEnvironment(Path workspaceRoot) {
+        Map<String, String> env = new HashMap<>();
+        if (!buildCommandProperties.isIsolatedExecution()) {
+            return env;
+        }
+
+        Path gradleUserHome = workspaceRoot.resolve(buildCommandProperties.getGradleUserHomeDir())
+                .toAbsolutePath()
+                .normalize();
+        try {
+            Files.createDirectories(gradleUserHome);
+            env.put("GRADLE_USER_HOME", gradleUserHome.toString());
+        } catch (IOException e) {
+            log.warn("[BUILD] Failed to create GRADLE_USER_HOME directory. path={}", gradleUserHome, e);
+        }
+        return env;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleDumpParser.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleDumpParser.java
@@ -1,0 +1,103 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.dto.json.BuildFailure;
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 역할:
+ * Gradle init script(ossdocDump) 출력 문자열을 모듈 매니페스트로 변환한다.
+ *
+ * 책임:
+ * 1) OSS_DOC_DUMP JSON 라인 추출
+ * 2) source/test/resource/classes/classpath 경로 정규화
+ * 3) 모듈 상태(OK/PARTIAL/FAILED) 판정
+ * 4) 파싱 실패를 BuildFailure로 누적
+ */
+@Component
+@RequiredArgsConstructor
+public class GradleDumpParser {
+
+    private final ObjectMapper objectMapper;
+    private final BuildPathNormalizer buildPathNormalizer;
+
+    /**
+     * 역할:
+     * dump 출력 전체를 파싱해 BuildModuleManifest 목록으로 반환한다.
+     *
+     * 책임:
+     * 유효한 dump 라인을 모두 읽어 모듈 정보를 생성하고, 예외는 failures에 기록한다.
+     */
+    public List<BuildModuleManifest> parse(Path repoRoot, String output, List<BuildFailure> failures) {
+        Pattern p = Pattern.compile("^OSS_DOC_DUMP=(\\{.*\\})$", Pattern.MULTILINE);
+        Matcher m = p.matcher(output);
+
+        List<BuildModuleManifest> modules = new ArrayList<>();
+        while (m.find()) {
+            try {
+                Map<String, Object> map = objectMapper.readValue(m.group(1), Map.class);
+
+                List<String> sourceRoots = readPathList(map, "sourceRoots", repoRoot);
+                List<String> testRoots = readPathList(map, "testRoots", repoRoot);
+                List<String> resourceRoots = readPathList(map, "resourceRoots", repoRoot);
+                List<String> classesDirs = readPathList(map, "classesDirs", repoRoot);
+                List<String> compileClasspath = readPathList(map, "compileClasspath", repoRoot);
+                List<String> runtimeClasspath = readPathList(map, "runtimeClasspath", repoRoot);
+
+                String status;
+                if (!classesDirs.isEmpty()) {
+                    status = "OK";
+                } else if (!sourceRoots.isEmpty() || !testRoots.isEmpty() || !resourceRoots.isEmpty()) {
+                    status = "PARTIAL";
+                } else {
+                    status = "FAILED";
+                }
+
+                modules.add(BuildModuleManifest.builder()
+                        .moduleId((String) map.getOrDefault("projectPath", ""))
+                        .name((String) map.getOrDefault("name", ""))
+                        .sourceRoots(sourceRoots)
+                        .testRoots(testRoots)
+                        .resourceRoots(resourceRoots)
+                        .classesDirs(classesDirs)
+                        .compileClasspath(compileClasspath)
+                        .runtimeClasspath(runtimeClasspath)
+                        .status(status)
+                        .build());
+
+            } catch (Exception e) {
+                failures.add(BuildFailure.builder()
+                        .code(BuildErrorCode.GRADLE_DUMP_FAILED.getCode())
+                        .message("Failed to parse OSS_DOC_DUMP - " + e.getMessage())
+                        .build());
+            }
+        }
+        return modules;
+    }
+
+    private List<String> readPathList(Map<String, Object> map, String key, Path repoRoot) {
+        Object rawValue = map.get(key);
+        if (!(rawValue instanceof List<?> values)) {
+            return List.of();
+        }
+
+        List<String> pathValues = new ArrayList<>();
+        for (Object value : values) {
+            if (value instanceof String path && !path.isBlank()) {
+                pathValues.add(path);
+            }
+        }
+
+        return buildPathNormalizer.toAbsolutePaths(repoRoot, pathValues);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriter.java
@@ -34,10 +34,10 @@ public class GradleInitScriptWriter {
                       if (hasJava && prj.hasProperty("sourceSets")) {
                         def main = prj.sourceSets.main
                         def test = prj.sourceSets.test
-                        result.sourceRoots = main.java.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.testRoots = test.java.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.resourceRoots = main.resources.srcDirs.collect { prj.rootProject.relativePath(it) }
-                        result.classesDirs = main.output.classesDirs.files.collect { prj.rootProject.relativePath(it) }
+                        result.sourceRoots = main.java.srcDirs.collect { it.absolutePath }
+                        result.testRoots = test.java.srcDirs.collect { it.absolutePath }
+                        result.resourceRoots = main.resources.srcDirs.collect { it.absolutePath }
+                        result.classesDirs = main.output.classesDirs.files.collect { it.absolutePath }
 
                         try { result.compileClasspath = main.compileClasspath.files.collect { it.absolutePath } } catch (ignored) { result.compileClasspath = [] }
                         try { result.runtimeClasspath = main.runtimeClasspath.files.collect { it.absolutePath } } catch (ignored) { result.runtimeClasspath = [] }

--- a/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
@@ -11,8 +11,19 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
+/**
+ * 역할:
+ * Maven 실행/출력 해석을 담당하는 실행 지원 컴포넌트.
+ *
+ * 책임:
+ * 1) compile/classpath 명령 실행
+ * 2) wrapper 실패 시 시스템 mvn 폴백
+ * 3) 모듈 매니페스트 및 classpath 파일 파싱 보조
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -23,28 +34,41 @@ public class MavenBuildSupport {
     private final BuildPathNormalizer buildPathNormalizer;
 
     /**
-     * Maven 컴파일 실행
-     * - 테스트는 스킵하고 compile까지만 가볍게 수행
+     * 역할:
+     * 테스트를 제외한 Maven 컴파일(test-compile)을 수행한다.
+     *
+     * 책임:
+     * mavenLocalRepoPath와 환경변수를 반영해 실행 결과를 반환한다.
      */
     public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath) {
         return compile(repoRoot, mavenLocalRepoPath, null);
     }
 
+    /**
+     * 역할:
+     * Maven 컴파일 실행의 내부 진입점.
+     *
+     * 책임:
+     * 실행 인자 조립 및 runMavenCommand 위임을 담당한다.
+     */
     public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath, Map<String, String> environmentOverrides) {
-        log.info("mvn path={}", repoRoot);
-        List<String> cmd = new ArrayList<>();
-        cmd.add(selectMavenCmd(repoRoot));
-        cmd.add("-q");
-        cmd.add("-DskipTests");
-        appendMavenLocalRepoOption(cmd, mavenLocalRepoPath);
-        cmd.add("test-compile");
+        List<String> args = new ArrayList<>();
+        args.add("-q");
+        args.add("-DskipTests");
+        // 격리 실행 모드에서는 Run 전용 로컬 저장소를 사용해 의존성 충돌을 줄인다.
+        appendMavenLocalRepoOption(args, mavenLocalRepoPath);
+        args.add("test-compile");
 
         log.info("[BUILD] Maven compile start. repoRoot={}", repoRoot);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(20), environmentOverrides);
+        return runMavenCommand(repoRoot, args, Duration.ofMinutes(20), environmentOverrides);
     }
 
     /**
-     * dependency:build-classpath 로 classpath 파일 생성
+     * 역할:
+     * dependency:build-classpath를 실행해 classpath 파일을 생성한다.
+     *
+     * 책임:
+     * build 단계에서 타입 해석에 필요한 의존성 경로 확보를 지원한다.
      */
     public ProcessRunner.Result buildClasspath(Path repoRoot, Path outputFile, Path mavenLocalRepoPath) {
         return buildClasspath(repoRoot, outputFile, mavenLocalRepoPath, null);
@@ -54,23 +78,24 @@ public class MavenBuildSupport {
                                                Path outputFile,
                                                Path mavenLocalRepoPath,
                                                Map<String, String> environmentOverrides) {
-        List<String> cmd = new ArrayList<>();
-        cmd.add(selectMavenCmd(repoRoot));
-        cmd.add("-q");
-        cmd.add("-DskipTests");
-        appendMavenLocalRepoOption(cmd, mavenLocalRepoPath);
-        cmd.add("dependency:build-classpath");
-        cmd.add("-Dmdep.outputFile=" + outputFile.toString());
+        List<String> args = new ArrayList<>();
+        args.add("-q");
+        args.add("-DskipTests");
+        // classpath 산출도 compile과 동일하게 격리 저장소를 사용한다.
+        appendMavenLocalRepoOption(args, mavenLocalRepoPath);
+        args.add("dependency:build-classpath");
+        args.add("-Dmdep.outputFile=" + outputFile);
 
         log.info("[BUILD] Maven classpath build start. repoRoot={}, output={}", repoRoot, outputFile);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(10), environmentOverrides);
+        return runMavenCommand(repoRoot, args, Duration.ofMinutes(10), environmentOverrides);
     }
 
     /**
-     * 모듈 루트 기준으로 BuildModuleManifest를 생성
-     * - sourceRoots/testRoots/resourceRoots
-     * - classesDirs
-     * - compileClasspath/runtimeClasspath
+     * 역할:
+     * Maven 모듈 루트 경로를 BuildModuleManifest로 변환한다.
+     *
+     * 책임:
+     * source/test/resource/classes/classpath 정보를 표준 DTO로 매핑한다.
      */
     public BuildModuleManifest toModuleManifest(Path repoRoot, Path moduleRoot, List<String> classpath) {
         List<String> sourceRoots = new ArrayList<>();
@@ -86,6 +111,7 @@ public class MavenBuildSupport {
         String moduleId = toModuleId(repoRoot, moduleRoot);
         String name = moduleRoot.getFileName() != null ? moduleRoot.getFileName().toString() : moduleId;
 
+        // classpath/runtimeClasspath은 절대경로로 정규화해 후속 분석 단계에서 OS 의존성을 줄인다.
         return BuildModuleManifest.builder()
                 .moduleId(moduleId)
                 .name(name)
@@ -100,6 +126,13 @@ public class MavenBuildSupport {
                 .build();
     }
 
+    /**
+     * 역할:
+     * Maven classpath 출력 파일을 읽어 경로 목록으로 반환한다.
+     *
+     * 책임:
+     * OS path separator 분리 + 절대경로 정규화 + 예외 안전 처리.
+     */
     public List<String> readClasspathFile(Path repoRoot, Path outputFile) {
         try {
             if (!Files.exists(outputFile)) {
@@ -115,6 +148,7 @@ public class MavenBuildSupport {
             List<String> result = new ArrayList<>();
             for (String entry : entries) {
                 if (!entry.isBlank()) {
+                    // 상대경로/절대경로 혼재를 방지하기 위해 한 번 더 절대경로로 통일한다.
                     String normalized = buildPathNormalizer.toAbsolutePath(repoRoot, entry);
                     if (normalized != null) {
                         result.add(normalized);
@@ -126,6 +160,62 @@ public class MavenBuildSupport {
             log.warn("[BUILD] Failed to read classpath file. file={}", outputFile, e);
             return List.of();
         }
+    }
+
+    private ProcessRunner.Result runMavenCommand(Path repoRoot,
+                                                 List<String> args,
+                                                 Duration timeout,
+                                                 Map<String, String> environmentOverrides) {
+        String primaryCommand = selectMavenCmd(repoRoot);
+        List<String> primary = new ArrayList<>();
+        primary.add(primaryCommand);
+        primary.addAll(args);
+
+        ProcessRunner.Result first = processRunner.run(repoRoot, primary, timeout, environmentOverrides);
+        if (first.getExitCode() == 0) {
+            return first;
+        }
+
+        if (!isWrapperCommand(primaryCommand) || !isWrapperBootstrapFailure(first)) {
+            return first;
+        }
+
+        // wrapper 실행 자체가 실패하면 시스템 mvn 명령으로 1회 폴백한다.
+        String fallbackCommand = buildCommandProperties.getMavenCommand();
+        if (fallbackCommand == null || fallbackCommand.isBlank() || Objects.equals(primaryCommand, fallbackCommand)) {
+            return first;
+        }
+
+        List<String> fallback = new ArrayList<>();
+        fallback.add(fallbackCommand);
+        fallback.addAll(args);
+
+        log.warn("[BUILD] Maven wrapper command failed to bootstrap. fallbackCommand={}", fallbackCommand);
+        ProcessRunner.Result fallbackResult = processRunner.run(repoRoot, fallback, timeout, environmentOverrides);
+        if (fallbackResult.getExitCode() == 0) {
+            log.info("[BUILD] Maven fallback command succeeded. command={}", fallbackCommand);
+        }
+        return fallbackResult;
+    }
+
+    private boolean isWrapperCommand(String command) {
+        String normalized = command == null ? "" : command.replace("\\", "/").toLowerCase(Locale.ROOT);
+        return normalized.endsWith("/mvnw")
+                || normalized.endsWith("/mvnw.cmd")
+                || normalized.equals("mvnw")
+                || normalized.equals("mvnw.cmd")
+                || normalized.equals("./mvnw");
+    }
+
+    private boolean isWrapperBootstrapFailure(ProcessRunner.Result result) {
+        String joined = ((result.getError() == null ? "" : result.getError()) + "\n"
+                + (result.getOutput() == null ? "" : result.getOutput())).toLowerCase(Locale.ROOT);
+
+        return joined.contains("cannot run program")
+                || joined.contains("createprocess error=2")
+                || joined.contains("is not recognized as an internal or external command")
+                || joined.contains("command not found")
+                || joined.contains("no such file or directory");
     }
 
     private void addIfExists(List<String> target, Path path) {
@@ -142,8 +232,18 @@ public class MavenBuildSupport {
     }
 
     private String selectMavenCmd(Path repoRoot) {
-        if (Files.exists(repoRoot.resolve("mvnw.cmd"))) return "mvnw.cmd";
-        if (Files.exists(repoRoot.resolve("mvnw"))) return "./mvnw";
+        Path mvnwCmd = repoRoot.resolve("mvnw.cmd");
+        if (Files.exists(mvnwCmd)) {
+            // wrapper는 절대경로로 호출해 ProcessBuilder 경로 탐색 이슈를 줄인다.
+            return mvnwCmd.toAbsolutePath().normalize().toString();
+        }
+
+        Path mvnw = repoRoot.resolve("mvnw");
+        if (Files.exists(mvnw)) {
+            // Windows/Unix 공통으로 wrapper 절대경로 우선
+            return mvnw.toAbsolutePath().normalize().toString();
+        }
+
         return buildCommandProperties.getMavenCommand();
     }
 
@@ -151,7 +251,7 @@ public class MavenBuildSupport {
         if (mavenLocalRepoPath == null) {
             return;
         }
+        // -Dmaven.repo.local 옵션으로 Run별 캐시 경로를 강제한다.
         command.add("-Dmaven.repo.local=" + buildPathNormalizer.normalize(mavenLocalRepoPath));
     }
-
 }

--- a/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/MavenBuildSupport.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -19,38 +20,50 @@ public class MavenBuildSupport {
 
     private final ProcessRunner processRunner;
     private final BuildCommandProperties buildCommandProperties;
+    private final BuildPathNormalizer buildPathNormalizer;
 
     /**
      * Maven 컴파일 실행
      * - 테스트는 스킵하고 compile까지만 가볍게 수행
      */
-    public ProcessRunner.Result compile(Path repoRoot) {
+    public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath) {
+        return compile(repoRoot, mavenLocalRepoPath, null);
+    }
+
+    public ProcessRunner.Result compile(Path repoRoot, Path mavenLocalRepoPath, Map<String, String> environmentOverrides) {
         log.info("mvn path={}", repoRoot);
-        List<String> cmd = List.of(
-                selectMavenCmd(repoRoot),
-                "-q",
-                "-DskipTests",
-                "test-compile"
-        );
+        List<String> cmd = new ArrayList<>();
+        cmd.add(selectMavenCmd(repoRoot));
+        cmd.add("-q");
+        cmd.add("-DskipTests");
+        appendMavenLocalRepoOption(cmd, mavenLocalRepoPath);
+        cmd.add("test-compile");
 
         log.info("[BUILD] Maven compile start. repoRoot={}", repoRoot);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(20));
+        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(20), environmentOverrides);
     }
 
     /**
      * dependency:build-classpath 로 classpath 파일 생성
      */
-    public ProcessRunner.Result buildClasspath(Path repoRoot, Path outputFile) {
-        List<String> cmd = List.of(
-                selectMavenCmd(repoRoot),
-                "-q",
-                "-DskipTests",
-                "dependency:build-classpath",
-                "-Dmdep.outputFile=" + outputFile.toString()
-        );
+    public ProcessRunner.Result buildClasspath(Path repoRoot, Path outputFile, Path mavenLocalRepoPath) {
+        return buildClasspath(repoRoot, outputFile, mavenLocalRepoPath, null);
+    }
+
+    public ProcessRunner.Result buildClasspath(Path repoRoot,
+                                               Path outputFile,
+                                               Path mavenLocalRepoPath,
+                                               Map<String, String> environmentOverrides) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(selectMavenCmd(repoRoot));
+        cmd.add("-q");
+        cmd.add("-DskipTests");
+        appendMavenLocalRepoOption(cmd, mavenLocalRepoPath);
+        cmd.add("dependency:build-classpath");
+        cmd.add("-Dmdep.outputFile=" + outputFile.toString());
 
         log.info("[BUILD] Maven classpath build start. repoRoot={}, output={}", repoRoot, outputFile);
-        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(10));
+        return processRunner.run(repoRoot, cmd, Duration.ofMinutes(10), environmentOverrides);
     }
 
     /**
@@ -80,14 +93,14 @@ public class MavenBuildSupport {
                 .testRoots(testRoots)
                 .resourceRoots(resourceRoots)
                 .classesDirs(classesDirs)
-                .compileClasspath(classpath)
-                .runtimeClasspath(classpath)
+                .compileClasspath(buildPathNormalizer.toAbsolutePaths(repoRoot, classpath))
+                .runtimeClasspath(buildPathNormalizer.toAbsolutePaths(repoRoot, classpath))
                 .status(classesDirs.isEmpty() ? "PARTIAL" : "OK")
                 .failReason(null)
                 .build();
     }
 
-    public List<String> readClasspathFile(Path outputFile) {
+    public List<String> readClasspathFile(Path repoRoot, Path outputFile) {
         try {
             if (!Files.exists(outputFile)) {
                 return List.of();
@@ -102,7 +115,10 @@ public class MavenBuildSupport {
             List<String> result = new ArrayList<>();
             for (String entry : entries) {
                 if (!entry.isBlank()) {
-                    result.add(entry.trim());
+                    String normalized = buildPathNormalizer.toAbsolutePath(repoRoot, entry);
+                    if (normalized != null) {
+                        result.add(normalized);
+                    }
                 }
             }
             return result;
@@ -114,7 +130,7 @@ public class MavenBuildSupport {
 
     private void addIfExists(List<String> target, Path path) {
         if (Files.exists(path) && Files.isDirectory(path)) {
-            target.add(path.toString());
+            target.add(buildPathNormalizer.normalize(path));
         }
     }
 
@@ -129,6 +145,13 @@ public class MavenBuildSupport {
         if (Files.exists(repoRoot.resolve("mvnw.cmd"))) return "mvnw.cmd";
         if (Files.exists(repoRoot.resolve("mvnw"))) return "./mvnw";
         return buildCommandProperties.getMavenCommand();
+    }
+
+    private void appendMavenLocalRepoOption(List<String> command, Path mavenLocalRepoPath) {
+        if (mavenLocalRepoPath == null) {
+            return;
+        }
+        command.add("-Dmaven.repo.local=" + buildPathNormalizer.normalize(mavenLocalRepoPath));
     }
 
 }

--- a/src/main/java/com/example/ossdoc/domain/build/support/MavenJavaVersionResolver.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/MavenJavaVersionResolver.java
@@ -1,0 +1,361 @@
+package com.example.ossdoc.domain.build.support;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class MavenJavaVersionResolver {
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("^\\$\\{([^}]+)}$");
+
+    public Optional<Integer> resolveRequiredJavaMajor(Path repoRoot) {
+        Path rootPom = repoRoot.resolve("pom.xml");
+        if (!Files.exists(rootPom)) {
+            return Optional.empty();
+        }
+
+        List<PomModel> lineage = collectPomLineage(rootPom);
+        if (lineage.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> mergedProperties = mergeProperties(lineage);
+
+        for (int i = lineage.size() - 1; i >= 0; i--) {
+            PomModel model = lineage.get(i);
+
+            Optional<Integer> pluginVersion = parseMajor(model.compilerRelease(), mergedProperties)
+                    .or(() -> parseMajor(model.compilerSource(), mergedProperties))
+                    .or(() -> parseMajor(model.compilerTarget(), mergedProperties));
+            if (pluginVersion.isPresent()) {
+                return pluginVersion;
+            }
+
+            Optional<Integer> propertyVersion = parseMajor(model.mavenCompilerRelease(), mergedProperties)
+                    .or(() -> parseMajor(model.mavenCompilerSource(), mergedProperties))
+                    .or(() -> parseMajor(model.mavenCompilerTarget(), mergedProperties))
+                    .or(() -> parseMajor(model.javaVersion(), mergedProperties))
+                    .or(() -> parseMajor(model.jdkVersion(), mergedProperties));
+            if (propertyVersion.isPresent()) {
+                return propertyVersion;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private List<PomModel> collectPomLineage(Path rootPom) {
+        List<PomModel> chain = new ArrayList<>();
+        Set<Path> visited = new HashSet<>();
+
+        Path current = rootPom.toAbsolutePath().normalize();
+        while (Files.exists(current) && visited.add(current)) {
+            Optional<PomModel> modelOptional = readPomModel(current);
+            if (modelOptional.isEmpty()) {
+                break;
+            }
+
+            PomModel model = modelOptional.get();
+            chain.add(model);
+
+            Optional<Path> parent = resolveParentPomPath(current, model);
+            if (parent.isEmpty()) {
+                break;
+            }
+            current = parent.get();
+        }
+
+        Collections.reverse(chain);
+        return chain;
+    }
+
+    private Optional<Path> resolveParentPomPath(Path currentPom, PomModel model) {
+        if (!model.hasParent()) {
+            return Optional.empty();
+        }
+
+        String relativePath = model.parentRelativePath();
+        if (relativePath == null) {
+            relativePath = "../pom.xml";
+        }
+        if (relativePath.isBlank()) {
+            return Optional.empty();
+        }
+
+        Path resolved = currentPom.getParent().resolve(relativePath).normalize();
+        if (Files.exists(resolved)) {
+            return Optional.of(resolved);
+        }
+        return Optional.empty();
+    }
+
+    private Map<String, String> mergeProperties(List<PomModel> lineage) {
+        Map<String, String> merged = new HashMap<>();
+        for (PomModel model : lineage) {
+            for (Map.Entry<String, String> entry : model.properties().entrySet()) {
+                String value = resolvePlaceholders(entry.getValue(), merged);
+                merged.put(entry.getKey(), value);
+            }
+        }
+        return merged;
+    }
+
+    private Optional<PomModel> readPomModel(Path pomPath) {
+        try (InputStream in = Files.newInputStream(pomPath)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(false);
+            safeSet(factory, "http://apache.org/xml/features/disallow-doctype-decl", true);
+            safeSet(factory, "http://xml.org/sax/features/external-general-entities", false);
+            safeSet(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+            safeSet(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setExpandEntityReferences(false);
+            factory.setXIncludeAware(false);
+
+            Document document = factory.newDocumentBuilder().parse(in);
+            Element project = document.getDocumentElement();
+            if (project == null) {
+                return Optional.empty();
+            }
+
+            Map<String, String> properties = readProperties(project);
+            String compilerRelease = findCompilerPluginConfig(project, "release").orElse(null);
+            String compilerSource = findCompilerPluginConfig(project, "source").orElse(null);
+            String compilerTarget = findCompilerPluginConfig(project, "target").orElse(null);
+
+            String mavenCompilerRelease = properties.get("maven.compiler.release");
+            String mavenCompilerSource = properties.get("maven.compiler.source");
+            String mavenCompilerTarget = properties.get("maven.compiler.target");
+            String javaVersion = properties.get("java.version");
+            String jdkVersion = properties.get("jdk.version");
+
+            Element parentElement = directChild(project, "parent");
+            boolean hasParent = parentElement != null;
+            String parentRelativePath = null;
+            if (hasParent) {
+                Element relativePathElement = directChild(parentElement, "relativePath");
+                parentRelativePath = relativePathElement == null ? null : text(relativePathElement);
+            }
+
+            return Optional.of(new PomModel(
+                    pomPath,
+                    properties,
+                    compilerRelease,
+                    compilerSource,
+                    compilerTarget,
+                    mavenCompilerRelease,
+                    mavenCompilerSource,
+                    mavenCompilerTarget,
+                    javaVersion,
+                    jdkVersion,
+                    hasParent,
+                    parentRelativePath
+            ));
+        } catch (Exception e) {
+            log.debug("[BUILD] Failed to parse pom for Java version detection. pom={}", pomPath, e);
+            return Optional.empty();
+        }
+    }
+
+    private void safeSet(DocumentBuilderFactory factory, String feature, boolean value) {
+        try {
+            factory.setFeature(feature, value);
+        } catch (Exception ignored) {
+            // Keep best-effort hardening without failing build analysis.
+        }
+    }
+
+    private Map<String, String> readProperties(Element project) {
+        Map<String, String> properties = new HashMap<>();
+        Element propertiesElement = directChild(project, "properties");
+        if (propertiesElement == null) {
+            return properties;
+        }
+
+        NodeList children = propertiesElement.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            String key = node.getNodeName();
+            String value = text((Element) node);
+            if (key != null && !key.isBlank() && value != null && !value.isBlank()) {
+                properties.put(key.trim(), value.trim());
+            }
+        }
+        return properties;
+    }
+
+    private Optional<String> findCompilerPluginConfig(Element project, String key) {
+        Element build = directChild(project, "build");
+        if (build == null) {
+            return Optional.empty();
+        }
+
+        Optional<String> fromPlugins = findCompilerPluginConfigInContainer(directChild(build, "plugins"), key);
+        if (fromPlugins.isPresent()) {
+            return fromPlugins;
+        }
+
+        Element pluginManagement = directChild(build, "pluginManagement");
+        if (pluginManagement == null) {
+            return Optional.empty();
+        }
+        return findCompilerPluginConfigInContainer(directChild(pluginManagement, "plugins"), key);
+    }
+
+    private Optional<String> findCompilerPluginConfigInContainer(Element pluginsContainer, String key) {
+        if (pluginsContainer == null) {
+            return Optional.empty();
+        }
+
+        for (Element plugin : directChildren(pluginsContainer, "plugin")) {
+            String artifactId = text(directChild(plugin, "artifactId"));
+            if (!"maven-compiler-plugin".equals(artifactId)) {
+                continue;
+            }
+            Element configuration = directChild(plugin, "configuration");
+            if (configuration == null) {
+                return Optional.empty();
+            }
+            Element target = directChild(configuration, key);
+            return Optional.ofNullable(text(target));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Integer> parseMajor(String expression, Map<String, String> properties) {
+        if (expression == null || expression.isBlank()) {
+            return Optional.empty();
+        }
+
+        String resolved = resolvePlaceholders(expression, properties);
+        if (resolved == null || resolved.isBlank()) {
+            return Optional.empty();
+        }
+
+        Integer major = parseMajorVersion(resolved);
+        return Optional.ofNullable(major);
+    }
+
+    private String resolvePlaceholders(String raw, Map<String, String> properties) {
+        String current = raw == null ? "" : raw.trim();
+        for (int i = 0; i < 8; i++) {
+            Matcher matcher = PLACEHOLDER_PATTERN.matcher(current);
+            if (!matcher.matches()) {
+                return current;
+            }
+
+            String key = matcher.group(1) == null ? "" : matcher.group(1).trim();
+            if (key.isBlank()) {
+                return current;
+            }
+
+            String replacement = properties.get(key);
+            if (replacement == null || replacement.isBlank()) {
+                return current;
+            }
+            current = replacement.trim();
+        }
+        return current;
+    }
+
+    private Integer parseMajorVersion(String value) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.isBlank()) {
+            return null;
+        }
+
+        if (trimmed.startsWith("1.")) {
+            String[] parts = trimmed.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    return Integer.parseInt(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        int dot = trimmed.indexOf('.');
+        String majorPart = dot >= 0 ? trimmed.substring(0, dot) : trimmed;
+        try {
+            return Integer.parseInt(majorPart);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Element directChild(Element parent, String childName) {
+        if (parent == null || childName == null) {
+            return null;
+        }
+
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (childName.equals(node.getNodeName())) {
+                return (Element) node;
+            }
+        }
+        return null;
+    }
+
+    private List<Element> directChildren(Element parent, String childName) {
+        List<Element> elements = new ArrayList<>();
+        if (parent == null || childName == null) {
+            return elements;
+        }
+
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (childName.equals(node.getNodeName())) {
+                elements.add((Element) node);
+            }
+        }
+        return elements;
+    }
+
+    private String text(Element element) {
+        if (element == null) {
+            return null;
+        }
+        String value = element.getTextContent();
+        return value == null ? null : value.trim();
+    }
+
+    private record PomModel(Path path,
+                            Map<String, String> properties,
+                            String compilerRelease,
+                            String compilerSource,
+                            String compilerTarget,
+                            String mavenCompilerRelease,
+                            String mavenCompilerSource,
+                            String mavenCompilerTarget,
+                            String javaVersion,
+                            String jdkVersion,
+                            boolean hasParent,
+                            String parentRelativePath) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/build/support/ProcessRunner.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/ProcessRunner.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -15,10 +16,17 @@ import java.util.concurrent.TimeUnit;
 public class ProcessRunner {
 
     public Result run(Path workingDir, List<String> command, Duration timeout) {
+        return run(workingDir, command, timeout, null);
+    }
+
+    public Result run(Path workingDir, List<String> command, Duration timeout, Map<String, String> environmentOverrides) {
         try {
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(workingDir.toFile());
             pb.redirectErrorStream(true);
+            if (environmentOverrides != null && !environmentOverrides.isEmpty()) {
+                pb.environment().putAll(environmentOverrides);
+            }
 
             Process p = pb.start();
 

--- a/src/main/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScanner.java
+++ b/src/main/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScanner.java
@@ -1,6 +1,7 @@
 package com.example.ossdoc.domain.build.support;
 
 import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,10 @@ import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SourceOnlyModuleScanner {
+
+    private final BuildPathNormalizer buildPathNormalizer;
 
     /**
      * SOURCE_ONLY 폴백용 스캐너
@@ -82,7 +86,7 @@ public class SourceOnlyModuleScanner {
     private void addIfExists(List<String> target, Path moduleRoot, String relativePath) {
         Path candidate = moduleRoot.resolve(relativePath);
         if (Files.exists(candidate) && Files.isDirectory(candidate)) {
-            target.add(candidate.toString());
+            target.add(buildPathNormalizer.normalize(candidate));
         }
     }
 

--- a/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
@@ -12,7 +12,8 @@ public enum RunErrorCode implements BaseCode {
     INVALID_REPO_URL(HttpStatus.BAD_REQUEST, "RUN_400_001", "Invalid GitHub repo URL."),
     GITHUB_API_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_001", "Failed to resolve repo info from GitHub."),
     DOWNLOAD_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_002", "Failed to download repository zip."),
-    UNZIP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_001", "Failed to unzip repository.");
+    UNZIP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_001", "Failed to unzip repository."),
+    JOB_MANIFEST_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_002", "Failed to write job_manifest.json");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -9,12 +9,17 @@ import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
-import com.example.ossdoc.domain.run.support.*;
+import com.example.ossdoc.domain.run.support.GithubClient;
+import com.example.ossdoc.domain.run.support.GithubRepoRef;
+import com.example.ossdoc.domain.run.support.GithubUrlParser;
+import com.example.ossdoc.domain.run.support.WorkspaceManager;
+import com.example.ossdoc.domain.run.support.ZipUtils;
 import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +27,7 @@ import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RepoRunService {
@@ -29,7 +35,6 @@ public class RepoRunService {
     private final RepoRunRepository repoRunRepository;
     private final UserRepository userRepository;
     private final ArtifactService artifactService;
-
     private final GithubClient githubClient;
     private final WorkspaceManager workspaceManager;
     private final ObjectMapper objectMapper;
@@ -39,31 +44,42 @@ public class RepoRunService {
         User owner = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
-        // 1) URL 파싱
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
+        log.info(
+                "Create run requested userId={}, owner={}, repo={}, requestedRef={}",
+                userId,
+                parsed.getOwner(),
+                parsed.getRepo(),
+                req.getRef()
+        );
 
-        // 2) ref 결정 (없으면 default_branch)
         String ref = parsed.getRef();
         if (ref == null || ref.isBlank()) {
             ref = githubClient.resolveDefaultBranch(parsed.getOwner(), parsed.getRepo());
+            log.info("Resolved default branch owner={}, repo={}, ref={}", parsed.getOwner(), parsed.getRepo(), ref);
         }
 
-        // 3) commit SHA 확정 (재현성 핵심)
         String commitSha = githubClient.resolveCommitSha(parsed.getOwner(), parsed.getRepo(), ref);
+        log.info(
+                "Resolved commit SHA owner={}, repo={}, ref={}, sha={}",
+                parsed.getOwner(),
+                parsed.getRepo(),
+                ref,
+                abbreviateSha(commitSha)
+        );
 
-        // 4) runId / workspace 경로
         String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "")
                 + "_" + UUID.randomUUID().toString().substring(0, 8);
         Path wsRoot = workspaceManager.workspaceRoot(runId);
+        log.info("Workspace prepared runId={}, workspaceRoot={}", runId, wsRoot);
 
-        // 5) zip 다운로드 → unzip
         Path zipPath = wsRoot.resolve("repo.zip");
         githubClient.downloadZip(parsed.getOwner(), parsed.getRepo(), commitSha, zipPath);
 
         Path unzipRoot = wsRoot.resolve("repo");
         ZipUtils.unzip(zipPath, unzipRoot);
+        log.info("Repository snapshot ready runId={}, zipPath={}, unzipRoot={}", runId, zipPath, unzipRoot);
 
-        // 6) DB 저장 (RepoRun)
         RepoRun run = new RepoRun(
                 runId,
                 owner,
@@ -78,7 +94,6 @@ public class RepoRunService {
         );
         repoRunRepository.save(run);
 
-        // 7) job_manifest Artifact → S3 + DB 저장 (로컬 파일 없이 meta 직접 구성)
         ObjectNode meta = objectMapper.createObjectNode();
         meta.put("ref", ref);
         meta.put("commitSha", commitSha);
@@ -86,6 +101,7 @@ public class RepoRunService {
 
         artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1",
                 "job_manifest.json", meta);
+        log.info("Run queued runId={}, status={}, sha={}", runId, run.getStatus(), abbreviateSha(commitSha));
 
         return RepoRunCreateResponse.builder()
                 .runId(runId)
@@ -93,5 +109,12 @@ public class RepoRunService {
                 .commitSha(commitSha)
                 .workspaceRoot(wsRoot.toString())
                 .build();
+    }
+
+    private String abbreviateSha(String sha) {
+        if (sha == null || sha.isBlank()) {
+            return "<empty>";
+        }
+        return sha.length() <= 8 ? sha : sha.substring(0, 8);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -12,6 +12,7 @@ import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.domain.run.support.GithubClient;
 import com.example.ossdoc.domain.run.support.GithubRepoRef;
 import com.example.ossdoc.domain.run.support.GithubUrlParser;
+import com.example.ossdoc.domain.run.support.JobManifestWriter;
 import com.example.ossdoc.domain.run.support.WorkspaceManager;
 import com.example.ossdoc.domain.run.support.ZipUtils;
 import com.example.ossdoc.domain.user.entity.User;
@@ -37,6 +38,7 @@ public class RepoRunService {
     private final ArtifactService artifactService;
     private final GithubClient githubClient;
     private final WorkspaceManager workspaceManager;
+    private final JobManifestWriter jobManifestWriter;
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -98,6 +100,9 @@ public class RepoRunService {
         meta.put("ref", ref);
         meta.put("commitSha", commitSha);
         meta.put("generatedAt", OffsetDateTime.now().toString());
+
+        Path artifactsDir = workspaceManager.artifactsDir(wsRoot);
+        jobManifestWriter.write(artifactsDir, meta);
 
         artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1",
                 "job_manifest.json", meta);

--- a/src/main/java/com/example/ossdoc/domain/run/support/GithubClient.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/GithubClient.java
@@ -1,41 +1,45 @@
 package com.example.ossdoc.domain.run.support;
 
-import com.example.ossdoc.domain.build.exception.BuildException;
-import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
-import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
 import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GithubClient {
 
+    private static final Duration API_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ZIP_TIMEOUT = Duration.ofSeconds(120);
+    private static final int ERROR_BODY_PREVIEW_LEN = 300;
+
     private final ObjectMapper objectMapper;
 
-    // GitHub API 호출용 HTTP 클라이언트
-    // GitHub API 호출용 HTTP 클라이언트
     private final WebClient webClient = WebClient.builder()
             .defaultHeader(HttpHeaders.USER_AGENT, "ossdoc")
             .build();
 
-    // 저장소의 기본 브랜치가 뭔지 알아냄
     public String resolveDefaultBranch(String owner, String repo) {
         try {
             String json = webClient.get()
                     .uri("https://api.github.com/repos/{owner}/{repo}", owner, repo)
                     .retrieve()
-                    .bodyToMono(String.class)   // ✅ String으로 받기
-                    .block();
+                    .bodyToMono(String.class)
+                    .block(API_TIMEOUT);
 
             if (json == null || json.isBlank()) {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
@@ -47,20 +51,35 @@ public class GithubClient {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
             }
             return branch.asText();
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "GitHub default-branch API failed owner={}, repo={}, status={}, body={}",
+                    owner,
+                    repo,
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         } catch (Exception e) {
-            log.debug("git fail error={}", e.getMessage());
+            log.error(
+                    "GitHub default-branch API failed owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
             throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         }
     }
 
-    // ref(브랜치/태그/커밋)를 실제 commit SHA로 변환하는 메서드
     public String resolveCommitSha(String owner, String repo, String ref) {
         try {
             String json = webClient.get()
                     .uri("https://api.github.com/repos/{owner}/{repo}/commits/{ref}", owner, repo, ref)
                     .retrieve()
-                    .bodyToMono(String.class)   // ✅ 여기도 String으로 받기 (중요)
-                    .block();
+                    .bodyToMono(String.class)
+                    .block(API_TIMEOUT);
 
             if (json == null || json.isBlank()) {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
@@ -72,31 +91,169 @@ public class GithubClient {
                 throw new RunException(RunErrorCode.GITHUB_API_FAILED);
             }
             return sha.asText();
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "GitHub commit API failed owner={}, repo={}, ref={}, status={}, body={}",
+                    owner,
+                    repo,
+                    ref,
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         } catch (Exception e) {
-            log.debug("git fail error={}", e.getMessage());
+            log.error(
+                    "GitHub commit API failed owner={}, repo={}, ref={}, cause={}",
+                    owner,
+                    repo,
+                    ref,
+                    e.toString(),
+                    e
+            );
             throw new RunException(RunErrorCode.GITHUB_API_FAILED);
         }
     }
 
-    // 특정 ref 상태의 저장소를 ZIP으로 다운로드
     public Path downloadZip(String owner, String repo, String commitSha, Path targetZip) {
-        try {
-            byte[] bytes = webClient.get()
-                    .uri("https://codeload.github.com/{owner}/{repo}/zip/{commitSha}", owner, repo, commitSha)
-                    .retrieve()
-                    .bodyToMono(byte[].class)
-                    .block();
+        ensureParentDir(targetZip);
 
-            if (bytes == null || bytes.length == 0) {
-                throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
-            }
+        boolean downloaded = tryDownloadZipToFile(
+                owner,
+                repo,
+                commitSha,
+                "codeload",
+                "https://codeload.github.com/{owner}/{repo}/zip/{commitSha}",
+                targetZip
+        );
 
-            Files.createDirectories(targetZip.getParent());
-            Files.write(targetZip, bytes);
-            return targetZip;
-        } catch (Exception e) {
-            log.debug("download fail error={}", e.getMessage());
+        if (!downloaded) {
+            log.warn(
+                    "Primary zip download failed owner={}, repo={}, sha={}. Trying GitHub API zipball fallback.",
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha)
+            );
+            downloaded = tryDownloadZipToFile(
+                    owner,
+                    repo,
+                    commitSha,
+                    "api-zipball",
+                    "https://api.github.com/repos/{owner}/{repo}/zipball/{commitSha}",
+                    targetZip
+            );
+        }
+
+        if (!downloaded) {
             throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
         }
+        return targetZip;
+    }
+
+    private boolean tryDownloadZipToFile(
+            String owner,
+            String repo,
+            String commitSha,
+            String source,
+            String uriTemplate,
+            Path targetZip
+    ) {
+        try {
+            Files.deleteIfExists(targetZip);
+
+            DataBufferUtils.write(
+                    webClient.get()
+                            .uri(uriTemplate, owner, repo, commitSha)
+                            .retrieve()
+                            .bodyToFlux(DataBuffer.class),
+                    targetZip,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE
+            ).block(ZIP_TIMEOUT);
+
+            if (!Files.exists(targetZip)) {
+                log.warn(
+                        "Zip file not created source={}, owner={}, repo={}, sha={}",
+                        source,
+                        owner,
+                        repo,
+                        abbreviateSha(commitSha)
+                );
+                return false;
+            }
+
+            long size = Files.size(targetZip);
+            if (size <= 0) {
+                log.warn(
+                        "Zip file is empty source={}, owner={}, repo={}, sha={}",
+                        source,
+                        owner,
+                        repo,
+                        abbreviateSha(commitSha)
+                );
+                Files.deleteIfExists(targetZip);
+                return false;
+            }
+            return true;
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "Zip download failed source={}, owner={}, repo={}, sha={}, status={}, body={}",
+                    source,
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha),
+                    e.getStatusCode().value(),
+                    previewBody(e.getResponseBodyAsString()),
+                    e
+            );
+            deleteQuietly(targetZip);
+            return false;
+        } catch (Exception e) {
+            log.error(
+                    "Zip download failed source={}, owner={}, repo={}, sha={}, cause={}",
+                    source,
+                    owner,
+                    repo,
+                    abbreviateSha(commitSha),
+                    e.toString(),
+                    e
+            );
+            deleteQuietly(targetZip);
+            return false;
+        }
+    }
+
+    private void ensureParentDir(Path targetZip) {
+        try {
+            Path parent = targetZip.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+        } catch (Exception e) {
+            log.error("Failed to create parent directory for zip path={}, cause={}", targetZip, e.toString(), e);
+            throw new RunException(RunErrorCode.DOWNLOAD_FAILED);
+        }
+    }
+
+    private void deleteQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (Exception ignored) {
+        }
+    }
+
+    private String previewBody(String body) {
+        if (body == null || body.isBlank()) {
+            return "<empty>";
+        }
+        return body.length() > ERROR_BODY_PREVIEW_LEN ? body.substring(0, ERROR_BODY_PREVIEW_LEN) + "..." : body;
+    }
+
+    private String abbreviateSha(String sha) {
+        if (sha == null || sha.isBlank()) {
+            return "<empty>";
+        }
+        return sha.length() <= 8 ? sha : sha.substring(0, 8);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/support/JobManifestWriter.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/JobManifestWriter.java
@@ -1,0 +1,32 @@
+package com.example.ossdoc.domain.run.support;
+
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobManifestWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public Path write(Path artifactsDir, JsonNode jobManifest) {
+        try {
+            Files.createDirectories(artifactsDir);
+            Path out = artifactsDir.resolve("job_manifest.json");
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(out.toFile(), jobManifest);
+            return out;
+        } catch (Exception e) {
+            log.debug("JobManifestWriter error={}", e.toString(), e);
+            throw new RunException(RunErrorCode.JOB_MANIFEST_WRITE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
+++ b/src/main/java/com/example/ossdoc/domain/run/support/WorkspaceManager.java
@@ -1,18 +1,22 @@
 package com.example.ossdoc.domain.run.support;
 
+import com.example.ossdoc.global.properties.WorkspaceProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
 
 @Component
+@RequiredArgsConstructor
 public class WorkspaceManager {
 
-    // TODO: application.yml로 빼는 걸 추천 (ex. ossdoc.workspace.base-dir=/data/ossdoc)
-    private final String baseDir = "/data/ossdoc";
+    private final WorkspaceProperties workspaceProperties;
 
     /** 특정 Run의 최상위 작업 디렉토리 경로 반환 */
     public Path workspaceRoot(String runId) {
-        return Path.of(baseDir, runId);
+        return Path.of(workspaceProperties.getBaseDir(), runId)
+                .toAbsolutePath()
+                .normalize();
     }
 
     /** 분석 결과물이 저장될 폴더 경로 반환 */

--- a/src/main/java/com/example/ossdoc/global/config/BuildCommandProperties.java
+++ b/src/main/java/com/example/ossdoc/global/config/BuildCommandProperties.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @Component
@@ -12,15 +15,32 @@ import org.springframework.stereotype.Component;
 public class BuildCommandProperties {
 
     /**
-     * mvnw / mvnw.cmd 가 없을 때 사용할 Maven 실행 명령어
-     * 예: mvn
-     * 예: C:\\tools\\apache-maven-3.9.13\\bin\\mvn.cmd
+     * Maven command used when mvnw/mvnw.cmd is not present in the target repository.
      */
     private String mavenCommand = "mvn";
 
     /**
-     * gradlew / gradlew.bat 가 없을 때 사용할 Gradle 실행 명령어
-     * 예: gradle
+     * Gradle command used when gradlew/gradlew.bat is not present in the target repository.
      */
     private String gradleCommand = "gradle";
+
+    /**
+     * Ordered JAVA_HOME candidates for Gradle compatibility fallback retries.
+     */
+    private List<String> javaHomes = new ArrayList<>();
+
+    /**
+     * Enables isolated execution directories per run workspace.
+     */
+    private boolean isolatedExecution = true;
+
+    /**
+     * Relative directory (from workspace root) used as GRADLE_USER_HOME.
+     */
+    private String gradleUserHomeDir = ".gradle-home";
+
+    /**
+     * Relative directory (from workspace root) used as Maven local repository.
+     */
+    private String mavenLocalRepoDir = ".m2/repository";
 }

--- a/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ossdoc.workspace")
+public class WorkspaceProperties {
+
+    /**
+     * Base directory where per-run workspaces are created.
+     * Example: C:/data/oss
+     */
+    private String baseDir = "C:/data/oss";
+}

--- a/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/WorkspaceProperties.java
@@ -13,7 +13,7 @@ public class WorkspaceProperties {
 
     /**
      * Base directory where per-run workspaces are created.
-     * Example: C:/data/oss
+     * Example: C:/data/ossdoc
      */
-    private String baseDir = "C:/data/oss";
+    private String baseDir = "C:/data/ossdoc";
 }

--- a/src/test/java/com/example/ossdoc/domain/build/service/BuildDetectorTest.java
+++ b/src/test/java/com/example/ossdoc/domain/build/service/BuildDetectorTest.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.build.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildDetectorTest {
+
+    private final BuildDetector buildDetector = new BuildDetector();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectsBothGradleAndMavenWhenBuildFilesCoexist() throws IOException {
+        Files.writeString(tempDir.resolve("build.gradle"), "plugins { id 'java' }");
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Files.writeString(tempDir.resolve("gradlew.bat"), "@echo off");
+        Files.writeString(tempDir.resolve("mvnw.cmd"), "@echo off");
+
+        BuildDetector.Detected detected = buildDetector.detect(tempDir);
+
+        assertTrue(detected.hasGradle());
+        assertTrue(detected.hasMaven());
+        assertTrue(detected.gradleWrapperExists());
+        assertTrue(detected.mavenWrapperExists());
+        assertTrue(detected.hasAnyBuildTool());
+    }
+
+    @Test
+    void returnsNoBuildToolWhenNoBuildFiles() {
+        BuildDetector.Detected detected = buildDetector.detect(tempDir);
+
+        assertFalse(detected.hasGradle());
+        assertFalse(detected.hasMaven());
+        assertFalse(detected.hasAnyBuildTool());
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/build/support/BuildPathNormalizerTest.java
+++ b/src/test/java/com/example/ossdoc/domain/build/support/BuildPathNormalizerTest.java
@@ -1,0 +1,38 @@
+package com.example.ossdoc.domain.build.support;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BuildPathNormalizerTest {
+
+    private final BuildPathNormalizer buildPathNormalizer = new BuildPathNormalizer();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolvesRelativePathAgainstBaseDir() {
+        String normalized = buildPathNormalizer.toAbsolutePath(tempDir, "src/main/java");
+
+        assertEquals(
+                buildPathNormalizer.normalize(tempDir.resolve("src/main/java")),
+                normalized
+        );
+    }
+
+    @Test
+    void normalizesAbsolutePath() {
+        Path raw = tempDir.resolve("repo").resolve("..").resolve("repo").resolve("build/classes/java/main");
+
+        String normalized = buildPathNormalizer.normalize(raw);
+
+        assertEquals(
+                buildPathNormalizer.normalize(tempDir.resolve("repo/build/classes/java/main")),
+                normalized
+        );
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriterTest.java
+++ b/src/test/java/com/example/ossdoc/domain/build/support/GradleInitScriptWriterTest.java
@@ -1,0 +1,28 @@
+package com.example.ossdoc.domain.build.support;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradleInitScriptWriterTest {
+
+    private final GradleInitScriptWriter writer = new GradleInitScriptWriter();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesScriptThatDumpsAbsolutePaths() throws IOException {
+        Path script = writer.write(tempDir);
+        String content = Files.readString(script);
+
+        assertTrue(content.contains("main.java.srcDirs.collect { it.absolutePath }"));
+        assertTrue(content.contains("main.output.classesDirs.files.collect { it.absolutePath }"));
+        assertTrue(content.contains("main.compileClasspath.files.collect { it.absolutePath }"));
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScannerTest.java
+++ b/src/test/java/com/example/ossdoc/domain/build/support/SourceOnlyModuleScannerTest.java
@@ -1,0 +1,38 @@
+package com.example.ossdoc.domain.build.support;
+
+import com.example.ossdoc.domain.build.dto.json.BuildModuleManifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SourceOnlyModuleScannerTest {
+
+    private final SourceOnlyModuleScanner scanner =
+            new SourceOnlyModuleScanner(new BuildPathNormalizer());
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void returnsNormalizedAbsolutePathsForDiscoveredRoots() throws IOException {
+        Files.createDirectories(tempDir.resolve("src/main/java"));
+        Files.createDirectories(tempDir.resolve("module-a/src/test/java"));
+
+        List<BuildModuleManifest> modules = scanner.scan(tempDir);
+
+        assertEquals(2, modules.size());
+        assertTrue(modules.stream()
+                .flatMap(module -> module.getSourceRoots().stream())
+                .allMatch(path -> Path.of(path).isAbsolute()));
+        assertTrue(modules.stream()
+                .flatMap(module -> module.getTestRoots().stream())
+                .allMatch(path -> Path.of(path).isAbsolute()));
+    }
+}


### PR DESCRIPTION
### 주요 작업
- 빌드 도메인 절대경로 통일(Gradle, Maven)
- JDK 버전 불일치 문제 해결(자동 재시도 11, 17, 21 버전)
- Run 도메인 다운로드 방식 스트리밍 방식으로 수정
- 빌드 도메인 BuildResolceService 코드 책임분리
- Gradle/Maven 혼합 프젝일 경우 둘다 실행해서 더 좋은 결과 추출(동점일시 gradle 추출)
- 빌드 도메인 build_manifest파일 s3업로드
- job_manifest, build_manifest 모두 로컬과 s3업로드 되게 dual-write 방식 적용

s3는 운영적관점으로 중간 산출물 영구 저장
로컬은 파이프 라인내에 분석할때 사용해야함 (나중에 TTL 방식으로 일정시간 지나면 제거)

**s3를 사용하지 않고 로컬에서 분석하는 이유**
- s3를 이용하면 네트워크 비용때문에 속도 저하 (그래서 시스템 복구 불가능할 경우 백업 데이터로 사용)
