### PR TITLE
Feat: 클래스 다이어그램 산출물 조회 API 추가

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/controller/ArtifactController.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/controller/ArtifactController.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.domain.artifact.controller;
+
+import com.example.ossdoc.domain.artifact.dto.response.ArtifactJsonResponse;
+import com.example.ossdoc.domain.artifact.service.ArtifactQueryService;
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/artifacts")
+public class ArtifactController {
+
+    private final ArtifactQueryService artifactQueryService;
+
+    @GetMapping("/{artifactId}")
+    public ApiResponse getJsonArtifact(
+            @PathVariable Long artifactId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
+
+        ArtifactJsonResponse response = artifactQueryService.getJsonArtifact(
+                artifactId,
+                authenticatedUser.getUserId()
+        );
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/artifact/dto/response/ArtifactJsonResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/dto/response/ArtifactJsonResponse.java
@@ -1,0 +1,36 @@
+package com.example.ossdoc.domain.artifact.dto.response;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArtifactJsonResponse {
+
+    private Long artifactId;
+    private String runId;
+    private String kind;
+    private String schemaVersion;
+    private String contentType;
+    private String path;
+
+    /*
+     * content : 실제 class_diagram.json 본문입니다.
+     * 프론트는 이 content.nodes, content.edges를 사용해서 렌더링합니다.
+     */
+    private JsonNode content;
+
+    public static ArtifactJsonResponse from(Artifact artifact) {
+        return ArtifactJsonResponse.builder()
+                .artifactId(artifact.getArtifactId())
+                .runId(artifact.getRun().getRunId())
+                .kind(artifact.getKind().name())
+                .schemaVersion(artifact.getSchemaVersion())
+                .contentType(artifact.getContentType())
+                .path(artifact.getPath())
+                .content(artifact.getMeta())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/artifact/exception/ArtifactException.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/exception/ArtifactException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.artifact.exception;
+
+import com.example.ossdoc.domain.artifact.exception.code.ArtifactErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class ArtifactException extends GeneralException {
+
+    public ArtifactException(ArtifactErrorCode code) {
+        super(code);
+    }
+
+    public ArtifactException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/artifact/exception/code/ArtifactErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/exception/code/ArtifactErrorCode.java
@@ -1,0 +1,59 @@
+package com.example.ossdoc.domain.artifact.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtifactErrorCode implements BaseCode {
+
+    ARTIFACT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "ARTIFACT404_1",
+            "존재하지 않는 산출물입니다."
+    ),
+
+    ARTIFACT_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "ARTIFACT403_1",
+            "해당 산출물 접근 권한이 없습니다."
+    ),
+
+    ARTIFACT_NOT_JSON(
+            HttpStatus.BAD_REQUEST,
+            "ARTIFACT400_1",
+            "JSON 산출물이 아닙니다."
+    ),
+
+    ARTIFACT_READ_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "ARTIFACT500_1",
+            "산출물 조회에 실패했습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
@@ -1,0 +1,45 @@
+package com.example.ossdoc.domain.artifact.service;
+
+import com.example.ossdoc.domain.artifact.dto.response.ArtifactJsonResponse;
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.artifact.exception.ArtifactException;
+import com.example.ossdoc.domain.artifact.exception.code.ArtifactErrorCode;
+import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtifactQueryService {
+
+    private final ArtifactRepository artifactRepository;
+
+    public ArtifactJsonResponse getJsonArtifact(Long artifactId, Long userId) {
+        Artifact artifact = artifactRepository.findById(artifactId)
+                .orElseThrow(() -> new ArtifactException(ArtifactErrorCode.ARTIFACT_NOT_FOUND));
+
+        validateOwner(artifact, userId);
+        validateJsonArtifact(artifact);
+
+        return ArtifactJsonResponse.from(artifact);
+    }
+
+    private void validateOwner(Artifact artifact, Long userId) {
+        RepoRun run = artifact.getRun();
+
+        if (run.getOwner() == null || !Objects.equals(run.getOwner().getId(), userId)) {
+            throw new ArtifactException(ArtifactErrorCode.ARTIFACT_FORBIDDEN);
+        }
+    }
+
+    private void validateJsonArtifact(Artifact artifact) {
+        if (!"application/json".equalsIgnoreCase(artifact.getContentType())) {
+            throw new ArtifactException(ArtifactErrorCode.ARTIFACT_NOT_JSON);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/classmap/service/ClassMapBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/classmap/service/ClassMapBuildService.java
@@ -44,12 +44,12 @@ public class ClassMapBuildService {
             "/src/it/",
             "/src/integrationtest/",
             "/src/integration-test/",
-            "/example/",
-            "/examples/",
-            "/sample/",
-            "/samples/",
-            "/demo/",
-            "/demos/"
+            "/example/src",
+            "/examples/src",
+            "/sample/src",
+            "/samples/src",
+            "/demo/src",
+            "/demos/src"
     );
     private static final Set<String> NON_PRODUCTION_PACKAGE_TOKENS = Set.of(
             "test",

--- a/src/main/java/com/example/ossdoc/domain/classmap/service/ClassMapBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/classmap/service/ClassMapBuildService.java
@@ -55,12 +55,6 @@ public class ClassMapBuildService {
             "test",
             "tests",
             "it",
-            "example",
-            "examples",
-            "sample",
-            "samples",
-            "demo",
-            "demos",
             "benchmark",
             "benchmarks"
     );


### PR DESCRIPTION
## 작업 내용

- 클래스 다이어그램 산출물 조회를 위한 Artifact GET API를 추가했습니다.
- `GET /api/v1/artifacts/{artifactId}` API를 통해 프론트엔드에서 `class_diagram.json` 산출물을 조회할 수 있도록 구현했습니다.
- 로그인된 사용자만 산출물을 조회할 수 있도록 인증 검증을 추가했습니다.
- 산출물이 해당 사용자의 run에 속한 경우에만 조회 가능하도록 소유권 검증을 추가했습니다.
- JSON 산출물만 조회 가능하도록 `contentType` 검증을 추가했습니다.
- Artifact 도메인 전용 예외 코드와 예외 클래스를 추가했습니다.
- ClassMap 생성 시 공개 타입 필터링 정책을 조정했습니다.

## 주요 변경 사항

### Artifact 조회 API 추가

- `ArtifactController` 추가
- `ArtifactQueryService` 추가
- `ArtifactJsonResponse` 추가
- `ArtifactException`, `ArtifactErrorCode` 추가

### 예외 처리

- 존재하지 않는 산출물 조회 시 `ARTIFACT404_1`
- 접근 권한이 없는 산출물 조회 시 `ARTIFACT403_1`
- JSON 산출물이 아닌 경우 `ARTIFACT400_1`
- 산출물 조회 실패 시 `ARTIFACT500_1`

### ClassMap 필터링 정책 조정

- `example`, `sample`, `demo` 등의 이름이 포함된 패키지를 무조건 제외하지 않도록 조정했습니다.
- 실제 예제/샘플/데모 소스 경로에 해당하는 경우만 제외되도록 경로 기반 필터링 기준을 보완했습니다.
- 라이브러리의 주 서비스 패키지명이 `example` 등으로 구성된 경우에도 공개 타입이 과도하게 제외되지 않도록 개선했습니다.

## 테스트 방법

- [ ] 로그인 후 분석 요청을 실행합니다.
- [ ] 생성된 class diagram 산출물의 `artifactId`를 확인합니다.
- [ ] Swagger 또는 프론트엔드에서 `GET /api/v1/artifacts/{artifactId}` 요청을 보냅니다.
- [ ] 정상 응답 시 `artifactId`, `runId`, `kind`, `schemaVersion`, `contentType`, `path`, `content`가 반환되는지 확인합니다.
- [ ] 비로그인 상태에서 요청 시 인증 오류가 발생하는지 확인합니다.
- [ ] 다른 사용자의 산출물 조회 시 접근 권한 오류가 발생하는지 확인합니다.
- [ ] 존재하지 않는 `artifactId` 요청 시 404 오류가 발생하는지 확인합니다.

## 기대 효과

- 프론트엔드에서 분석 완료 후 클래스 다이어그램 JSON 산출물을 직접 조회할 수 있습니다.
- 사용자별 분석 결과 접근 권한을 보장할 수 있습니다.
- ClassMap 공개 타입 필터링이 과도하게 동작하는 문제를 줄여 실제 서비스 코드가 누락되는 상황을 완화할 수 있습니다.