### PR TITLE
Feat: graphstore 기반 cluster 분석 및 ranking artifact 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     //JavaParser & ASM
     implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.28.0'
     implementation 'org.ow2.asm:asm:9.9.1'
+
+    //Leiden
+    implementation 'nl.cwts:networkanalysis:1.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ossdoc/domain/artifact/entity/Artifact.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/entity/Artifact.java
@@ -18,6 +18,7 @@ import org.hibernate.type.SqlTypes;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+
 public class Artifact extends BaseCreatedEntity {
 
     @Id

--- a/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
@@ -12,7 +12,7 @@ public enum ArtifactKind {
     LLM_SUBSYSTEM_SUMMARIES,
     LLM_API_DOCS,
 
-    //군집화 결과물
+    //군집화 결과물 추가
     RAKINGS_JSON,
     SUBSYSTEMS_JSON
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
@@ -13,6 +13,6 @@ public enum ArtifactKind {
     LLM_API_DOCS,
 
     //군집화 결과물 추가
-    RAKINGS_JSON,
+    RANKINGS_JSON,
     SUBSYSTEMS_JSON
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
@@ -10,5 +10,9 @@ public enum ArtifactKind {
     LLM_REFINED_RULES,
     LLM_SCENARIO_SPECS,
     LLM_SUBSYSTEM_SUMMARIES,
-    LLM_API_DOCS
+    LLM_API_DOCS,
+
+    //군집화 결과물
+    RAKINGS_JSON,
+    SUBSYSTEMS_JSON
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/artifact/output/RankingsJson.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/artifact/output/RankingsJson.java
@@ -1,4 +1,4 @@
-package com.example.ossdoc.domain.cluster.dto.output;
+package com.example.ossdoc.domain.cluster.artifact.output;
 
 import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
 import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class RankingsJsonDto {
+public class RankingsJson {
     private String schemaVersion;
     private String runId;
     private OffsetDateTime generatedAt;

--- a/src/main/java/com/example/ossdoc/domain/cluster/artifact/output/SubsystemsJson.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/artifact/output/SubsystemsJson.java
@@ -1,4 +1,4 @@
-package com.example.ossdoc.domain.cluster.dto.output;
+package com.example.ossdoc.domain.cluster.artifact.output;
 
 import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
 import lombok.Builder;
@@ -10,7 +10,7 @@ import java.util.Map;
 
 @Getter
 @Builder
-public class SubsystemsJsonDto {
+public class SubsystemsJson {
     private String schemaVersion;
     private String runId;
     private OffsetDateTime generatedAt;

--- a/src/main/java/com/example/ossdoc/domain/cluster/controller/ClusterController.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/controller/ClusterController.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.cluster.controller;
+
+import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
+import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
+import com.example.ossdoc.domain.cluster.service.ClusterBuildService;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/clusters")
+public class ClusterController {
+
+    private final ClusterBuildService clusterBuildService;
+
+    @PostMapping("/build")
+    @Operation(summary = "graphstore 기반 subsystem / ranking 생성")
+    public ApiResponse<ClusterBuildResponse> build(@Valid @RequestBody ClusterBuildRequest request) {
+        return ApiResponse.onSuccess(clusterBuildService.build(request));
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/output/RankingsJsonDto.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/output/RankingsJsonDto.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.domain.cluster.dto.output;
+
+import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class RankingsJsonDto {
+    private String schemaVersion;
+    private String runId;
+    private OffsetDateTime generatedAt;
+    private List<SymbolRankingItem> symbolRankings;
+    private List<SubsystemRankingItem> subsystemRankings;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/output/SubsystemsJsonDto.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/output/SubsystemsJsonDto.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.domain.cluster.dto.output;
+
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class SubsystemsJsonDto {
+    private String schemaVersion;
+    private String runId;
+    private OffsetDateTime generatedAt;
+    private Map<String, Object> algorithm;
+    private List<Subsystem> subsystems;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
@@ -1,0 +1,30 @@
+package com.example.ossdoc.domain.cluster.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+/* 군집화 알고리즘 : Leiden알고리즘
+* resolution : 군집 세분화 정도 파라미터. 값이 높을 수록 군집이 세분화됨. 범위(0~1)
+* iterations : 품질 개선을 위해 노드 이동, 정교화, 집계 과정을 반복할 횟수
+* minClusterSize : 군집 내의 멤버가 너무 적으면, 그 군집을 subsystem으로 인정할지에 대한 기준값 / 군집(subsystem) 필터
+* topK : symbol을 상위 몇개까지 ranking 결과를 뽑을지 정하는 값 / 랭킹(symbol) 필터
+ * */
+@Getter
+@NoArgsConstructor
+public class ClusterBuildRequest {
+    @NotBlank
+    private String runId;
+
+    /*Leiden 군집화 알고리즘 관련*/
+    private Double resolution = 0.012;
+
+    @Min(1)
+    private Integer iterations = 10;
+
+    @Min(1)
+    private Integer minClusterSize = 3;
+
+    @Min(1)
+    private Integer topK = 30;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/response/ClusterBuildResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/response/ClusterBuildResponse.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.cluster.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClusterBuildResponse {
+    private String runId;
+    private int subsystemCount;
+    private int rankedSymbolCount;
+    private Long rankingsArtifactId;
+    private Long subsystemsArtifactId;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/exception/ClusterException.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/exception/ClusterException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.cluster.exception;
+
+import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class ClusterException extends GeneralException {
+
+    public ClusterException(ClusterErrorCode code) {
+        super(code);
+    }
+
+    public ClusterException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/exception/code/ClusterErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/exception/code/ClusterErrorCode.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.cluster.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ClusterErrorCode implements BaseCode {
+
+    CLUSTER_RUN_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUSTER404_1", "존재하지 않는 run 입니다."),
+    CLUSTER_GRAPH_EMPTY(HttpStatus.BAD_REQUEST, "CLUSTER400_1", "군집화할 graph 데이터가 없습니다."),
+    CLUSTER_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUSTER403_1", "해당 run에 접근할 권한이 없습니다."),
+    CLUSTER_PROJECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CLUSTER500_1", "graph projection에 실패했습니다."),
+    CLUSTER_LEIDEN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CLUSTER500_2", "Leiden 군집화에 실패했습니다."),
+    CLUSTER_ASSEMBLY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CLUSTER500_3", "subsystem 조립에 실패했습니다."),
+    CLUSTER_RANKING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CLUSTER500_4", "중요도 산정에 실패했습니다."),
+    CLUSTER_ARTIFACT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CLUSTER500_5", "cluster 산출물 저장에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/CommunityResult.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/CommunityResult.java
@@ -1,0 +1,15 @@
+package com.example.ossdoc.domain.cluster.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommunityResult {
+    /*
+    * node index -> cluster id
+    * 예 : cluster[3] = 1이면?
+    * 3번 node는 1번 community에 속한다는 의미
+    * */
+    private int[] clusters;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedEdge.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedEdge.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.cluster.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectedEdge {
+    private int fromIndex;
+    private int toIndex;
+    private double weight;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedGraph.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedGraph.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.cluster.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class ProjectedGraph {
+    private String runId;
+    private List<ProjectedNode> nodes;
+    private List<ProjectedEdge> edges;
+
+    private Map<String, Integer> nodeIndexMap;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedNode.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedNode.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.cluster.model;
+
+import lombok.Builder;
+import lombok.Getter;
+/* ProjectedNode.java : 군집화 알고리즘에 넣기 전, DB에 SymbolEntity를 군집화용으로 변환한 노드
+* 즉, 군집화에 필요한 최소 정보만 들고 있는 가벼운 객체
+* */
+@Getter
+@Builder
+public class ProjectedNode {
+    private String symbolId;
+    private String qualifiedName; //rankingJson 생성에 필요
+    private String simpleName;
+    private String packageName; //subsystem 이름
+    private String moduleId; //같은 모듈끼리 묶을때 필요
+    private boolean publicApi; //entry symbol 판단
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SubsystemRankingItem.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SubsystemRankingItem.java
@@ -1,0 +1,13 @@
+package com.example.ossdoc.domain.cluster.model.ranking;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubsystemRankingItem {
+    private int rank;
+    private String subsystemId;
+    private String name;
+    private double score;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SymbolRankingItem.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SymbolRankingItem.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.domain.cluster.model.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SymbolRankingItem {
+    private int rank;
+    private String symbolId;
+    private String qualifiedName;
+    private String subsystemId;
+    private double score;
+    private double structuralScore;
+    private double bridgeScore;
+    private double apiScore;
+    private double evidenceScore;
+    private double subsystemCentralityScore;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/subsystem/Subsystem.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/subsystem/Subsystem.java
@@ -1,0 +1,18 @@
+package com.example.ossdoc.domain.cluster.model.subsystem;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class Subsystem {
+    private String subsystemId;
+    private String name;
+    private double score;
+    private List<String> memberSymbolIds;
+    private List<String> entrySymbolIds;
+    private List<String> coreSymbolIds;
+    private List<String> packageRoots;
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/subsystem/Subsystem.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/subsystem/Subsystem.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class Subsystem {
     private String subsystemId;
     private String name;

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
@@ -5,6 +5,8 @@ import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.service.ArtifactService;
 import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
 import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.cluster.exception.ClusterException;
+import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,24 +21,36 @@ public class ClusterArtifactPublisher {
     private final ObjectMapper objectMapper;
 
     public Artifact publishRankings(RepoRun run, RankingsJsonDto dto) {
-        JsonNode content = objectMapper.valueToTree(dto);
-        return artifactService.saveJsonArtifact(
-                run,
-                ArtifactKind.RANKINGS_JSON,
-                "1.0",
-                "analysis/rankings.json",
-                content
-        );
+        try {
+            JsonNode content = objectMapper.valueToTree(dto);
+            return artifactService.saveJsonArtifact(
+                    run,
+                    ArtifactKind.RANKINGS_JSON,
+                    "1.0",
+                    "analysis/rankings.json",
+                    content
+            );
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_ARTIFACT_SAVE_FAILED);
+        }
     }
 
     public Artifact publishSubsystems(RepoRun run, SubsystemsJsonDto dto) {
-        JsonNode content = objectMapper.valueToTree(dto);
-        return artifactService.saveJsonArtifact(
-                run,
-                ArtifactKind.SUBSYSTEMS_JSON,
-                "1.0",
-                "analysis/subsystems.json",
-                content
-        );
+        try {
+            JsonNode content = objectMapper.valueToTree(dto);
+            return artifactService.saveJsonArtifact(
+                    run,
+                    ArtifactKind.SUBSYSTEMS_JSON,
+                    "1.0",
+                    "analysis/subsystems.json",
+                    content
+            );
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_ARTIFACT_SAVE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
@@ -1,0 +1,42 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
+import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClusterArtifactPublisher {
+
+    private final ArtifactService artifactService;
+    private final ObjectMapper objectMapper;
+
+    public Artifact publishRankings(RepoRun run, RankingsJsonDto dto) {
+        JsonNode content = objectMapper.valueToTree(dto);
+        return artifactService.saveJsonArtifact(
+                run,
+                ArtifactKind.RANKINGS_JSON,
+                "1.0",
+                "analysis/rankings.json",
+                content
+        );
+    }
+
+    public Artifact publishSubsystems(RepoRun run, SubsystemsJsonDto dto) {
+        JsonNode content = objectMapper.valueToTree(dto);
+        return artifactService.saveJsonArtifact(
+                run,
+                ArtifactKind.SUBSYSTEMS_JSON,
+                "1.0",
+                "analysis/subsystems.json",
+                content
+        );
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterArtifactPublisher.java
@@ -3,8 +3,8 @@ package com.example.ossdoc.domain.cluster.service;
 import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.service.ArtifactService;
-import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
-import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.cluster.artifact.output.RankingsJson;
+import com.example.ossdoc.domain.cluster.artifact.output.SubsystemsJson;
 import com.example.ossdoc.domain.cluster.exception.ClusterException;
 import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
 import com.example.ossdoc.domain.run.entity.RepoRun;
@@ -20,7 +20,7 @@ public class ClusterArtifactPublisher {
     private final ArtifactService artifactService;
     private final ObjectMapper objectMapper;
 
-    public Artifact publishRankings(RepoRun run, RankingsJsonDto dto) {
+    public Artifact publishRankings(RepoRun run, RankingsJson dto) {
         try {
             JsonNode content = objectMapper.valueToTree(dto);
             return artifactService.saveJsonArtifact(
@@ -37,7 +37,7 @@ public class ClusterArtifactPublisher {
         }
     }
 
-    public Artifact publishSubsystems(RepoRun run, SubsystemsJsonDto dto) {
+    public Artifact publishSubsystems(RepoRun run, SubsystemsJson dto) {
         try {
             JsonNode content = objectMapper.valueToTree(dto);
             return artifactService.saveJsonArtifact(

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
@@ -64,7 +64,7 @@ public class ClusterBuildService {
                         "iterations", request.getIterations(),
                         "graphMode", "UNDIRECTED_WEIGHTED_TYPE_GRAPH"
                 ))
-                .subsystems(subsystems)
+                .subsystems(rankingResult.enrichedSubsystems())
                 .build();
 
         RankingsJsonDto rankingsJson = RankingsJsonDto.builder()

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
@@ -1,8 +1,8 @@
 package com.example.ossdoc.domain.cluster.service;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
-import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
-import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.cluster.artifact.output.RankingsJson;
+import com.example.ossdoc.domain.cluster.artifact.output.SubsystemsJson;
 import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
 import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
 import com.example.ossdoc.domain.cluster.exception.ClusterException;
@@ -86,7 +86,7 @@ public class ClusterBuildService {
         }
 
         try {
-            SubsystemsJsonDto subsystemsJson = SubsystemsJsonDto.builder()
+            SubsystemsJson subsystemsJson = SubsystemsJson.builder()
                     .schemaVersion("1.0")
                     .runId(run.getRunId())
                     .generatedAt(OffsetDateTime.now())
@@ -99,7 +99,7 @@ public class ClusterBuildService {
                     .subsystems(subsystems)
                     .build();
 
-            RankingsJsonDto rankingsJson = RankingsJsonDto.builder()
+            RankingsJson rankingsJson = RankingsJson.builder()
                     .schemaVersion("1.0")
                     .runId(run.getRunId())
                     .generatedAt(OffsetDateTime.now())

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
@@ -1,0 +1,89 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
+import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
+import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
+import com.example.ossdoc.domain.cluster.model.CommunityResult;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClusterBuildService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final GraphProjectionService graphProjectionService;
+    private final LeidenCommunityService leidenCommunityService;
+    private final SubsystemAssembler subsystemAssembler;
+    private final RankingService rankingService;
+    private final ClusterArtifactPublisher clusterArtifactPublisher;
+
+    public ClusterBuildResponse build(ClusterBuildRequest request) {
+        RepoRun run = repoRunRepository.findById(request.getRunId())
+                .orElseThrow(() -> new IllegalArgumentException("run not found: " + request.getRunId()));
+
+        ProjectedGraph projectedGraph = graphProjectionService.loadProjectedGraph(request.getRunId());
+
+        CommunityResult communityResult = leidenCommunityService.detect(
+                projectedGraph,
+                request.getResolution(),
+                request.getIterations()
+        );
+
+        List<Subsystem> subsystems = subsystemAssembler.assemble(
+                projectedGraph,
+                communityResult.getClusters(),
+                request.getMinClusterSize()
+        );
+
+        RankingService.RankingResult rankingResult = rankingService.rank(
+                projectedGraph,
+                subsystems,
+                request.getTopK()
+        );
+
+        SubsystemsJsonDto subsystemsJson = SubsystemsJsonDto.builder()
+                .schemaVersion("1.0")
+                .runId(run.getRunId())
+                .generatedAt(OffsetDateTime.now())
+                .algorithm(Map.of(
+                        "name", "Leiden",
+                        "resolution", request.getResolution(),
+                        "iterations", request.getIterations(),
+                        "graphMode", "UNDIRECTED_WEIGHTED_TYPE_GRAPH"
+                ))
+                .subsystems(subsystems)
+                .build();
+
+        RankingsJsonDto rankingsJson = RankingsJsonDto.builder()
+                .schemaVersion("1.0")
+                .runId(run.getRunId())
+                .generatedAt(OffsetDateTime.now())
+                .symbolRankings(rankingResult.symbolRankings())
+                .subsystemRankings(rankingResult.subsystemRankings())
+                .build();
+
+        Artifact subsystemsArtifact = clusterArtifactPublisher.publishSubsystems(run, subsystemsJson);
+        Artifact rankingsArtifact = clusterArtifactPublisher.publishRankings(run, rankingsJson);
+
+        return new ClusterBuildResponse(
+                run.getRunId(),
+                subsystems.size(),
+                rankingResult.symbolRankings().size(),
+                rankingsArtifact.getId(),
+                subsystemsArtifact.getId()
+        );
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
@@ -5,9 +5,12 @@ import com.example.ossdoc.domain.cluster.dto.output.RankingsJsonDto;
 import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
 import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
 import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
+import com.example.ossdoc.domain.cluster.exception.ClusterException;
+import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
 import com.example.ossdoc.domain.cluster.model.CommunityResult;
 import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
 import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.cluster.support.SubsystemAssembler;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,58 +35,92 @@ public class ClusterBuildService {
 
     public ClusterBuildResponse build(ClusterBuildRequest request) {
         RepoRun run = repoRunRepository.findById(request.getRunId())
-                .orElseThrow(() -> new IllegalArgumentException("run not found: " + request.getRunId()));
+                .orElseThrow(() -> new ClusterException(ClusterErrorCode.CLUSTER_RUN_NOT_FOUND));
 
-        ProjectedGraph projectedGraph = graphProjectionService.loadProjectedGraph(request.getRunId());
+        ProjectedGraph projectedGraph;
+        try {
+            projectedGraph = graphProjectionService.loadProjectedGraph(request.getRunId());
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_PROJECTION_FAILED);
+        }
 
-        CommunityResult communityResult = leidenCommunityService.detect(
-                projectedGraph,
-                request.getResolution(),
-                request.getIterations()
-        );
+        if (projectedGraph.getNodes() == null || projectedGraph.getNodes().isEmpty()) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_GRAPH_EMPTY);
+        }
 
-        List<Subsystem> subsystems = subsystemAssembler.assemble(
-                projectedGraph,
-                communityResult.getClusters(),
-                request.getMinClusterSize()
-        );
+        CommunityResult communityResult;
+        try {
+            communityResult = leidenCommunityService.detect(
+                    projectedGraph,
+                    request.getResolution(),
+                    request.getIterations()
+            );
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_LEIDEN_FAILED);
+        }
 
-        RankingService.RankingResult rankingResult = rankingService.rank(
-                projectedGraph,
-                subsystems,
-                request.getTopK()
-        );
+        List<Subsystem> subsystems;
+        try {
+            subsystems = subsystemAssembler.assemble(
+                    projectedGraph,
+                    communityResult.getClusters(),
+                    request.getMinClusterSize()
+            );
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_ASSEMBLY_FAILED);
+        }
 
-        SubsystemsJsonDto subsystemsJson = SubsystemsJsonDto.builder()
-                .schemaVersion("1.0")
-                .runId(run.getRunId())
-                .generatedAt(OffsetDateTime.now())
-                .algorithm(Map.of(
-                        "name", "Leiden",
-                        "resolution", request.getResolution(),
-                        "iterations", request.getIterations(),
-                        "graphMode", "UNDIRECTED_WEIGHTED_TYPE_GRAPH"
-                ))
-                .subsystems(rankingResult.enrichedSubsystems())
-                .build();
+        RankingService.RankingResult rankingResult;
+        try {
+            rankingResult = rankingService.rank(
+                    projectedGraph,
+                    subsystems,
+                    request.getTopK()
+            );
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_RANKING_FAILED);
+        }
 
-        RankingsJsonDto rankingsJson = RankingsJsonDto.builder()
-                .schemaVersion("1.0")
-                .runId(run.getRunId())
-                .generatedAt(OffsetDateTime.now())
-                .symbolRankings(rankingResult.symbolRankings())
-                .subsystemRankings(rankingResult.subsystemRankings())
-                .build();
+        try {
+            SubsystemsJsonDto subsystemsJson = SubsystemsJsonDto.builder()
+                    .schemaVersion("1.0")
+                    .runId(run.getRunId())
+                    .generatedAt(OffsetDateTime.now())
+                    .algorithm(Map.of(
+                            "name", "Leiden",
+                            "resolution", request.getResolution(),
+                            "iterations", request.getIterations(),
+                            "graphMode", "UNDIRECTED_WEIGHTED_TYPE_GRAPH"
+                    ))
+                    .subsystems(subsystems)
+                    .build();
 
-        Artifact subsystemsArtifact = clusterArtifactPublisher.publishSubsystems(run, subsystemsJson);
-        Artifact rankingsArtifact = clusterArtifactPublisher.publishRankings(run, rankingsJson);
+            RankingsJsonDto rankingsJson = RankingsJsonDto.builder()
+                    .schemaVersion("1.0")
+                    .runId(run.getRunId())
+                    .generatedAt(OffsetDateTime.now())
+                    .symbolRankings(rankingResult.symbolRankings())
+                    .subsystemRankings(rankingResult.subsystemRankings())
+                    .build();
 
-        return new ClusterBuildResponse(
-                run.getRunId(),
-                subsystems.size(),
-                rankingResult.symbolRankings().size(),
-                rankingsArtifact.getArtifactId(),
-                subsystemsArtifact.getArtifactId()
-        );
+            Artifact subsystemsArtifact = clusterArtifactPublisher.publishSubsystems(run, subsystemsJson);
+            Artifact rankingsArtifact = clusterArtifactPublisher.publishRankings(run, rankingsJson);
+
+            return new ClusterBuildResponse(
+                    run.getRunId(),
+                    subsystems.size(),
+                    rankingResult.symbolRankings().size(),
+                    rankingsArtifact.getArtifactId(),
+                    subsystemsArtifact.getArtifactId()
+            );
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_ARTIFACT_SAVE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterBuildService.java
@@ -82,8 +82,8 @@ public class ClusterBuildService {
                 run.getRunId(),
                 subsystems.size(),
                 rankingResult.symbolRankings().size(),
-                rankingsArtifact.getId(),
-                subsystemsArtifact.getId()
+                rankingsArtifact.getArtifactId(),
+                subsystemsArtifact.getArtifactId()
         );
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
@@ -33,7 +33,7 @@ public class GraphProjectionService {
     public ProjectedGraph loadProjectedGraph(String runId) {
         List<SymbolEntity> typeSymbols;
         try {
-            typeSymbols = symbolRepository.findAllByRun_RunIdAndSymbolKind(runId, SymbolKind.TYPE);
+            typeSymbols = symbolRepository.findAllByRunIdAndSymbolKind(runId, SymbolKind.TYPE);
         } catch (Exception e) {
             throw new ClusterException(ClusterErrorCode.CLUSTER_PROJECTION_FAILED);
         }
@@ -44,7 +44,7 @@ public class GraphProjectionService {
 
         Set<String> publicApiSymbolIds;
         try {
-            publicApiSymbolIds = publicApiEntryRepository.findAllByRun_RunId(runId).stream()
+            publicApiSymbolIds = publicApiEntryRepository.findAllByRunId(runId).stream()
                     .map(PublicApiEntry::getSymbol)
                     .map(SymbolEntity::getSymbolId)
                     .collect(Collectors.toSet());

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
@@ -1,0 +1,110 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import com.example.ossdoc.domain.cluster.support.EdgeWeightPolicy;
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
+import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolRepository;
+import com.example.ossdoc.domain.publicapi.entity.PublicApiEntry;
+import com.example.ossdoc.domain.publicapi.repository.PublicApiEntryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GraphProjectionService {
+
+    private final SymbolRepository symbolRepository;
+    private final EdgeRepository edgeRepository;
+    private final PublicApiEntryRepository publicApiEntryRepository;
+    private final EdgeWeightPolicy edgeWeightPolicy;
+
+    public ProjectedGraph loadProjectedGraph(String runId) {
+        List<SymbolEntity> typeSymbols = symbolRepository.findAllByRun_RunIdAndSymbolKind(runId, SymbolKind.TYPE);
+        Set<String> publicApiSymbolIds = publicApiEntryRepository.findAllByRun_RunId(runId).stream()
+                .map(PublicApiEntry::getSymbol)
+                .map(SymbolEntity::getSymbolId)
+                .collect(Collectors.toSet());
+
+        List<ProjectedNode> nodes = new ArrayList<>();
+        Map<String, Integer> nodeIndexMap = new HashMap<>();
+
+        for (int i = 0; i < typeSymbols.size(); i++) {
+            SymbolEntity symbol = typeSymbols.get(i);
+
+            String packageName = extractPackageName(symbol.getQualifiedName());
+
+            nodes.add(ProjectedNode.builder()
+                    .symbolId(symbol.getSymbolId())
+                    .qualifiedName(symbol.getQualifiedName())
+                    .simpleName(symbol.getSimpleName())
+                    .packageName(packageName)
+                    .moduleId(symbol.getModule() == null ? null : symbol.getModule().getModuleId())
+                    .publicApi(publicApiSymbolIds.contains(symbol.getSymbolId()))
+                    .build());
+
+            nodeIndexMap.put(symbol.getSymbolId(), i);
+        }
+
+        List<Edge> allEdges = edgeRepository.findAllByRun_RunId(runId);
+
+        Map<String, Double> undirectedWeightMap = new HashMap<>();
+
+        for (Edge edge : allEdges) {
+            if (edge.getFromSymbol() == null || edge.getToSymbol() == null) {
+                continue;
+            }
+
+            Integer fromIndex = nodeIndexMap.get(edge.getFromSymbol().getSymbolId());
+            Integer toIndex = nodeIndexMap.get(edge.getToSymbol().getSymbolId());
+
+            if (fromIndex == null || toIndex == null) {
+                continue;
+            }
+
+            if (fromIndex.equals(toIndex)) {
+                continue;
+            }
+
+            int a = Math.min(fromIndex, toIndex);
+            int b = Math.max(fromIndex, toIndex);
+
+            String key = a + ":" + b;
+            double weight = edgeWeightPolicy.weightOf(edge);
+
+            undirectedWeightMap.merge(key, weight, Double::sum);
+        }
+
+        List<ProjectedEdge> projectedEdges = new ArrayList<>();
+        for (Map.Entry<String, Double> entry : undirectedWeightMap.entrySet()) {
+            String[] split = entry.getKey().split(":");
+            projectedEdges.add(new ProjectedEdge(
+                    Integer.parseInt(split[0]),
+                    Integer.parseInt(split[1]),
+                    entry.getValue()
+            ));
+        }
+
+        return ProjectedGraph.builder()
+                .runId(runId)
+                .nodes(nodes)
+                .edges(projectedEdges)
+                .nodeIndexMap(nodeIndexMap)
+                .build();
+    }
+
+    private String extractPackageName(String qualifiedName) {
+        int idx = qualifiedName == null ? -1 : qualifiedName.lastIndexOf('.');
+        if (idx < 0) return "";
+        return qualifiedName.substring(0, idx);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
@@ -1,5 +1,7 @@
 package com.example.ossdoc.domain.cluster.service;
 
+import com.example.ossdoc.domain.cluster.exception.ClusterException;
+import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
 import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
 import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
 import com.example.ossdoc.domain.cluster.model.ProjectedNode;
@@ -29,18 +31,32 @@ public class GraphProjectionService {
     private final EdgeWeightPolicy edgeWeightPolicy;
 
     public ProjectedGraph loadProjectedGraph(String runId) {
-        List<SymbolEntity> typeSymbols = symbolRepository.findAllByRun_RunIdAndSymbolKind(runId, SymbolKind.TYPE);
-        Set<String> publicApiSymbolIds = publicApiEntryRepository.findAllByRun_RunId(runId).stream()
-                .map(PublicApiEntry::getSymbol)
-                .map(SymbolEntity::getSymbolId)
-                .collect(Collectors.toSet());
+        List<SymbolEntity> typeSymbols;
+        try {
+            typeSymbols = symbolRepository.findAllByRun_RunIdAndSymbolKind(runId, SymbolKind.TYPE);
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_PROJECTION_FAILED);
+        }
+
+        if (typeSymbols == null || typeSymbols.isEmpty()) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_GRAPH_EMPTY);
+        }
+
+        Set<String> publicApiSymbolIds;
+        try {
+            publicApiSymbolIds = publicApiEntryRepository.findAllByRun_RunId(runId).stream()
+                    .map(PublicApiEntry::getSymbol)
+                    .map(SymbolEntity::getSymbolId)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_PROJECTION_FAILED);
+        }
 
         List<ProjectedNode> nodes = new ArrayList<>();
         Map<String, Integer> nodeIndexMap = new HashMap<>();
 
         for (int i = 0; i < typeSymbols.size(); i++) {
             SymbolEntity symbol = typeSymbols.get(i);
-
             String packageName = extractPackageName(symbol.getQualifiedName());
 
             nodes.add(ProjectedNode.builder()
@@ -55,7 +71,12 @@ public class GraphProjectionService {
             nodeIndexMap.put(symbol.getSymbolId(), i);
         }
 
-        List<Edge> allEdges = edgeRepository.findAllByRun_RunId(runId);
+        List<Edge> allEdges;
+        try {
+            allEdges = edgeRepository.findAllByRun_RunId(runId);
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_PROJECTION_FAILED);
+        }
 
         Map<String, Double> undirectedWeightMap = new HashMap<>();
 
@@ -67,11 +88,7 @@ public class GraphProjectionService {
             Integer fromIndex = nodeIndexMap.get(edge.getFromSymbol().getSymbolId());
             Integer toIndex = nodeIndexMap.get(edge.getToSymbol().getSymbolId());
 
-            if (fromIndex == null || toIndex == null) {
-                continue;
-            }
-
-            if (fromIndex.equals(toIndex)) {
+            if (fromIndex == null || toIndex == null || fromIndex.equals(toIndex)) {
                 continue;
             }
 

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityService.java
@@ -1,5 +1,7 @@
 package com.example.ossdoc.domain.cluster.service;
 
+import com.example.ossdoc.domain.cluster.exception.ClusterException;
+import com.example.ossdoc.domain.cluster.exception.code.ClusterErrorCode;
 import com.example.ossdoc.domain.cluster.model.CommunityResult;
 import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
 import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
@@ -16,42 +18,48 @@ import org.springframework.stereotype.Service;
 public class LeidenCommunityService { //Leiden 실행 서비스
 
     public CommunityResult detect(ProjectedGraph graph, double resolution, int iterations) {
-        int nNodes = graph.getNodes().size();
+        try {
+            int nNodes = graph.getNodes().size();
 
-        if (nNodes == 0) {
-            return new CommunityResult(new int[0]);
+            if (nNodes == 0) {
+                throw new ClusterException(ClusterErrorCode.CLUSTER_GRAPH_EMPTY);
+            }
+
+            LargeIntArray sources = new LargeIntArray(graph.getEdges().size());
+            LargeIntArray targets = new LargeIntArray(graph.getEdges().size());
+            LargeDoubleArray weights = new LargeDoubleArray(graph.getEdges().size());
+
+            int cursor = 0;
+            for (ProjectedEdge edge : graph.getEdges()) {
+                sources.set(cursor, edge.getFromIndex());
+                targets.set(cursor, edge.getToIndex());
+                weights.set(cursor, edge.getWeight());
+                cursor++;
+            }
+
+            LargeIntArray[] edgeList = new LargeIntArray[]{sources, targets};
+
+            Network network = new Network(
+                    nNodes,
+                    true,
+                    edgeList,
+                    weights,
+                    false,
+                    true
+            );
+
+            LeidenAlgorithm leiden = new LeidenAlgorithm();
+            leiden.setResolution(resolution);
+            leiden.setNIterations(iterations);
+
+            Clustering clustering = new Clustering(nNodes);
+            leiden.improveClustering(network, clustering);
+
+            return new CommunityResult(clustering.getClusters());
+        } catch (ClusterException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ClusterException(ClusterErrorCode.CLUSTER_LEIDEN_FAILED);
         }
-
-        LargeIntArray sources = new LargeIntArray(graph.getEdges().size());
-        LargeIntArray targets = new LargeIntArray(graph.getEdges().size());
-        LargeDoubleArray weights = new LargeDoubleArray(graph.getEdges().size());
-
-        int cursor = 0;
-        for (ProjectedEdge edge : graph.getEdges()) {
-            sources.set(cursor, edge.getFromIndex());
-            targets.set(cursor, edge.getToIndex());
-            weights.set(cursor, edge.getWeight());
-            cursor++;
-        }
-
-        LargeIntArray[] edgeList = new LargeIntArray[]{sources, targets};
-
-        Network network = new Network(
-                nNodes,  //노드 개수
-                true,     //node의 가중치를 edge들의 가중치의 총합으로 설정 / false면 모든 node의 가중치를 1로
-                edgeList,
-                weights, //각 edge의 가중치 목록을 의미. EdgeWeightPolicy로 계산한 가중치 값이 여기에 해당
-                false,    // edgeList가 이미 정렬된 상태인지를 의미. 현재는 무방향이기 때문에 false
-                true      //무결성 검사
-        );
-
-        LeidenAlgorithm leiden = new LeidenAlgorithm();
-        leiden.setResolution(resolution);
-        leiden.setNIterations(iterations);
-
-        Clustering clustering = new Clustering(nNodes);
-        leiden.improveClustering(network, clustering);
-
-        return new CommunityResult(clustering.getClusters());
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityService.java
@@ -1,0 +1,57 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.CommunityResult;
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import lombok.RequiredArgsConstructor;
+import nl.cwts.networkanalysis.Clustering;
+import nl.cwts.networkanalysis.LeidenAlgorithm;
+import nl.cwts.networkanalysis.Network;
+import nl.cwts.util.LargeDoubleArray;
+import nl.cwts.util.LargeIntArray;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeidenCommunityService { //Leiden 실행 서비스
+
+    public CommunityResult detect(ProjectedGraph graph, double resolution, int iterations) {
+        int nNodes = graph.getNodes().size();
+
+        if (nNodes == 0) {
+            return new CommunityResult(new int[0]);
+        }
+
+        LargeIntArray sources = new LargeIntArray(graph.getEdges().size());
+        LargeIntArray targets = new LargeIntArray(graph.getEdges().size());
+        LargeDoubleArray weights = new LargeDoubleArray(graph.getEdges().size());
+
+        int cursor = 0;
+        for (ProjectedEdge edge : graph.getEdges()) {
+            sources.set(cursor, edge.getFromIndex());
+            targets.set(cursor, edge.getToIndex());
+            weights.set(cursor, edge.getWeight());
+            cursor++;
+        }
+
+        LargeIntArray[] edgeList = new LargeIntArray[]{sources, targets};
+
+        Network network = new Network(
+                nNodes,  //노드 개수
+                true,     //node의 가중치를 edge들의 가중치의 총합으로 설정 / false면 모든 node의 가중치를 1로
+                edgeList,
+                weights, //각 edge의 가중치 목록을 의미. EdgeWeightPolicy로 계산한 가중치 값이 여기에 해당
+                false,    // edgeList가 이미 정렬된 상태인지를 의미. 현재는 무방향이기 때문에 false
+                true      //무결성 검사
+        );
+
+        LeidenAlgorithm leiden = new LeidenAlgorithm();
+        leiden.setResolution(resolution);
+        leiden.setNIterations(iterations);
+
+        Clustering clustering = new Clustering(nNodes);
+        leiden.improveClustering(network, clustering);
+
+        return new CommunityResult(clustering.getClusters());
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/RankingService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/RankingService.java
@@ -1,129 +1,59 @@
 package com.example.ossdoc.domain.cluster.service;
 
-import com.example.ossdoc.domain.cluster.model.*;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
 import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
-import com.example.ossdoc.domain.cluster.model.ranking.*;
-
-
-import com.example.ossdoc.domain.cluster.support.ScoreNormalizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class RankingService {
 
-    private final ScoreNormalizer scoreNormalizer;
+    private final SymbolScoringService symbolScoringService;
+    private final SubsystemScoringService subsystemScoringService;
 
     public RankingResult rank(ProjectedGraph graph, List<Subsystem> subsystems, int topK) {
-        Map<String, String> subsystemBySymbolId = new HashMap<>();
+        Map<String, String> subsystemBySymbolId = buildSubsystemBySymbolId(subsystems);
+
+        List<SymbolRankingItem> allSymbolItems =
+                symbolScoringService.scoreSymbols(graph, subsystemBySymbolId);
+
+        List<SymbolRankingItem> topRankedSymbols =
+                symbolScoringService.topRankedSymbols(allSymbolItems, topK);
+
+        List<Subsystem> enrichedSubsystems =
+                subsystemScoringService.enrichSubsystems(subsystems, allSymbolItems);
+
+        List<SubsystemRankingItem> subsystemRankings =
+                subsystemScoringService.rankSubsystems(enrichedSubsystems);
+
+        return new RankingResult(
+                topRankedSymbols,
+                subsystemRankings,
+                enrichedSubsystems
+        );
+    }
+
+    private Map<String, String> buildSubsystemBySymbolId(List<Subsystem> subsystems) {
+        Map<String, String> map = new HashMap<>();
         for (Subsystem subsystem : subsystems) {
             for (String member : subsystem.getMemberSymbolIds()) {
-                subsystemBySymbolId.put(member, subsystem.getSubsystemId());
+                map.put(member, subsystem.getSubsystemId());
             }
         }
-
-        Map<String, Double> degreeMap = new HashMap<>();
-        for (ProjectedNode node : graph.getNodes()) {
-            degreeMap.put(node.getSymbolId(), 0.0);
-        }
-
-        for (ProjectedEdge edge : graph.getEdges()) {
-            ProjectedNode from = graph.getNodes().get(edge.getFromIndex());
-            ProjectedNode to = graph.getNodes().get(edge.getToIndex());
-
-            degreeMap.merge(from.getSymbolId(), edge.getWeight(), Double::sum);
-            degreeMap.merge(to.getSymbolId(), edge.getWeight(), Double::sum);
-        }
-
-        double maxDegree = degreeMap.values().stream().mapToDouble(v -> v).max().orElse(1.0);
-
-        List<SymbolRankingItem> symbolItems = new ArrayList<>();
-        for (ProjectedNode node : graph.getNodes()) {
-            double structural = scoreNormalizer.normalize(degreeMap.get(node.getSymbolId()), maxDegree);
-            double bridge = 0.0; // 추후 subsystem 간 연결도 계산으로 확장
-            double api = node.isPublicApi() ? 1.0 : 0.0;
-            double evidence = 0.5; // 추후 evidence 테이블 기반 정교화
-            double centrality = structural;
-
-            double total = 0.35 * structural
-                    + 0.25 * bridge
-                    + 0.20 * api
-                    + 0.10 * evidence
-                    + 0.10 * centrality;
-
-            symbolItems.add(SymbolRankingItem.builder()
-                    .symbolId(node.getSymbolId())
-                    .qualifiedName(node.getQualifiedName())
-                    .subsystemId(subsystemBySymbolId.get(node.getSymbolId()))
-                    .score(total)
-                    .structuralScore(structural)
-                    .bridgeScore(bridge)
-                    .apiScore(api)
-                    .evidenceScore(evidence)
-                    .subsystemCentralityScore(centrality)
-                    .build());
-        }
-
-        symbolItems = symbolItems.stream()
-                .sorted(Comparator.comparingDouble(SymbolRankingItem::getScore).reversed())
-                .limit(topK)
-                .collect(Collectors.toList());
-
-        for (int i = 0; i < symbolItems.size(); i++) {
-            SymbolRankingItem item = symbolItems.get(i);
-            symbolItems.set(i, SymbolRankingItem.builder()
-                    .rank(i + 1)
-                    .symbolId(item.getSymbolId())
-                    .qualifiedName(item.getQualifiedName())
-                    .subsystemId(item.getSubsystemId())
-                    .score(item.getScore())
-                    .structuralScore(item.getStructuralScore())
-                    .bridgeScore(item.getBridgeScore())
-                    .apiScore(item.getApiScore())
-                    .evidenceScore(item.getEvidenceScore())
-                    .subsystemCentralityScore(item.getSubsystemCentralityScore())
-                    .build());
-        }
-
-        Map<String, Double> subsystemScoreMap = new HashMap<>();
-        for (Subsystem subsystem : subsystems) {
-            double score = symbolItems.stream()
-                    .filter(item -> subsystem.getSubsystemId().equals(item.getSubsystemId()))
-                    .mapToDouble(SymbolRankingItem::getScore)
-                    .sum();
-            subsystemScoreMap.put(subsystem.getSubsystemId(), score);
-        }
-
-        List<SubsystemRankingItem> subsystemItems = subsystems.stream()
-                .map(ss -> new SubsystemRankingItem(
-                        0,
-                        ss.getSubsystemId(),
-                        ss.getName(),
-                        subsystemScoreMap.getOrDefault(ss.getSubsystemId(), 0.0)
-                ))
-                .sorted(Comparator.comparingDouble(SubsystemRankingItem::getScore).reversed())
-                .collect(Collectors.toList());
-
-        List<SubsystemRankingItem> rankedSubsystemItems = new ArrayList<>();
-        for (int i = 0; i < subsystemItems.size(); i++) {
-            SubsystemRankingItem item = subsystemItems.get(i);
-            rankedSubsystemItems.add(new SubsystemRankingItem(
-                    i + 1,
-                    item.getSubsystemId(),
-                    item.getName(),
-                    item.getScore()
-            ));
-        }
-
-        return new RankingResult(symbolItems, rankedSubsystemItems);
+        return map;
     }
 
     public record RankingResult(
             List<SymbolRankingItem> symbolRankings,
-            List<SubsystemRankingItem> subsystemRankings
-    ) {}
+            List<SubsystemRankingItem> subsystemRankings,
+            List<Subsystem> enrichedSubsystems
+    ) {
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/RankingService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/RankingService.java
@@ -1,0 +1,129 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.*;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.cluster.model.ranking.*;
+
+
+import com.example.ossdoc.domain.cluster.support.ScoreNormalizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final ScoreNormalizer scoreNormalizer;
+
+    public RankingResult rank(ProjectedGraph graph, List<Subsystem> subsystems, int topK) {
+        Map<String, String> subsystemBySymbolId = new HashMap<>();
+        for (Subsystem subsystem : subsystems) {
+            for (String member : subsystem.getMemberSymbolIds()) {
+                subsystemBySymbolId.put(member, subsystem.getSubsystemId());
+            }
+        }
+
+        Map<String, Double> degreeMap = new HashMap<>();
+        for (ProjectedNode node : graph.getNodes()) {
+            degreeMap.put(node.getSymbolId(), 0.0);
+        }
+
+        for (ProjectedEdge edge : graph.getEdges()) {
+            ProjectedNode from = graph.getNodes().get(edge.getFromIndex());
+            ProjectedNode to = graph.getNodes().get(edge.getToIndex());
+
+            degreeMap.merge(from.getSymbolId(), edge.getWeight(), Double::sum);
+            degreeMap.merge(to.getSymbolId(), edge.getWeight(), Double::sum);
+        }
+
+        double maxDegree = degreeMap.values().stream().mapToDouble(v -> v).max().orElse(1.0);
+
+        List<SymbolRankingItem> symbolItems = new ArrayList<>();
+        for (ProjectedNode node : graph.getNodes()) {
+            double structural = scoreNormalizer.normalize(degreeMap.get(node.getSymbolId()), maxDegree);
+            double bridge = 0.0; // 추후 subsystem 간 연결도 계산으로 확장
+            double api = node.isPublicApi() ? 1.0 : 0.0;
+            double evidence = 0.5; // 추후 evidence 테이블 기반 정교화
+            double centrality = structural;
+
+            double total = 0.35 * structural
+                    + 0.25 * bridge
+                    + 0.20 * api
+                    + 0.10 * evidence
+                    + 0.10 * centrality;
+
+            symbolItems.add(SymbolRankingItem.builder()
+                    .symbolId(node.getSymbolId())
+                    .qualifiedName(node.getQualifiedName())
+                    .subsystemId(subsystemBySymbolId.get(node.getSymbolId()))
+                    .score(total)
+                    .structuralScore(structural)
+                    .bridgeScore(bridge)
+                    .apiScore(api)
+                    .evidenceScore(evidence)
+                    .subsystemCentralityScore(centrality)
+                    .build());
+        }
+
+        symbolItems = symbolItems.stream()
+                .sorted(Comparator.comparingDouble(SymbolRankingItem::getScore).reversed())
+                .limit(topK)
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < symbolItems.size(); i++) {
+            SymbolRankingItem item = symbolItems.get(i);
+            symbolItems.set(i, SymbolRankingItem.builder()
+                    .rank(i + 1)
+                    .symbolId(item.getSymbolId())
+                    .qualifiedName(item.getQualifiedName())
+                    .subsystemId(item.getSubsystemId())
+                    .score(item.getScore())
+                    .structuralScore(item.getStructuralScore())
+                    .bridgeScore(item.getBridgeScore())
+                    .apiScore(item.getApiScore())
+                    .evidenceScore(item.getEvidenceScore())
+                    .subsystemCentralityScore(item.getSubsystemCentralityScore())
+                    .build());
+        }
+
+        Map<String, Double> subsystemScoreMap = new HashMap<>();
+        for (Subsystem subsystem : subsystems) {
+            double score = symbolItems.stream()
+                    .filter(item -> subsystem.getSubsystemId().equals(item.getSubsystemId()))
+                    .mapToDouble(SymbolRankingItem::getScore)
+                    .sum();
+            subsystemScoreMap.put(subsystem.getSubsystemId(), score);
+        }
+
+        List<SubsystemRankingItem> subsystemItems = subsystems.stream()
+                .map(ss -> new SubsystemRankingItem(
+                        0,
+                        ss.getSubsystemId(),
+                        ss.getName(),
+                        subsystemScoreMap.getOrDefault(ss.getSubsystemId(), 0.0)
+                ))
+                .sorted(Comparator.comparingDouble(SubsystemRankingItem::getScore).reversed())
+                .collect(Collectors.toList());
+
+        List<SubsystemRankingItem> rankedSubsystemItems = new ArrayList<>();
+        for (int i = 0; i < subsystemItems.size(); i++) {
+            SubsystemRankingItem item = subsystemItems.get(i);
+            rankedSubsystemItems.add(new SubsystemRankingItem(
+                    i + 1,
+                    item.getSubsystemId(),
+                    item.getName(),
+                    item.getScore()
+            ));
+        }
+
+        return new RankingResult(symbolItems, rankedSubsystemItems);
+    }
+
+    public record RankingResult(
+            List<SymbolRankingItem> symbolRankings,
+            List<SubsystemRankingItem> subsystemRankings
+    ) {}
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/SubsystemAssembler.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/SubsystemAssembler.java
@@ -1,0 +1,68 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.cluster.support.PackageTokenExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class SubsystemAssembler {
+
+    private final PackageTokenExtractor packageTokenExtractor;
+
+    public List<Subsystem> assemble(ProjectedGraph graph, int[] clusters, int minClusterSize) {
+        Map<Integer, List<ProjectedNode>> grouped = new HashMap<>();
+
+        for (int i = 0; i < clusters.length; i++) {
+            grouped.computeIfAbsent(clusters[i], k -> new ArrayList<>())
+                    .add(graph.getNodes().get(i));
+        }
+
+        //너무 작은 cluster는 일단 버리고, 추후 흡수 로직을 넣을 수 있음
+        List<Map.Entry<Integer, List<ProjectedNode>>> filtered = grouped.entrySet().stream()
+                .filter(e -> e.getValue().size() >= minClusterSize)
+                .toList();
+
+        List<Subsystem> subsystems = new ArrayList<>();
+        int seq = 1;
+
+        for (Map.Entry<Integer, List<ProjectedNode>> entry : filtered) {
+            List<ProjectedNode> members = entry.getValue();
+
+            List<String> symbolIds = members.stream()
+                    .map(ProjectedNode::getSymbolId)
+                    .toList();
+
+            List<String> entrySymbols = members.stream()
+                    .filter(ProjectedNode::isPublicApi)
+                    .map(ProjectedNode::getSymbolId)
+                    .toList();
+
+            List<String> packageRoots = members.stream()
+                    .map(ProjectedNode::getPackageName)
+                    .filter(pkg -> pkg != null && !pkg.isBlank())
+                    .distinct()
+                    .sorted()
+                    .toList();
+
+            String label = packageTokenExtractor.labelOf(members);
+
+            subsystems.add(Subsystem.builder()
+                    .subsystemId(String.format("ss_%03d", seq++))
+                    .name(label)
+                    .score(0.0) //RankingService에서 채움
+                    .memberSymbolIds(symbolIds)
+                    .entrySymbolIds(entrySymbols)
+                    .coreSymbolIds(List.of())
+                    .packageRoots(packageRoots)
+                    .build());
+        }
+
+        return subsystems;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/SubsystemScoringService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/SubsystemScoringService.java
@@ -1,0 +1,63 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class SubsystemScoringService {
+    /* 역할
+    * - subsystem별 멤버 symbol 점수 묶기
+    * - subsystem score 계산
+    * - core symbol 추출
+    * - subsystem ranking 생성
+    * */
+    public List<Subsystem> enrichSubsystems(List<Subsystem> subsystems, List<SymbolRankingItem> allSymbolItems) {
+        Map<String, List<SymbolRankingItem>> symbolsBySubsystem = allSymbolItems.stream()
+                .collect(Collectors.groupingBy(SymbolRankingItem::getSubsystemId));
+
+        List<Subsystem> enriched = new ArrayList<>();
+
+        for (Subsystem subsystem : subsystems) {
+            List<SymbolRankingItem> members = symbolsBySubsystem.getOrDefault(subsystem.getSubsystemId(), List.of());
+
+            double subsystemScore = members.stream()
+                    .mapToDouble(SymbolRankingItem::getScore)
+                    .sum();
+
+            List<String> coreSymbolIds = members.stream()
+                    .sorted(Comparator.comparingDouble(SymbolRankingItem::getScore).reversed())
+                    .limit(2)
+                    .map(SymbolRankingItem::getSymbolId)
+                    .toList();
+
+            enriched.add(subsystem.toBuilder()
+                    .score(subsystemScore)
+                    .coreSymbolIds(coreSymbolIds)
+                    .build());
+        }
+
+        enriched.sort(Comparator.comparingDouble(Subsystem::getScore).reversed());
+        return enriched;
+    }
+
+    public List<SubsystemRankingItem> rankSubsystems(List<Subsystem> enrichedSubsystems) {
+        List<SubsystemRankingItem> rankings = new ArrayList<>();
+
+        for (int i = 0; i < enrichedSubsystems.size(); i++) {
+            Subsystem ss = enrichedSubsystems.get(i);
+            rankings.add(new SubsystemRankingItem(
+                    i + 1,
+                    ss.getSubsystemId(),
+                    ss.getName(),
+                    ss.getScore()
+            ));
+        }
+
+        return rankings;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/SymbolScoringService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/SymbolScoringService.java
@@ -1,0 +1,135 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import com.example.ossdoc.domain.cluster.support.ScoreNormalizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SymbolScoringService {
+    /* 역할
+    * - degree map 계산
+    * - bridge map 계산
+    * - symbol별 점수 계산
+    * - 전체 symbol ranking item 리스트 반환
+    *  */
+
+    private final ScoreNormalizer scoreNormalizer;
+
+    public List<SymbolRankingItem> scoreSymbols(ProjectedGraph graph, Map<String, String> subsystemBySymbolId) {
+        Map<String, Double> degreeMap = buildDegreeMap(graph);
+        Map<String, Double> bridgeMap = buildBridgeMap(graph, subsystemBySymbolId);
+
+        double maxDegree = degreeMap.values().stream().mapToDouble(v -> v).max().orElse(1.0);
+        double maxBridge = bridgeMap.values().stream().mapToDouble(v -> v).max().orElse(1.0);
+
+        List<SymbolRankingItem> items = new ArrayList<>();
+
+        for (ProjectedNode node : graph.getNodes()) {
+            double structural = scoreNormalizer.normalize(
+                    degreeMap.getOrDefault(node.getSymbolId(), 0.0),
+                    maxDegree
+            );
+            double bridge = scoreNormalizer.normalize(
+                    bridgeMap.getOrDefault(node.getSymbolId(), 0.0),
+                    maxBridge
+            );
+            double api = node.isPublicApi() ? 1.0 : 0.0;
+            double evidence = 0.5;
+            double subsystemCentrality = structural;
+
+            double total = 0.35 * structural
+                    + 0.25 * bridge
+                    + 0.20 * api
+                    + 0.10 * evidence
+                    + 0.10 * subsystemCentrality;
+
+            items.add(SymbolRankingItem.builder()
+                    .symbolId(node.getSymbolId())
+                    .qualifiedName(node.getQualifiedName())
+                    .subsystemId(subsystemBySymbolId.get(node.getSymbolId()))
+                    .score(total)
+                    .structuralScore(structural)
+                    .bridgeScore(bridge)
+                    .apiScore(api)
+                    .evidenceScore(evidence)
+                    .subsystemCentralityScore(subsystemCentrality)
+                    .build());
+        }
+
+        return items;
+    }
+
+    public List<SymbolRankingItem> topRankedSymbols(List<SymbolRankingItem> allItems, int topK) {
+        List<SymbolRankingItem> sorted = allItems.stream()
+                .sorted(Comparator.comparingDouble(SymbolRankingItem::getScore).reversed())
+                .limit(topK)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        List<SymbolRankingItem> ranked = new ArrayList<>();
+        for (int i = 0; i < sorted.size(); i++) {
+            SymbolRankingItem item = sorted.get(i);
+            ranked.add(SymbolRankingItem.builder()
+                    .rank(i + 1)
+                    .symbolId(item.getSymbolId())
+                    .qualifiedName(item.getQualifiedName())
+                    .subsystemId(item.getSubsystemId())
+                    .score(item.getScore())
+                    .structuralScore(item.getStructuralScore())
+                    .bridgeScore(item.getBridgeScore())
+                    .apiScore(item.getApiScore())
+                    .evidenceScore(item.getEvidenceScore())
+                    .subsystemCentralityScore(item.getSubsystemCentralityScore())
+                    .build());
+        }
+        return ranked;
+    }
+
+    private Map<String, Double> buildDegreeMap(ProjectedGraph graph) {
+        Map<String, Double> degreeMap = new HashMap<>();
+
+        for (ProjectedNode node : graph.getNodes()) {
+            degreeMap.put(node.getSymbolId(), 0.0);
+        }
+
+        for (ProjectedEdge edge : graph.getEdges()) {
+            ProjectedNode from = graph.getNodes().get(edge.getFromIndex());
+            ProjectedNode to = graph.getNodes().get(edge.getToIndex());
+
+            degreeMap.merge(from.getSymbolId(), edge.getWeight(), Double::sum);
+            degreeMap.merge(to.getSymbolId(), edge.getWeight(), Double::sum);
+        }
+
+        return degreeMap;
+    }
+
+    private Map<String, Double> buildBridgeMap(ProjectedGraph graph, Map<String, String> subsystemBySymbolId) {
+        Map<String, Double> bridgeMap = new HashMap<>();
+
+        for (ProjectedNode node : graph.getNodes()) {
+            bridgeMap.put(node.getSymbolId(), 0.0);
+        }
+
+        for (ProjectedEdge edge : graph.getEdges()) {
+            ProjectedNode from = graph.getNodes().get(edge.getFromIndex());
+            ProjectedNode to = graph.getNodes().get(edge.getToIndex());
+
+            String fromSubsystem = subsystemBySymbolId.get(from.getSymbolId());
+            String toSubsystem = subsystemBySymbolId.get(to.getSymbolId());
+
+            if (fromSubsystem != null && toSubsystem != null && !fromSubsystem.equals(toSubsystem)) {
+                bridgeMap.merge(from.getSymbolId(), edge.getWeight(), Double::sum);
+                bridgeMap.merge(to.getSymbolId(), edge.getWeight(), Double::sum);
+            }
+        }
+
+        return bridgeMap;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/support/EdgeWeightPolicy.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/support/EdgeWeightPolicy.java
@@ -1,0 +1,38 @@
+package com.example.ossdoc.domain.cluster.support;
+
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.enums.EdgeType;
+import com.example.ossdoc.domain.graphstore.enums.ResolutionStatus;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class EdgeWeightPolicy {
+    private double baseWeight(EdgeType type){
+        return switch(type){
+            case EXTENDS, IMPLEMENTS -> 3.0;
+            case HAS_FIELD, PARAM, RETURNS, THROWS -> 2.0;
+            case CALLS, OVERRIDES, ACCESSES_FIELD -> 1.5;
+            case ANNOTATED_WITH -> 0.7;
+            case CONTAINS -> 0.5;
+        };
+    }
+    private double resolutionFactor(ResolutionStatus status){
+        return switch (status){
+            case RESOLVED -> 1.0;
+            case PARTIAL -> 0.7;
+            case UNRESOLVED -> 0.3;
+        };
+    }
+    private double confidence(BigDecimal confidence){
+        return confidence == null ? 1.0 : confidence.doubleValue();
+    }
+    public double weightOf(Edge edge){
+        double base = baseWeight(edge.getEdgeType());
+        double resolutionFactor = resolutionFactor(edge.getResolution());
+        double confidence = confidence(edge.getConfidence());
+        return base * resolutionFactor * confidence;
+    }
+
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/support/PackageTokenExtractor.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/support/PackageTokenExtractor.java
@@ -1,0 +1,37 @@
+package com.example.ossdoc.domain.cluster.support;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class PackageTokenExtractor {
+
+    public String labelOf(List<ProjectedNode> members) {
+        Map<String, Integer> counter = new HashMap<>();
+
+        for (ProjectedNode member : members) {
+            if (member.getPackageName() == null || member.getPackageName().isBlank()) continue;
+
+            String[] tokens = member.getPackageName().split("\\.");
+            for (String token : tokens) {
+                if (token.length() < 3) continue;
+                counter.merge(token.toLowerCase(), 1, Integer::sum);
+            }
+        }
+
+        List<String> top = counter.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(2)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+        if (top.isEmpty()) {
+            return "subsystem";
+        }
+
+        return String.join(" / ", top);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/support/PackageTokenExtractor.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/support/PackageTokenExtractor.java
@@ -8,30 +8,73 @@ import java.util.stream.Collectors;
 
 @Component
 public class PackageTokenExtractor {
+    private static final Set<String> STOPWORDS = Set.of(
+            "com", "org", "net", "io", "dev",
+            "example", "sample", "seed", "demo", "test"); //해당 토큰들은 이름 생성에서 제외
 
     public String labelOf(List<ProjectedNode> members) {
+        List<String> packageRoots = members.stream()
+                .map(ProjectedNode::getPackageName)
+                .filter(pkg -> pkg != null && !pkg.isBlank())
+                .distinct()
+                .sorted()
+                .toList();
+
+        String rootBased = labelFromPackageRoots(packageRoots);
+        if (rootBased != null) {
+            return rootBased;
+        }
+
         Map<String, Integer> counter = new HashMap<>();
-
         for (ProjectedNode member : members) {
-            if (member.getPackageName() == null || member.getPackageName().isBlank()) continue;
+            String packageName = member.getPackageName();
+            if (packageName == null || packageName.isBlank()) continue;
 
-            String[] tokens = member.getPackageName().split("\\.");
-            for (String token : tokens) {
-                if (token.length() < 3) continue;
-                counter.merge(token.toLowerCase(), 1, Integer::sum);
+            for (String token : packageName.split("\\.")) {
+                String normalized = token.toLowerCase(Locale.ROOT);
+                if (normalized.length() < 3) continue;
+                if (STOPWORDS.contains(normalized)) continue;
+                counter.merge(normalized, 1, Integer::sum);
             }
         }
 
         List<String> top = counter.entrySet().stream()
-                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .sorted((a, b) -> {
+                    int byCount = Integer.compare(b.getValue(), a.getValue());
+                    if(byCount != 0) return byCount;
+                    return a.getKey().compareTo(b.getKey());
+                })
                 .limit(2)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
 
-        if (top.isEmpty()) {
-            return "subsystem";
+        return top.isEmpty()? "subsystem" : String.join("/", top);
+    }
+
+    private String labelFromPackageRoots(List<String> packageRoots) {
+        if (packageRoots.isEmpty()) return null;
+
+        String[] first = packageRoots.get(0).split("\\.");
+        int prefixLen = first.length;
+
+        for (int i = 1; i < packageRoots.size(); i++) {
+            String[] current = packageRoots.get(i).split("\\.");
+            prefixLen = Math.min(prefixLen, current.length);
+            for (int j = 0; j < prefixLen; j++) {
+                if (!Objects.equals(first[j], current[j])) {
+                    prefixLen = j;
+                    break;
+                }
+            }
         }
+        if (prefixLen == 0) return null;
 
-        return String.join(" / ", top);
+        for (int i = prefixLen - 1; i >= 0; i--) {
+            String token = first[i].toLowerCase(Locale.ROOT);
+            if (!STOPWORDS.contains(token) && token.length() >= 3) {
+                return token;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/support/ScoreNormalizer.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/support/ScoreNormalizer.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.cluster.support;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScoreNormalizer {
+
+    public double normalize(double value, double max) {
+        if (max <= 0.0) return 0.0;
+        return value / max;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/cluster/support/SubsystemAssembler.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/support/SubsystemAssembler.java
@@ -1,15 +1,14 @@
-package com.example.ossdoc.domain.cluster.service;
+package com.example.ossdoc.domain.cluster.support;
 
 import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
 import com.example.ossdoc.domain.cluster.model.ProjectedNode;
 import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
-import com.example.ossdoc.domain.cluster.support.PackageTokenExtractor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.util.*;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class SubsystemAssembler {
 

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
@@ -21,4 +21,6 @@ public interface EdgeRepository extends JpaRepository<Edge, Long> {
             String fromSymbolId,
             EdgeType edgeType
     );
+
+    List<Edge> findAllByRun_RunId(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
@@ -1,11 +1,16 @@
 package com.example.ossdoc.domain.graphstore.repository;
 
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SymbolRepository extends JpaRepository<SymbolEntity, String> {
 
     Optional<SymbolEntity> findByRun_RunIdAndQualifiedName(String runId, String qualifiedName);
+
+    //추가 : 특정 run에 속한 symbol들 중에서, 특정 종류(symbolKind)만 전부 조회
+    List<SymbolEntity> findAllByRun_RunIdAndSymbolKind(String runId, SymbolKind symbolkind);
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 
 public interface SymbolRepository extends JpaRepository<SymbolEntity, String> {
 
-    Optional<SymbolEntity> findByRun_RunIdAndQualifiedName(String runId, String qualifiedName);
+    Optional<SymbolEntity> findByRunIdAndQualifiedName(String runId, String qualifiedName);
 
     //추가 : 특정 run에 속한 symbol들 중에서, 특정 종류(symbolKind)만 전부 조회
-    List<SymbolEntity> findAllByRun_RunIdAndSymbolKind(String runId, SymbolKind symbolkind);
+    List<SymbolEntity> findAllByRunIdAndSymbolKind(String runId, SymbolKind symbolkind);
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/service/GraphStoreIngestService.java
@@ -176,7 +176,7 @@ public class GraphStoreIngestService {
                 continue;
             }
 
-            SymbolEntity existing = symbolRepository.findByRun_RunIdAndQualifiedName(run.getRunId(), dto.symbol())
+            SymbolEntity existing = symbolRepository.findByRunIdAndQualifiedName(run.getRunId(), dto.symbol())
                     .orElse(null);
 
             SymbolEntity symbol;

--- a/src/main/java/com/example/ossdoc/domain/publicapi/repository/PublicApiEntryRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/repository/PublicApiEntryRepository.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.publicapi.repository;
+
+import com.example.ossdoc.domain.publicapi.entity.PublicApiEntry;
+import com.example.ossdoc.domain.publicapi.entity.PublicApiEntryId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+/* graphstore의 symbol 중에서, 어떤게 공개 API인지 알려주는 데이터 공급 역할
+*  1. ProjectedNode.publicApi 설정,
+*  2. subsystem entry symbol 판단,
+*  3. ranking의 apiScore 반영
+*  4. subsystem 이름/설명 품질 향상
+*  즉, 해당 run에서 어떤 symbol이 공개 API인지 조회해서, cluster/ranking 후처리에 활용하게 해주는 repository
+*  */
+public interface PublicApiEntryRepository extends JpaRepository<PublicApiEntry, PublicApiEntryId> {
+    List<PublicApiEntry> findAllByRun_RunId(String runId);
+}

--- a/src/main/java/com/example/ossdoc/domain/publicapi/repository/PublicApiEntryRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/repository/PublicApiEntryRepository.java
@@ -13,5 +13,5 @@ import java.util.List;
 *  즉, 해당 run에서 어떤 symbol이 공개 API인지 조회해서, cluster/ranking 후처리에 활용하게 해주는 repository
 *  */
 public interface PublicApiEntryRepository extends JpaRepository<PublicApiEntry, PublicApiEntryId> {
-    List<PublicApiEntry> findAllByRun_RunId(String runId);
+    List<PublicApiEntry> findAllByRunId(String runId);
 }

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/ClusterBuildServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/ClusterBuildServiceTest.java
@@ -1,0 +1,144 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
+import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
+import com.example.ossdoc.domain.cluster.model.CommunityResult;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterBuildServiceTest {
+
+    @Mock
+    private RepoRunRepository repoRunRepository;
+
+    @Mock
+    private GraphProjectionService graphProjectionService;
+
+    @Mock
+    private LeidenCommunityService leidenCommunityService;
+
+    @Mock
+    private SubsystemAssembler subsystemAssembler;
+
+    @Mock
+    private RankingService rankingService;
+
+    @Mock
+    private ClusterArtifactPublisher clusterArtifactPublisher;
+
+    @InjectMocks
+    private ClusterBuildService clusterBuildService;
+
+    @Test
+    @DisplayName("ClusterBuildService는 graphstore 기반 subsystem/ranking 산출물을 생성하고 발행한다")
+    void build_shouldGenerateAndPublishArtifacts() {
+        // given
+        ClusterBuildRequest request = mock(ClusterBuildRequest.class);
+        when(request.getRunId()).thenReturn("run-1");
+        when(request.getResolution()).thenReturn(0.012);
+        when(request.getIterations()).thenReturn(10);
+        when(request.getMinClusterSize()).thenReturn(3);
+        when(request.getTopK()).thenReturn(20);
+
+        RepoRun run = mock(RepoRun.class);
+        when(run.getRunId()).thenReturn("run-1");
+        when(repoRunRepository.findById("run-1")).thenReturn(Optional.of(run));
+
+        ProjectedGraph projectedGraph = mock(ProjectedGraph.class);
+        when(graphProjectionService.loadProjectedGraph("run-1")).thenReturn(projectedGraph);
+
+        CommunityResult communityResult = new CommunityResult(new int[]{0, 0, 1, 1});
+        when(leidenCommunityService.detect(projectedGraph, 0.012, 10))
+                .thenReturn(communityResult);
+
+        List<Subsystem> subsystems = List.of(
+                Subsystem.builder()
+                        .subsystemId("ss_001")
+                        .name("auth / token")
+                        .score(0.0)
+                        .memberSymbolIds(List.of("A1", "A2"))
+                        .entrySymbolIds(List.of("A1"))
+                        .coreSymbolIds(List.of("A2"))
+                        .packageRoots(List.of("com.example.auth"))
+                        .build(),
+                Subsystem.builder()
+                        .subsystemId("ss_002")
+                        .name("user / account")
+                        .score(0.0)
+                        .memberSymbolIds(List.of("B1", "B2"))
+                        .entrySymbolIds(List.of("B1"))
+                        .coreSymbolIds(List.of("B2"))
+                        .packageRoots(List.of("com.example.user"))
+                        .build()
+        );
+
+        when(subsystemAssembler.assemble(projectedGraph, communityResult.getClusters(), 3))
+                .thenReturn(subsystems);
+
+        RankingService.RankingResult rankingResult = new RankingService.RankingResult(
+                List.of(), //symbolRankings
+                List.of(), //subsystemRankings
+                subsystems //enrichedSubsystems
+        );
+        when(rankingService.rank(projectedGraph, subsystems, 20))
+                .thenReturn(rankingResult);
+
+        Artifact rankingsArtifact = mock(Artifact.class);
+        when(rankingsArtifact.getArtifactId()).thenReturn(101L);
+
+        Artifact subsystemsArtifact = mock(Artifact.class);
+        when(subsystemsArtifact.getArtifactId()).thenReturn(202L);
+
+        when(clusterArtifactPublisher.publishSubsystems(eq(run), any()))
+                .thenReturn(subsystemsArtifact);
+        when(clusterArtifactPublisher.publishRankings(eq(run), any()))
+                .thenReturn(rankingsArtifact);
+
+        // when
+        ClusterBuildResponse response = clusterBuildService.build(request);
+
+        // then
+        assertThat(response.getRunId()).isEqualTo("run-1");
+        assertThat(response.getSubsystemCount()).isEqualTo(2);
+        assertThat(response.getRankedSymbolCount()).isEqualTo(0);
+        assertThat(response.getRankingsArtifactId()).isEqualTo(101L);
+        assertThat(response.getSubsystemsArtifactId()).isEqualTo(202L);
+
+        verify(repoRunRepository).findById("run-1");
+        verify(graphProjectionService).loadProjectedGraph("run-1");
+        verify(leidenCommunityService).detect(projectedGraph, 0.012, 10);
+        verify(subsystemAssembler).assemble(projectedGraph, communityResult.getClusters(), 3);
+        verify(rankingService).rank(projectedGraph, subsystems, 20);
+        verify(clusterArtifactPublisher).publishSubsystems(eq(run), any());
+        verify(clusterArtifactPublisher).publishRankings(eq(run), any());
+
+        ArgumentCaptor<SubsystemsJsonDto> subsystemsDtoCaptor =
+                ArgumentCaptor.forClass(SubsystemsJsonDto.class);
+
+        verify(clusterArtifactPublisher).publishSubsystems(eq(run), subsystemsDtoCaptor.capture());
+
+        SubsystemsJsonDto captured = subsystemsDtoCaptor.getValue();
+        assertThat(captured).isNotNull();
+        assertThat(captured.getSubsystems()).hasSize(2);
+        assertThat(captured.getSubsystems().get(0).getSubsystemId()).isEqualTo("ss_001");
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/ClusterBuildServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/ClusterBuildServiceTest.java
@@ -1,12 +1,13 @@
 package com.example.ossdoc.domain.cluster.service;
 
-import com.example.ossdoc.domain.cluster.dto.output.SubsystemsJsonDto;
+import com.example.ossdoc.domain.cluster.artifact.output.SubsystemsJsonDto;
 import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
 import com.example.ossdoc.domain.cluster.dto.response.ClusterBuildResponse;
 import com.example.ossdoc.domain.cluster.model.CommunityResult;
 import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
 import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import com.example.ossdoc.domain.cluster.support.SubsystemAssembler;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/GraphProjectionServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/GraphProjectionServiceTest.java
@@ -1,0 +1,115 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import com.example.ossdoc.domain.cluster.support.EdgeWeightPolicy;
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.EdgeType;
+import com.example.ossdoc.domain.graphstore.enums.ResolutionStatus;
+import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
+import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolRepository;
+import com.example.ossdoc.domain.publicapi.entity.PublicApiEntry;
+import com.example.ossdoc.domain.publicapi.repository.PublicApiEntryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GraphProjectionServiceTest {
+
+    @Test
+    @DisplayName("Projects TYPE symbols and merges bidirectional CALLS edges into one undirected weighted edge")
+    void loadProjectedGraph_shouldProjectTypeGraphCorrectly() {
+        // given
+        SymbolRepository symbolRepository = mock(SymbolRepository.class);
+        EdgeRepository edgeRepository = mock(EdgeRepository.class);
+        PublicApiEntryRepository publicApiEntryRepository = mock(PublicApiEntryRepository.class);
+        EdgeWeightPolicy edgeWeightPolicy = new EdgeWeightPolicy();
+
+        GraphProjectionService graphProjectionService = new GraphProjectionService(
+                symbolRepository,
+                edgeRepository,
+                publicApiEntryRepository,
+                edgeWeightPolicy
+        );
+
+        SymbolEntity authController = mock(SymbolEntity.class);
+        when(authController.getSymbolId()).thenReturn("sym-auth-controller");
+        when(authController.getQualifiedName()).thenReturn("com.example.auth.AuthController");
+        when(authController.getSimpleName()).thenReturn("AuthController");
+        when(authController.getModule()).thenReturn(null);
+
+        SymbolEntity authService = mock(SymbolEntity.class);
+        when(authService.getSymbolId()).thenReturn("sym-auth-service");
+        when(authService.getQualifiedName()).thenReturn("com.example.auth.AuthService");
+        when(authService.getSimpleName()).thenReturn("AuthService");
+        when(authService.getModule()).thenReturn(null);
+
+        // TYPE 조회 결과에는 이 둘만 들어감
+        when(symbolRepository.findAllByRun_RunIdAndSymbolKind("run-1", SymbolKind.TYPE))
+                .thenReturn(List.of(authController, authService));
+
+        PublicApiEntry publicApiEntry = mock(PublicApiEntry.class);
+        when(publicApiEntry.getSymbol()).thenReturn(authController);
+
+        when(publicApiEntryRepository.findAllByRun_RunId("run-1"))
+                .thenReturn(List.of(publicApiEntry));
+
+        Edge edge1 = mock(Edge.class);
+        when(edge1.getFromSymbol()).thenReturn(authController);
+        when(edge1.getToSymbol()).thenReturn(authService);
+        when(edge1.getEdgeType()).thenReturn(EdgeType.CALLS);
+        when(edge1.getResolution()).thenReturn(ResolutionStatus.RESOLVED);
+        when(edge1.getConfidence()).thenReturn(new BigDecimal("1.0"));
+
+        Edge edge2 = mock(Edge.class);
+        when(edge2.getFromSymbol()).thenReturn(authService);
+        when(edge2.getToSymbol()).thenReturn(authController);
+        when(edge2.getEdgeType()).thenReturn(EdgeType.CALLS);
+        when(edge2.getResolution()).thenReturn(ResolutionStatus.RESOLVED);
+        when(edge2.getConfidence()).thenReturn(new BigDecimal("0.5"));
+
+        when(edgeRepository.findAllByRun_RunId("run-1"))
+                .thenReturn(List.of(edge1, edge2));
+
+        // when
+        ProjectedGraph projectedGraph = graphProjectionService.loadProjectedGraph("run-1");
+
+        // then
+        assertThat(projectedGraph.getNodes()).hasSize(2);
+        assertThat(projectedGraph.getNodeIndexMap())
+                .containsKeys("sym-auth-controller", "sym-auth-service");
+
+        ProjectedNode first = projectedGraph.getNodes().get(0);
+        ProjectedNode second = projectedGraph.getNodes().get(1);
+
+        assertThat(first.getQualifiedName()).isEqualTo("com.example.auth.AuthController");
+        assertThat(first.isPublicApi()).isTrue();
+
+        assertThat(second.getQualifiedName()).isEqualTo("com.example.auth.AuthService");
+        assertThat(second.isPublicApi()).isFalse();
+
+        // directed 2개가 하나의 undirected edge로 합쳐져야 함
+        assertThat(projectedGraph.getEdges()).hasSize(1);
+
+        ProjectedEdge mergedEdge = projectedGraph.getEdges().get(0);
+        assertThat(mergedEdge.getFromIndex()).isEqualTo(0);
+        assertThat(mergedEdge.getToIndex()).isEqualTo(1);
+
+        // CALLS = 1.5
+        // edge1 = 1.5 * 1.0 * 1.0 = 1.5
+        // edge2 = 1.5 * 1.0 * 0.5 = 0.75
+        // 합계 = 2.25
+        assertThat(mergedEdge.getWeight()).isEqualTo(2.25);
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/GraphProjectionServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/GraphProjectionServiceTest.java
@@ -56,13 +56,13 @@ class GraphProjectionServiceTest {
         when(authService.getModule()).thenReturn(null);
 
         // TYPE 조회 결과에는 이 둘만 들어감
-        when(symbolRepository.findAllByRun_RunIdAndSymbolKind("run-1", SymbolKind.TYPE))
+        when(symbolRepository.findAllByRunIdAndSymbolKind("run-1", SymbolKind.TYPE))
                 .thenReturn(List.of(authController, authService));
 
         PublicApiEntry publicApiEntry = mock(PublicApiEntry.class);
         when(publicApiEntry.getSymbol()).thenReturn(authController);
 
-        when(publicApiEntryRepository.findAllByRun_RunId("run-1"))
+        when(publicApiEntryRepository.findAllByRunId("run-1"))
                 .thenReturn(List.of(publicApiEntry));
 
         Edge edge1 = mock(Edge.class);

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/LeidenCommunityServiceTest.java
@@ -1,0 +1,123 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.CommunityResult;
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeidenCommunityServiceTest {
+
+    private final LeidenCommunityService leidenCommunityService = new LeidenCommunityService();
+
+    @Test
+    @DisplayName("강하게 연결된 두 그룹은 서로 다른 community로 분리된다")
+    void detect_shouldSplitTwoDenseGroups() {
+        // given
+        List<ProjectedNode> nodes = List.of(
+                ProjectedNode.builder()
+                        .symbolId("A1")
+                        .qualifiedName("com.example.auth.AuthController")
+                        .simpleName("AuthController")
+                        .packageName("com.example.auth")
+                        .moduleId("mod-auth")
+                        .publicApi(true)
+                        .build(),
+                ProjectedNode.builder()
+                        .symbolId("A2")
+                        .qualifiedName("com.example.auth.AuthService")
+                        .simpleName("AuthService")
+                        .packageName("com.example.auth")
+                        .moduleId("mod-auth")
+                        .publicApi(false)
+                        .build(),
+                ProjectedNode.builder()
+                        .symbolId("A3")
+                        .qualifiedName("com.example.auth.JwtProvider")
+                        .simpleName("JwtProvider")
+                        .packageName("com.example.auth")
+                        .moduleId("mod-auth")
+                        .publicApi(false)
+                        .build(),
+
+                ProjectedNode.builder()
+                        .symbolId("B1")
+                        .qualifiedName("com.example.user.UserController")
+                        .simpleName("UserController")
+                        .packageName("com.example.user")
+                        .moduleId("mod-user")
+                        .publicApi(true)
+                        .build(),
+                ProjectedNode.builder()
+                        .symbolId("B2")
+                        .qualifiedName("com.example.user.UserService")
+                        .simpleName("UserService")
+                        .packageName("com.example.user")
+                        .moduleId("mod-user")
+                        .publicApi(false)
+                        .build(),
+                ProjectedNode.builder()
+                        .symbolId("B3")
+                        .qualifiedName("com.example.user.UserRepository")
+                        .simpleName("UserRepository")
+                        .packageName("com.example.user")
+                        .moduleId("mod-user")
+                        .publicApi(false)
+                        .build()
+        );
+
+        List<ProjectedEdge> edges = List.of(
+                // auth 내부 강한 연결
+                new ProjectedEdge(0, 1, 5.0),
+                new ProjectedEdge(1, 2, 5.0),
+                new ProjectedEdge(0, 2, 4.0),
+
+                // user 내부 강한 연결
+                new ProjectedEdge(3, 4, 5.0),
+                new ProjectedEdge(4, 5, 5.0),
+                new ProjectedEdge(3, 5, 4.0),
+
+                // 그룹 간 약한 연결
+                new ProjectedEdge(1, 4, 0.2)
+        );
+
+        ProjectedGraph graph = ProjectedGraph.builder()
+                .runId("run-test")
+                .nodes(nodes)
+                .edges(edges)
+                .nodeIndexMap(Map.of(
+                        "A1", 0,
+                        "A2", 1,
+                        "A3", 2,
+                        "B1", 3,
+                        "B2", 4,
+                        "B3", 5
+                ))
+                .build();
+
+        // when
+        CommunityResult result = leidenCommunityService.detect(graph, 0.01, 10);
+
+        // then
+        int[] clusters = result.getClusters();
+
+        assertThat(clusters).hasSize(6);
+
+        // auth 3개는 같은 cluster
+        assertThat(clusters[0]).isEqualTo(clusters[1]);
+        assertThat(clusters[1]).isEqualTo(clusters[2]);
+
+        // user 3개는 같은 cluster
+        assertThat(clusters[3]).isEqualTo(clusters[4]);
+        assertThat(clusters[4]).isEqualTo(clusters[5]);
+
+        // auth 그룹과 user 그룹은 다른 cluster
+        assertThat(clusters[0]).isNotEqualTo(clusters[3]);
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/RankingServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/RankingServiceTest.java
@@ -1,0 +1,89 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class RankingServiceTest {
+
+    @Test
+    @DisplayName("RankingService는 symbol scoring과 subsystem scoring 결과를 조립한다")
+    void rank_shouldAssembleResults() {
+        // given
+        SymbolScoringService symbolScoringService = mock(SymbolScoringService.class);
+        SubsystemScoringService subsystemScoringService = mock(SubsystemScoringService.class);
+
+        RankingService rankingService = new RankingService(
+                symbolScoringService,
+                subsystemScoringService
+        );
+
+        ProjectedGraph graph = mock(ProjectedGraph.class);
+
+        List<Subsystem> subsystems = List.of(
+                Subsystem.builder()
+                        .subsystemId("ss_001")
+                        .name("auth")
+                        .score(0.0)
+                        .memberSymbolIds(List.of("a1", "a2"))
+                        .entrySymbolIds(List.of("a1"))
+                        .coreSymbolIds(List.of())
+                        .packageRoots(List.of("com.example.auth"))
+                        .build()
+        );
+
+        List<SymbolRankingItem> allItems = List.of(
+                SymbolRankingItem.builder().symbolId("a1").subsystemId("ss_001").score(0.9).build()
+        );
+
+        List<SymbolRankingItem> topItems = List.of(
+                SymbolRankingItem.builder().rank(1).symbolId("a1").subsystemId("ss_001").score(0.9).build()
+        );
+
+        List<Subsystem> enrichedSubsystems = List.of(
+                Subsystem.builder()
+                        .subsystemId("ss_001")
+                        .name("auth")
+                        .score(0.9)
+                        .memberSymbolIds(List.of("a1", "a2"))
+                        .entrySymbolIds(List.of("a1"))
+                        .coreSymbolIds(List.of("a1"))
+                        .packageRoots(List.of("com.example.auth"))
+                        .build()
+        );
+
+        List<SubsystemRankingItem> subsystemRankings = List.of(
+                new SubsystemRankingItem(1, "ss_001", "auth", 0.9)
+        );
+
+        when(symbolScoringService.scoreSymbols(any(), any())).thenReturn(allItems);
+        when(symbolScoringService.topRankedSymbols(allItems, 10)).thenReturn(topItems);
+        when(subsystemScoringService.enrichSubsystems(subsystems, allItems)).thenReturn(enrichedSubsystems);
+        when(subsystemScoringService.rankSubsystems(enrichedSubsystems)).thenReturn(subsystemRankings);
+
+        // when
+        RankingService.RankingResult result = rankingService.rank(graph, subsystems, 10);
+
+        // then
+        assertThat(result.symbolRankings()).hasSize(1);
+        assertThat(result.subsystemRankings()).hasSize(1);
+        assertThat(result.enrichedSubsystems()).hasSize(1);
+
+        assertThat(result.symbolRankings().get(0).getSymbolId()).isEqualTo("a1");
+        assertThat(result.subsystemRankings().get(0).getSubsystemId()).isEqualTo("ss_001");
+        assertThat(result.enrichedSubsystems().get(0).getCoreSymbolIds()).containsExactly("a1");
+
+        verify(symbolScoringService).scoreSymbols(any(), any());
+        verify(symbolScoringService).topRankedSymbols(allItems, 10);
+        verify(subsystemScoringService).enrichSubsystems(subsystems, allItems);
+        verify(subsystemScoringService).rankSubsystems(enrichedSubsystems);
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/SubsystemScoringServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/SubsystemScoringServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ranking.SubsystemRankingItem;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import com.example.ossdoc.domain.cluster.model.subsystem.Subsystem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubsystemScoringServiceTest {
+
+    private final SubsystemScoringService subsystemScoringService =
+            new SubsystemScoringService();
+
+    @Test
+    @DisplayName("subsystem score를 계산하고 상위 2개 symbol을 core로 채운다")
+    void enrichSubsystems_shouldFillScoreAndCoreSymbols() {
+        // given
+        List<Subsystem> subsystems = List.of(
+                Subsystem.builder()
+                        .subsystemId("ss_001")
+                        .name("auth")
+                        .score(0.0)
+                        .memberSymbolIds(List.of("a1", "a2", "a3"))
+                        .entrySymbolIds(List.of("a1"))
+                        .coreSymbolIds(List.of())
+                        .packageRoots(List.of("com.example.auth"))
+                        .build()
+        );
+
+        List<SymbolRankingItem> symbolItems = List.of(
+                SymbolRankingItem.builder().symbolId("a1").subsystemId("ss_001").score(0.9).build(),
+                SymbolRankingItem.builder().symbolId("a2").subsystemId("ss_001").score(0.7).build(),
+                SymbolRankingItem.builder().symbolId("a3").subsystemId("ss_001").score(0.3).build()
+        );
+
+        // when
+        List<Subsystem> enriched =
+                subsystemScoringService.enrichSubsystems(subsystems, symbolItems);
+
+        List<SubsystemRankingItem> rankings =
+                subsystemScoringService.rankSubsystems(enriched);
+
+        // then
+        assertThat(enriched).hasSize(1);
+        Subsystem ss = enriched.get(0);
+
+        assertThat(ss.getScore()).isEqualTo(1.9);
+        assertThat(ss.getCoreSymbolIds()).containsExactly("a1", "a2");
+
+        assertThat(rankings).hasSize(1);
+        assertThat(rankings.get(0).getSubsystemId()).isEqualTo("ss_001");
+        assertThat(rankings.get(0).getScore()).isEqualTo(1.9);
+    }
+}

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/SymbolScoringServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/SymbolScoringServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.ossdoc.domain.cluster.service;
+
+import com.example.ossdoc.domain.cluster.model.ProjectedEdge;
+import com.example.ossdoc.domain.cluster.model.ProjectedGraph;
+import com.example.ossdoc.domain.cluster.model.ProjectedNode;
+import com.example.ossdoc.domain.cluster.model.ranking.SymbolRankingItem;
+import com.example.ossdoc.domain.cluster.support.ScoreNormalizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SymbolScoringServiceTest {
+
+    private final SymbolScoringService symbolScoringService =
+            new SymbolScoringService(new ScoreNormalizer());
+
+    @Test
+    @DisplayName("public API controller가 non-public symbol보다 높은 점수를 가진다")
+    void scoreSymbols_shouldPrioritizePublicApiController() {
+        // given
+        ProjectedGraph graph = ProjectedGraph.builder()
+                .runId("run-test")
+                .nodes(List.of(
+                        ProjectedNode.builder()
+                                .symbolId("sym_controller")
+                                .qualifiedName("com.example.auth.AuthController")
+                                .simpleName("AuthController")
+                                .packageName("com.example.auth")
+                                .moduleId("m1")
+                                .publicApi(true)
+                                .build(),
+                        ProjectedNode.builder()
+                                .symbolId("sym_service")
+                                .qualifiedName("com.example.auth.AuthService")
+                                .simpleName("AuthService")
+                                .packageName("com.example.auth")
+                                .moduleId("m1")
+                                .publicApi(false)
+                                .build()
+                ))
+                .edges(List.of(
+                        new ProjectedEdge(0, 1, 1.0)
+                ))
+                .nodeIndexMap(Map.of(
+                        "sym_controller", 0,
+                        "sym_service", 1
+                ))
+                .build();
+
+        Map<String, String> subsystemBySymbolId = Map.of(
+                "sym_controller", "ss_001",
+                "sym_service", "ss_001"
+        );
+
+        // when
+        List<SymbolRankingItem> allItems =
+                symbolScoringService.scoreSymbols(graph, subsystemBySymbolId);
+
+        List<SymbolRankingItem> ranked =
+                symbolScoringService.topRankedSymbols(allItems, 10);
+
+        // then
+        assertThat(ranked).hasSize(2);
+        assertThat(ranked.get(0).getSymbolId()).isEqualTo("sym_controller");
+        assertThat(ranked.get(0).getApiScore()).isEqualTo(1.0);
+        assertThat(ranked.get(1).getSymbolId()).isEqualTo("sym_service");
+        assertThat(ranked.get(1).getApiScore()).isEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
## 작업 내용
graphstore를 입력으로 subsystem 군집화 및 중요도 ranking을 생성하는 cluster 분석 기능을 추가했습니다.

이번 PR에서는 graphstore의 symbol/edge 데이터를 Leiden 기반 분석 그래프로 투영한 뒤,
subsystem과 symbol ranking을 계산하고,
결과를 `subsystems.json`, `rankings.json` artifact로 저장할 수 있도록 구현했습니다.

## 주요 변경 사항
- `domain/cluster` 도메인 추가
  - `ClusterController`
  - `ClusterBuildService`
  - `GraphProjectionService`
  - `LeidenCommunityService`
  - `SubsystemAssembler`
  - `ClusterArtifactPublisher`
- graphstore 기반 무방향 가중 그래프 투영 로직 구현
- Leiden 알고리즘 기반 subsystem 군집화 구현
- symbol / subsystem ranking 계산 로직 구현
- cluster 결과 artifact 저장 지원
  - `RANKINGS_JSON`
  - `SUBSYSTEMS_JSON`
- subsystem 결과 품질 개선
  - subsystem naming 개선
  - core symbol 반영
  - subsystem score 반영
- ranking 계산 로직 책임 분리
  - `SymbolScoringService`
  - `SubsystemScoringService`

## 산출물
- `analysis/subsystems.json`
- `analysis/rankings.json`

## 테스트
다음 테스트를 추가 및 확인했습니다.
- `LeidenCommunityServiceTest`
- `GraphProjectionServiceTest`
- `ClusterBuildServiceTest`
- `SymbolScoringServiceTest`
- `SubsystemScoringServiceTest`
- `RankingServiceTest`

또한 Swagger 및 seed 데이터 기반으로 아래를 확인했습니다.
- auth / user subsystem 분리 정상 동작
- symbol ranking 생성 정상 동작
- `SUBSYSTEMS_JSON`, `RANKINGS_JSON` artifact 저장 정상 동작

## 참고 사항
- 현재 cluster 분석은 graphstore(`symbol`, `edge`)가 채워져 있는 run을 기준으로 동작합니다.
- `FACTS_JSON` 생성 및 graphstore ingest 이전 단계가 없는 경우에는 seed 데이터 또는 사전 적재된 graphstore 데이터가 필요합니다.