### PR TITLE
Feat : 자동 분석 파이프라인 및 진행 상태 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/dto/response/ArtifactJsonResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/dto/response/ArtifactJsonResponse.java
@@ -1,7 +1,6 @@
 package com.example.ossdoc.domain.artifact.dto.response;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
-import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,12 +16,12 @@ public class ArtifactJsonResponse {
     private String path;
 
     /*
-     * content : 실제 class_diagram.json 본문입니다.
-     * 프론트는 이 content.nodes, content.edges를 사용해서 렌더링합니다.
+     * JsonNode를 그대로 노출하지 않습니다.
+     * Map/List/String/Number 등 일반 Java 값으로 변환된 JSON 본문을 담습니다.
      */
-    private JsonNode content;
+    private Object content;
 
-    public static ArtifactJsonResponse from(Artifact artifact) {
+    public static ArtifactJsonResponse from(Artifact artifact, Object content) {
         return ArtifactJsonResponse.builder()
                 .artifactId(artifact.getArtifactId())
                 .runId(artifact.getRun().getRunId())
@@ -30,7 +29,7 @@ public class ArtifactJsonResponse {
                 .schemaVersion(artifact.getSchemaVersion())
                 .contentType(artifact.getContentType())
                 .path(artifact.getPath())
-                .content(artifact.getMeta())
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
@@ -6,6 +6,7 @@ import com.example.ossdoc.domain.artifact.exception.ArtifactException;
 import com.example.ossdoc.domain.artifact.exception.code.ArtifactErrorCode;
 import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.util.Objects;
 public class ArtifactQueryService {
 
     private final ArtifactRepository artifactRepository;
+    private final ObjectMapper objectMapper;
 
     public ArtifactJsonResponse getJsonArtifact(Long artifactId, Long userId) {
         Artifact artifact = artifactRepository.findById(artifactId)
@@ -26,7 +28,17 @@ public class ArtifactQueryService {
         validateOwner(artifact, userId);
         validateJsonArtifact(artifact);
 
-        return ArtifactJsonResponse.from(artifact);
+        /*
+         * 중요:
+         * JsonNode 자체를 응답으로 넘기지 않고,
+         * 일반 Java 구조(Map/List 등)로 변환해서 넘깁니다.
+         */
+        Object plainJsonContent = objectMapper.convertValue(
+                artifact.getMeta(),
+                Object.class
+        );
+
+        return ArtifactJsonResponse.from(artifact, plainJsonContent);
     }
 
     private void validateOwner(Artifact artifact, Long userId) {

--- a/src/main/java/com/example/ossdoc/domain/classmap/dto/request/ClassMapBuildRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/classmap/dto/request/ClassMapBuildRequest.java
@@ -3,10 +3,14 @@ package com.example.ossdoc.domain.classmap.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class ClassMapBuildRequest {
     @NotBlank

--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
@@ -2,6 +2,8 @@ package com.example.ossdoc.domain.cluster.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 /* 군집화 알고리즘 : Leiden알고리즘
@@ -11,7 +13,9 @@ import lombok.NoArgsConstructor;
 * topK : symbol을 상위 몇개까지 ranking 결과를 뽑을지 정하는 값 / 랭킹(symbol) 필터
  * */
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ClusterBuildRequest {
     @NotBlank
     private String runId;

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterParameterRecommendService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/ClusterParameterRecommendService.java
@@ -20,7 +20,7 @@ import java.math.RoundingMode;
  *
  * 목적:
  * - 레포 크기마다 적정 파라미터가 달라 사용자가 매번 수동 튜닝해야 하는 문제를 줄인다.
- * - 동일 run에서 재현 가능한 기본값을 제공해 프런트 UX를 단순화한다.
+ * - 동일 run에서 재현 가능한 기본값을 제공해 프런트 UX와 자동 파이프라인을 단순화한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,20 +32,38 @@ public class ClusterParameterRecommendService {
     private final EdgeRepository edgeRepository;
 
     /**
-     * run의 그래프 규모를 바탕으로 cluster/class-map 추천값을 계산한다.
+     * 컨트롤러용 메서드.
+     * 외부 API 요청은 기존 DTO를 그대로 받되,
+     * 내부 계산은 runId 기반 공통 메서드로 위임한다.
      */
-    public ClusterParameterRecommendResponse recommend(ClusterParameterRecommendRequest request) {
-        String runId = request.getRunId();
+    public ClusterParameterRecommendResponse recommend(
+            ClusterParameterRecommendRequest request
+    ) {
+        return recommend(request.getRunId());
+    }
+
+    /**
+     * 파이프라인 내부 호출용 메서드.
+     * runId만으로 군집화/클래스맵 추천 파라미터를 계산한다.
+     */
+    public ClusterParameterRecommendResponse recommend(String runId) {
         repoRunRepository.findById(runId)
                 .orElseThrow(() -> new ClusterException(ClusterErrorCode.CLUSTER_RUN_NOT_FOUND));
 
-        long typeSymbolCount = symbolRepository.countByRun_RunIdAndSymbolKind(runId, SymbolKind.TYPE);
-        long edgeCount = edgeRepository.countByRun_RunId(runId);
-        double edgePerType = calculateEdgePerType(typeSymbolCount, edgeCount);
+        long typeSymbolCount =
+                symbolRepository.countByRun_RunIdAndSymbolKind(
+                        runId,
+                        SymbolKind.TYPE
+                );
 
+        long edgeCount = edgeRepository.countByRun_RunId(runId);
+
+        double edgePerType = calculateEdgePerType(typeSymbolCount, edgeCount);
         SizeTier sizeTier = decideSizeTier(typeSymbolCount, edgeCount);
+
         ClusterParameterRecommendResponse.ClusterRecommended clusterRecommended =
                 recommendCluster(sizeTier, edgePerType);
+
         ClusterParameterRecommendResponse.ClassMapRecommended classMapRecommended =
                 recommendClassMap(sizeTier, edgePerType);
 
@@ -68,12 +86,15 @@ public class ClusterParameterRecommendService {
         if (typeSymbolCount == 0L) {
             return SizeTier.SMALL;
         }
+
         if (typeSymbolCount <= 180L && edgeCount <= 30_000L) {
             return SizeTier.SMALL;
         }
+
         if (typeSymbolCount <= 750L && edgeCount <= 150_000L) {
             return SizeTier.MEDIUM;
         }
+
         return SizeTier.LARGE;
     }
 
@@ -81,8 +102,10 @@ public class ClusterParameterRecommendService {
      * 밀도 보정을 적용해 cluster 파라미터를 추천한다.
      * - edgePerType이 높은 그래프는 과분할/노이즈를 줄이기 위해 minClusterSize/topK를 소폭 상향한다.
      */
-    private ClusterParameterRecommendResponse.ClusterRecommended recommendCluster(SizeTier sizeTier, double edgePerType) {
-        // 기본값을 먼저 두고 tier별로 덮어써 컴파일러가 초기화를 확실히 인지하도록 한다.
+    private ClusterParameterRecommendResponse.ClusterRecommended recommendCluster(
+            SizeTier sizeTier,
+            double edgePerType
+    ) {
         double resolution = 0.22;
         int iterations = 8;
         int minClusterSize = 2;
@@ -129,8 +152,10 @@ public class ClusterParameterRecommendService {
      * class-map 노출 밀도를 제어하는 추천값을 계산한다.
      * - 군집화와 동일한 tier를 사용해 노드/엣지 상한을 함께 조정한다.
      */
-    private ClusterParameterRecommendResponse.ClassMapRecommended recommendClassMap(SizeTier sizeTier, double edgePerType) {
-        // 기본값을 먼저 두고 tier별로 덮어써 컴파일러가 초기화를 확실히 인지하도록 한다.
+    private ClusterParameterRecommendResponse.ClassMapRecommended recommendClassMap(
+            SizeTier sizeTier,
+            double edgePerType
+    ) {
         int maxNodes = 24;
         int maxEdges = 42;
         int startHereTopN = 3;
@@ -175,6 +200,7 @@ public class ClusterParameterRecommendService {
         if (typeSymbolCount <= 0L) {
             return 0.0;
         }
+
         return round((double) edgeCount / (double) typeSymbolCount, 3);
     }
 

--- a/src/main/java/com/example/ossdoc/domain/graphstore/dto/request/GraphStoreIngestRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/dto/request/GraphStoreIngestRequest.java
@@ -1,11 +1,22 @@
 package com.example.ossdoc.domain.graphstore.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class GraphStoreIngestRequest {
+
     @NotBlank
     private String runId;
+
+    /*
+     * null이면 GraphStoreIngestService가 해당 run의 최신 FACTS_JSON artifact를 찾습니다.
+     */
     private Long artifactId;
 }

--- a/src/main/java/com/example/ossdoc/domain/publicapi/service/PublicApiEntrySyncService.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/service/PublicApiEntrySyncService.java
@@ -1,4 +1,3 @@
-// 역할: run 기준 Symbol 정보를 바탕으로 public_api_entry를 일관되게 생성한다.
 package com.example.ossdoc.domain.publicapi.service;
 
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
@@ -21,33 +20,61 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+/*
+ * 역할:
+ * run 기준 Symbol 정보를 바탕으로 public_api_entry를 일관되게 생성합니다.
+ *
+ * 주의:
+ * public_api_entry는 이후 cluster 단계의 선행 입력으로 사용됩니다.
+ * 따라서 이 단계에서는 "실제 운영 코드일 가능성이 있는 타입"을 너무 공격적으로 제거하면 안 됩니다.
+ *
+ * 예:
+ * - org.springframework.samples.petclinic
+ *   → 패키지명에 samples가 들어가지만, PetClinic 프로젝트의 실제 메인 로직입니다.
+ *
+ * 그래서 이 서비스에서는
+ * 1. 명확한 테스트 코드만 제외하고
+ * 2. sample/example/demo 같은 단어만으로는 메인 로직을 제거하지 않습니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PublicApiEntrySyncService {
+
+    /*
+     * 명확한 테스트 소스 루트만 제외합니다.
+     *
+     * sample/example/demo 경로는 제외하지 않습니다.
+     * 이유:
+     * - 어떤 저장소에서는 별도 예제 폴더일 수 있지만
+     * - 어떤 저장소에서는 실제 프로젝트 본체일 수 있습니다.
+     * - public_api_entry는 cluster의 입력이므로, 여기서 너무 일찍 제거하면
+     *   실제 서비스 로직 전체가 군집화 대상에서 사라질 수 있습니다.
+     */
     private static final List<String> NON_PRODUCTION_PATH_MARKERS = List.of(
             "/src/test/",
             "/src/it/",
             "/src/integrationtest/",
-            "/src/integration-test/",
-            "/example/",
-            "/examples/",
-            "/sample/",
-            "/samples/",
-            "/demo/",
-            "/demos/"
+            "/src/integration-test/"
     );
 
+    /*
+     * 패키지명만 보고 제외해도 비교적 안전한 테스트/벤치마크 계열 토큰만 둡니다.
+     *
+     * 제거한 토큰:
+     * - example, examples
+     * - sample, samples
+     * - demo, demos
+     *
+     * 이유:
+     * - org.springframework.samples.petclinic 처럼
+     *   실제 메인 패키지에 samples가 포함되는 프로젝트가 존재합니다.
+     * - 이런 단어는 "비운영 코드"의 강한 증거가 아닙니다.
+     */
     private static final Set<String> NON_PRODUCTION_PACKAGE_TOKENS = Set.of(
             "test",
             "tests",
             "it",
-            "example",
-            "examples",
-            "sample",
-            "samples",
-            "demo",
-            "demos",
             "benchmark",
             "benchmarks"
     );
@@ -56,20 +83,33 @@ public class PublicApiEntrySyncService {
     private final SymbolRepository symbolRepository;
 
     /**
-     * 역할: run의 TYPE 심볼을 읽어 공개 API 엔트리를 동기화하고 symbol id 집합을 반환한다.
+     * 역할:
+     * run의 TYPE 심볼을 읽어 공개 API 엔트리를 동기화하고,
+     * 생성된 public API TYPE의 symbol id 집합을 반환합니다.
      */
     public Set<String> ensureTypeEntries(RepoRun run) {
-        List<SymbolEntity> typeSymbols = symbolRepository.findAllByRun_RunIdAndSymbolKind(run.getRunId(), SymbolKind.TYPE);
+        List<SymbolEntity> typeSymbols =
+                symbolRepository.findAllByRun_RunIdAndSymbolKind(
+                        run.getRunId(),
+                        SymbolKind.TYPE
+                );
+
         return ensureTypeEntries(run, typeSymbols);
     }
 
     /**
-     * 역할: 전달받은 TYPE 목록을 기준으로 공개 API 엔트리를 전량 재생성한다.
+     * 역할:
+     * 전달받은 TYPE 목록을 기준으로 공개 API 엔트리를 전량 재생성합니다.
+     *
+     * 기존 엔트리를 지운 뒤 최신 Symbol 상태 기준으로 다시 만드는 이유:
+     * - 같은 run에서 재실행하더라도 중복 엔트리를 방지
+     * - symbol access / 필터 정책 변경 시 결과를 일관되게 재동기화
      */
     public Set<String> ensureTypeEntries(RepoRun run, List<SymbolEntity> typeSymbols) {
         List<SymbolEntity> visibleTypes = collectVisibleTypes(typeSymbols);
 
         publicApiEntryRepository.deleteByRun_RunId(run.getRunId());
+
         if (visibleTypes.isEmpty()) {
             return Set.of();
         }
@@ -86,16 +126,22 @@ public class PublicApiEntrySyncService {
                     resolveExposure(symbol.getAccess()),
                     buildReason(symbol)
             );
+
             entries.add(entry);
             symbolIds.add(symbol.getSymbolId());
         }
 
         publicApiEntryRepository.saveAll(entries);
+
         return symbolIds;
     }
 
     /**
-     * 역할: 공개 대상 접근제어(public/protected) + 운영 코드 여부를 기준으로 TYPE을 필터링한다.
+     * 역할:
+     * 공개 대상 접근 제어(public/protected) + 명확한 비운영 코드 여부를 기준으로
+     * TYPE을 필터링합니다.
+     *
+     * 여기서 제외하는 것은 "명확히 테스트/벤치마크 코드라고 판단 가능한 것"으로 제한합니다.
      */
     private List<SymbolEntity> collectVisibleTypes(List<SymbolEntity> typeSymbols) {
         if (typeSymbols == null || typeSymbols.isEmpty()) {
@@ -103,26 +149,51 @@ public class PublicApiEntrySyncService {
         }
 
         List<SymbolEntity> visible = new ArrayList<>();
+
         for (SymbolEntity type : typeSymbols) {
             if (type == null || type.getSymbolKind() != SymbolKind.TYPE) {
                 continue;
             }
+
             if (!isPublicOrProtected(type.getAccess())) {
                 continue;
             }
-            if (isNonProductionType(type)) {
+
+            if (isClearlyNonProductionType(type)) {
                 continue;
             }
+
             visible.add(type);
         }
+
         return List.copyOf(visible);
     }
 
     /**
-     * 역할: 테스트/예제 성격 타입을 public API 후보에서 제외한다.
+     * 역할:
+     * 명확하게 테스트/벤치마크 코드로 볼 수 있는 타입만 제외합니다.
+     *
+     * 제외 기준:
+     * 1. source path가 test 계열 소스 루트에 속함
+     * 2. package token이 test/tests/it/benchmark/benchmarks
+     * 3. simple name이 Test/Tests/TestCase로 끝남
+     *
+     * 제외하지 않는 것:
+     * - sample/samples
+     * - example/examples
+     * - demo/demos
+     *
+     * 이유:
+     * 위 단어들은 실제 메인 프로젝트 이름이나 패키지명으로도 자주 쓰이므로
+     * 단어만 보고 제거하면 실제 로직을 누락할 위험이 큽니다.
      */
-    private boolean isNonProductionType(SymbolEntity type) {
-        String sourcePath = normalizePath(type.getSourceFile() == null ? null : type.getSourceFile().getPath());
+    private boolean isClearlyNonProductionType(SymbolEntity type) {
+        String sourcePath = normalizePath(
+                type.getSourceFile() == null
+                        ? null
+                        : type.getSourceFile().getPath()
+        );
+
         if (sourcePath != null) {
             for (String marker : NON_PRODUCTION_PATH_MARKERS) {
                 if (sourcePath.contains(marker)) {
@@ -132,8 +203,12 @@ public class PublicApiEntrySyncService {
         }
 
         String packageName = extractPackageName(type.getQualifiedName());
+
         if (packageName != null) {
-            String[] tokens = packageName.toLowerCase(Locale.ROOT).split("\\.");
+            String[] tokens = packageName
+                    .toLowerCase(Locale.ROOT)
+                    .split("\\.");
+
             for (String token : tokens) {
                 if (NON_PRODUCTION_PACKAGE_TOKENS.contains(token)) {
                     return true;
@@ -142,9 +217,15 @@ public class PublicApiEntrySyncService {
         }
 
         String simpleName = trimToNull(type.getSimpleName());
+
         if (simpleName != null) {
             String lower = simpleName.toLowerCase(Locale.ROOT);
-            if (lower.endsWith("test") || lower.endsWith("tests") || lower.endsWith("testcase")) {
+
+            if (
+                    lower.endsWith("test")
+                            || lower.endsWith("tests")
+                            || lower.endsWith("testcase")
+            ) {
                 return true;
             }
         }
@@ -153,68 +234,101 @@ public class PublicApiEntrySyncService {
     }
 
     /**
-     * 역할: access 값을 public_api_entry.exposure 문자열로 변환한다.
+     * 역할:
+     * access 값을 public_api_entry.exposure 문자열로 변환합니다.
      */
     private String resolveExposure(AccessLevel accessLevel) {
         if (accessLevel == null) {
             return "UNKNOWN";
         }
+
         return accessLevel.name();
     }
 
     /**
-     * 역할: 공개 API로 분류한 근거를 JSON으로 기록한다.
+     * 역할:
+     * 공개 API로 분류한 근거를 JSON으로 기록합니다.
      */
     private ObjectNode buildReason(SymbolEntity symbol) {
         ObjectNode reason = JsonNodeFactory.instance.objectNode();
+
         reason.put("source", "graphstore_symbol_access");
-        reason.put("symbolKind", symbol.getSymbolKind() == null ? "UNKNOWN" : symbol.getSymbolKind().name());
-        reason.put("access", symbol.getAccess() == null ? "UNKNOWN" : symbol.getAccess().name());
-        reason.put("rule", "TYPE and access in [PUBLIC, PROTECTED] + non-production exclusion");
+        reason.put(
+                "symbolKind",
+                symbol.getSymbolKind() == null
+                        ? "UNKNOWN"
+                        : symbol.getSymbolKind().name()
+        );
+        reason.put(
+                "access",
+                symbol.getAccess() == null
+                        ? "UNKNOWN"
+                        : symbol.getAccess().name()
+        );
+        reason.put(
+                "rule",
+                "TYPE and access in [PUBLIC, PROTECTED] + clear test/benchmark exclusion"
+        );
+
         return reason;
     }
 
     /**
-     * 역할: qualified name에서 패키지명을 추출한다.
+     * 역할:
+     * qualified name에서 패키지명을 추출합니다.
      */
     private String extractPackageName(String qualifiedName) {
         String normalized = trimToNull(qualifiedName);
+
         if (normalized == null) {
             return null;
         }
+
         int idx = normalized.lastIndexOf('.');
+
         if (idx <= 0) {
             return null;
         }
+
         return normalized.substring(0, idx);
     }
 
     /**
-     * 역할: 운영체제 경로 구분자 차이를 없애기 위해 슬래시/소문자로 정규화한다.
+     * 역할:
+     * 운영체제 경로 구분자 차이를 없애기 위해 슬래시/소문자로 정규화합니다.
      */
     private String normalizePath(String rawPath) {
         String path = trimToNull(rawPath);
+
         if (path == null) {
             return null;
         }
-        return path.replace('\\', '/').toLowerCase(Locale.ROOT);
+
+        return path
+                .replace('\\', '/')
+                .toLowerCase(Locale.ROOT);
     }
 
     /**
-     * 역할: 공백 문자열을 null로 정규화한다.
+     * 역할:
+     * 공백 문자열을 null로 정규화합니다.
      */
     private String trimToNull(String text) {
         if (text == null) {
             return null;
         }
+
         String trimmed = text.trim();
+
         return trimmed.isEmpty() ? null : trimmed;
     }
 
     /**
-     * 역할: 공개 API 후보 접근 제어(public/protected) 여부를 판별한다.
+     * 역할:
+     * 공개 API 후보 접근 제어(public/protected) 여부를 판별합니다.
      */
     private boolean isPublicOrProtected(AccessLevel accessLevel) {
-        return accessLevel == AccessLevel.PUBLIC || accessLevel == AccessLevel.PROTECTED;
+        return accessLevel == AccessLevel.PUBLIC
+                || accessLevel == AccessLevel.PROTECTED;
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/controller/RepoRunController.java
+++ b/src/main/java/com/example/ossdoc/domain/run/controller/RepoRunController.java
@@ -2,9 +2,11 @@ package com.example.ossdoc.domain.run.controller;
 
 import com.example.ossdoc.domain.auth.exception.AuthException;
 import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
-import com.example.ossdoc.domain.run.dto.RepoRunCreateRequest;
-import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
+import com.example.ossdoc.domain.run.dto.request.RepoRunCreateRequest;
+import com.example.ossdoc.domain.run.dto.response.RepoRunCreateResponse;
+import com.example.ossdoc.domain.run.dto.response.RepoRunProgressResponse;
 import com.example.ossdoc.domain.run.service.RepoRunService;
+import com.example.ossdoc.domain.run.service.RunProgressQueryService;
 import com.example.ossdoc.global.apiPayload.ApiResponse;
 import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
 import jakarta.validation.Valid;
@@ -18,15 +20,48 @@ import org.springframework.web.bind.annotation.*;
 public class RepoRunController {
 
     private final RepoRunService repoRunService;
+    private final RunProgressQueryService runProgressQueryService;
 
+    /*
+     * 프론트는 이 API만 호출해서 분석을 요청합니다.
+     * 이후 전체 pipeline은 백엔드 worker가 자동으로 처리합니다.
+     */
     @PostMapping
-    public ApiResponse<RepoRunCreateResponse> create(@Valid @RequestBody RepoRunCreateRequest request,
-                                                     @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+    public ApiResponse<RepoRunCreateResponse> create(
+            @Valid @RequestBody RepoRunCreateRequest request,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
         if (authenticatedUser == null) {
             throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
         }
 
-        RepoRunCreateResponse response = repoRunService.createRun(request, authenticatedUser.getUserId());
+        RepoRunCreateResponse response = repoRunService.createRun(
+                request,
+                authenticatedUser.getUserId()
+        );
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    /*
+     * 프론트 진행률 바 polling API입니다.
+     *
+     * GET /api/v1/runs/{runId}/progress
+     */
+    @GetMapping("/{runId}/progress")
+    public ApiResponse<RepoRunProgressResponse> progress(
+            @PathVariable String runId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
+
+        RepoRunProgressResponse response = runProgressQueryService.getProgress(
+                runId,
+                authenticatedUser.getUserId()
+        );
+
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/dto/request/RepoRunCreateRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/request/RepoRunCreateRequest.java
@@ -1,5 +1,5 @@
 // domain/run/dto/RepoRunCreateRequest.java
-package com.example.ossdoc.domain.run.dto;
+package com.example.ossdoc.domain.run.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunCreateResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunCreateResponse.java
@@ -1,4 +1,4 @@
-package com.example.ossdoc.domain.run.dto;
+package com.example.ossdoc.domain.run.dto.response;
 
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import lombok.Builder;

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunProgressResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunProgressResponse.java
@@ -1,0 +1,50 @@
+package com.example.ossdoc.domain.run.dto.response;
+
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RepoRunProgressResponse {
+
+    private String runId;
+    private String status;
+    private String stage;
+    private String stageLabel;
+    private Integer progress;
+    private String message;
+    private String failureMessage;
+    private String repoUrl;
+    private String commitSha;
+
+    private RunArtifactIdsResponse artifacts;
+    private List<RunStepProgressResponse> steps;
+    private List<RunFailedStepResponse> failedSteps;
+
+    public static RepoRunProgressResponse of(
+            RepoRun run,
+            RunPipelineJob job,
+            RunArtifactIdsResponse artifacts,
+            List<RunStepProgressResponse> steps,
+            List<RunFailedStepResponse> failedSteps
+    ) {
+        return RepoRunProgressResponse.builder()
+                .runId(run.getRunId())
+                .status(run.getStatus().name())
+                .stage(job.getCurrentStage() == null ? null : job.getCurrentStage().name())
+                .stageLabel(job.getCurrentStage() == null ? null : job.getCurrentStage().getDefaultMessage())
+                .progress(job.getProgress())
+                .message(job.getStatusMessage())
+                .failureMessage(job.getFailureMessage())
+                .repoUrl(run.getRepoUrl())
+                .commitSha(run.getCommitSha())
+                .artifacts(artifacts)
+                .steps(steps)
+                .failedSteps(failedSteps)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RunArtifactIdsResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RunArtifactIdsResponse.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.run.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RunArtifactIdsResponse {
+
+    private Long jobManifestArtifactId;
+    private Long buildManifestArtifactId;
+    private Long factsArtifactId;
+    private Long graphStatsArtifactId;
+    private Long rankingsArtifactId;
+    private Long subsystemsArtifactId;
+    private Long classDiagramArtifactId;
+}

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RunFailedStepResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RunFailedStepResponse.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.run.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RunFailedStepResponse {
+
+    private String stage;
+    private String message;
+}

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RunStepProgressResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RunStepProgressResponse.java
@@ -1,0 +1,28 @@
+package com.example.ossdoc.domain.run.dto.response;
+
+import com.example.ossdoc.domain.run.entity.RunPipelineStepExecution;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RunStepProgressResponse {
+
+    private String stage;
+    private String status;
+    private Boolean required;
+    private Integer progress;
+    private String message;
+    private String errorMessage;
+
+    public static RunStepProgressResponse from(RunPipelineStepExecution step) {
+        return RunStepProgressResponse.builder()
+                .stage(step.getStage().name())
+                .status(step.getStatus().name())
+                .required(step.getRequiredStep())
+                .progress(step.getProgress())
+                .message(step.getMessage())
+                .errorMessage(step.getErrorMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
+++ b/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
@@ -3,21 +3,20 @@ package com.example.ossdoc.domain.run.entity;
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
-import com.example.ossdoc.global.apiPayload.code.BaseCreatedEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-
-import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "repo_run")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-
 public class RepoRun extends BaseAuditedEntity {
 
     @Id
@@ -31,9 +30,22 @@ public class RepoRun extends BaseAuditedEntity {
     @Column(name = "repo_url", nullable = false)
     private String repoUrl;
 
+    @Column(name = "repo_owner")
+    private String repoOwner;
+
+    @Column(name = "repo_name")
+    private String repoName;
+
+    @Column(name = "resolved_ref")
+    private String resolvedRef;
+
     @Column(name = "commit_sha", nullable = false)
     private String commitSha;
 
+    /*
+     * run의 대표 최종 상태만 저장합니다.
+     * 세부 진행률은 RunPipelineJob이 담당합니다.
+     */
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private RunStatus status = RunStatus.QUEUED;
@@ -54,7 +66,44 @@ public class RepoRun extends BaseAuditedEntity {
     @Column(name = "workspace_root")
     private String workspaceRoot;
 
+    public RepoRun(
+            String runId,
+            User owner,
+            String repoUrl,
+            String repoOwner,
+            String repoName,
+            String resolvedRef,
+            String commitSha,
+            String workspaceRoot
+    ) {
+        this.runId = runId;
+        this.owner = owner;
+        this.repoUrl = repoUrl;
+        this.repoOwner = repoOwner;
+        this.repoName = repoName;
+        this.resolvedRef = resolvedRef;
+        this.commitSha = commitSha;
+        this.workspaceRoot = workspaceRoot;
+        this.status = RunStatus.QUEUED;
+    }
+
     public void assignOwner(User owner) {
         this.owner = owner;
+    }
+
+    public void markRunning() {
+        this.status = RunStatus.RUNNING;
+    }
+
+    public void markSuccess() {
+        this.status = RunStatus.SUCCESS;
+    }
+
+    public void markPartialSuccess() {
+        this.status = RunStatus.PARTIAL_SUCCESS;
+    }
+
+    public void markFailed() {
+        this.status = RunStatus.FAILED;
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/entity/RunPipelineJob.java
+++ b/src/main/java/com/example/ossdoc/domain/run/entity/RunPipelineJob.java
@@ -1,0 +1,180 @@
+package com.example.ossdoc.domain.run.entity;
+
+import com.example.ossdoc.domain.run.enums.PipelineJobStatus;
+import com.example.ossdoc.domain.run.enums.RunStage;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "run_pipeline_job",
+        uniqueConstraints = @UniqueConstraint(
+                name = "ux_run_pipeline_job_run",
+                columnNames = "run_id"
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunPipelineJob extends BaseAuditedEntity {
+
+    private static final int USER_MESSAGE_LIMIT = 1000;
+    private static final int INTERNAL_ERROR_LIMIT = 4000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_id")
+    private Long jobId;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "run_id", nullable = false)
+    private RepoRun run;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PipelineJobStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_stage")
+    private RunStage currentStage;
+
+    @Column(name = "progress")
+    private Integer progress;
+
+    @Column(name = "status_message", length = 500)
+    private String statusMessage;
+
+    @Column(name = "failure_message", columnDefinition = "text")
+    private String failureMessage;
+
+    @Column(name = "attempt_count", nullable = false)
+    private Integer attemptCount;
+
+    @Column(name = "max_attempts", nullable = false)
+    private Integer maxAttempts;
+
+    @Column(name = "locked_by")
+    private String lockedBy;
+
+    @Column(name = "locked_at")
+    private LocalDateTime lockedAt;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Column(name = "next_run_at", nullable = false)
+    private LocalDateTime nextRunAt;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+
+    public static RunPipelineJob create(RepoRun run, Long userId) {
+        RunPipelineJob job = new RunPipelineJob();
+        job.run = run;
+        job.userId = userId;
+        job.status = PipelineJobStatus.QUEUED;
+        job.currentStage = RunStage.QUEUED;
+        job.progress = 0;
+        job.statusMessage = RunStage.QUEUED.getDefaultMessage();
+        job.attemptCount = 0;
+        job.maxAttempts = 1;
+        job.nextRunAt = LocalDateTime.now();
+        return job;
+    }
+
+    public void claim(String workerId, LocalDateTime now, LocalDateTime lockedUntil) {
+        this.status = PipelineJobStatus.RUNNING;
+        this.lockedBy = workerId;
+        this.lockedAt = now;
+        this.lockedUntil = lockedUntil;
+        this.startedAt = this.startedAt == null ? now : this.startedAt;
+        this.attemptCount = this.attemptCount + 1;
+
+        this.run.markRunning();
+    }
+
+    public void updateProgress(RunStage stage, String message) {
+        this.status = PipelineJobStatus.RUNNING;
+        this.currentStage = stage;
+        this.progress = stage.getProgress();
+        this.statusMessage = normalizeMessage(message, stage.getDefaultMessage(), 500);
+        this.failureMessage = null;
+
+        this.run.markRunning();
+    }
+
+    public void markSuccess() {
+        this.status = PipelineJobStatus.SUCCESS;
+        this.currentStage = RunStage.DONE;
+        this.progress = 100;
+        this.statusMessage = RunStage.DONE.getDefaultMessage();
+        this.failureMessage = null;
+        this.lastError = null;
+        this.completedAt = LocalDateTime.now();
+
+        this.run.markSuccess();
+        clearLock();
+    }
+
+    public void markPartialSuccess(String message) {
+        this.status = PipelineJobStatus.PARTIAL_SUCCESS;
+        this.currentStage = RunStage.DONE;
+        this.progress = 100;
+        this.statusMessage = "일부 분석 결과 생성에 실패했습니다.";
+        this.failureMessage = normalizeMessage(message, "일부 선택 단계가 실패했습니다.", USER_MESSAGE_LIMIT);
+        this.lastError = this.failureMessage;
+        this.completedAt = LocalDateTime.now();
+
+        this.run.markPartialSuccess();
+        clearLock();
+    }
+
+    public void markFailed(String userMessage, String internalError) {
+        this.status = PipelineJobStatus.FAILED;
+        this.currentStage = RunStage.FAILED;
+        this.progress = 100;
+        this.statusMessage = "분석에 실패했습니다.";
+        this.failureMessage = normalizeMessage(userMessage, "분석 파이프라인 실행 중 오류가 발생했습니다.", USER_MESSAGE_LIMIT);
+        this.lastError = normalizeMessage(internalError, this.failureMessage, INTERNAL_ERROR_LIMIT);
+        this.completedAt = LocalDateTime.now();
+
+        this.run.markFailed();
+        clearLock();
+    }
+
+    public void markRetrying(String errorMessage, LocalDateTime nextRunAt) {
+        this.status = PipelineJobStatus.RETRYING;
+        this.lastError = normalizeMessage(errorMessage, "재시도 대기 중입니다.", INTERNAL_ERROR_LIMIT);
+        this.nextRunAt = nextRunAt;
+        clearLock();
+    }
+
+    private void clearLock() {
+        this.lockedBy = null;
+        this.lockedAt = null;
+        this.lockedUntil = null;
+    }
+
+    private String normalizeMessage(String message, String defaultMessage, int limit) {
+        String value = (message == null || message.isBlank()) ? defaultMessage : message;
+
+        if (value.length() <= limit) {
+            return value;
+        }
+
+        return value.substring(0, limit);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/entity/RunPipelineStepExecution.java
+++ b/src/main/java/com/example/ossdoc/domain/run/entity/RunPipelineStepExecution.java
@@ -1,0 +1,121 @@
+package com.example.ossdoc.domain.run.entity;
+
+import com.example.ossdoc.domain.run.enums.PipelineStepStatus;
+import com.example.ossdoc.domain.run.enums.RunStage;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "run_pipeline_step_execution",
+        uniqueConstraints = @UniqueConstraint(
+                name = "ux_pipeline_step_job_stage",
+                columnNames = {"job_id", "stage"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunPipelineStepExecution extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "step_id")
+    private Long stepId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false)
+    private RunPipelineJob job;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "run_id", nullable = false)
+    private RepoRun run;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stage", nullable = false)
+    private RunStage stage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PipelineStepStatus status;
+
+    @Column(name = "required_step", nullable = false)
+    private Boolean requiredStep;
+
+    @Column(name = "progress", nullable = false)
+    private Integer progress;
+
+    @Column(name = "message", length = 500)
+    private String message;
+
+    @Column(name = "error_message", columnDefinition = "text")
+    private String errorMessage;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    public static RunPipelineStepExecution create(
+            RunPipelineJob job,
+            RepoRun run,
+            RunStage stage
+    ) {
+        RunPipelineStepExecution step = new RunPipelineStepExecution();
+        step.job = job;
+        step.run = run;
+        step.stage = stage;
+        step.status = PipelineStepStatus.QUEUED;
+        step.requiredStep = stage.isRequired();
+        step.progress = stage.getProgress();
+        step.message = stage.getDefaultMessage();
+        return step;
+    }
+
+    public void start(String message) {
+        this.status = PipelineStepStatus.RUNNING;
+        this.startedAt = LocalDateTime.now();
+        this.message = normalizeMessage(message, stage.getDefaultMessage());
+        this.errorMessage = null;
+    }
+
+    public void succeed(String message) {
+        this.status = PipelineStepStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+        this.message = normalizeMessage(message, stage.getDefaultMessage());
+        this.errorMessage = null;
+    }
+
+    public void fail(String message) {
+        this.status = PipelineStepStatus.FAILED;
+        this.completedAt = LocalDateTime.now();
+        this.errorMessage = truncate(message);
+    }
+
+    public void skip(String message) {
+        this.status = PipelineStepStatus.SKIPPED;
+        this.completedAt = LocalDateTime.now();
+        this.message = normalizeMessage(message, "단계를 건너뛰었습니다.");
+    }
+
+    private String normalizeMessage(String message, String defaultMessage) {
+        if (message == null || message.isBlank()) {
+            return defaultMessage;
+        }
+
+        return message;
+    }
+
+    private String truncate(String value) {
+        if (value == null) {
+            return null;
+        }
+        int limit = 4000;
+        return value.length() <= limit ? value : value.substring(0, limit);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/enums/PipelineJobStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/run/enums/PipelineJobStatus.java
@@ -1,0 +1,10 @@
+package com.example.ossdoc.domain.run.enums;
+
+public enum PipelineJobStatus {
+    QUEUED,
+    RUNNING,
+    SUCCESS,
+    PARTIAL_SUCCESS,
+    FAILED,
+    RETRYING
+}

--- a/src/main/java/com/example/ossdoc/domain/run/enums/PipelineStepStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/run/enums/PipelineStepStatus.java
@@ -1,0 +1,9 @@
+package com.example.ossdoc.domain.run.enums;
+
+public enum PipelineStepStatus {
+    QUEUED,
+    RUNNING,
+    SUCCESS,
+    FAILED,
+    SKIPPED
+}

--- a/src/main/java/com/example/ossdoc/domain/run/enums/RunStage.java
+++ b/src/main/java/com/example/ossdoc/domain/run/enums/RunStage.java
@@ -1,0 +1,66 @@
+package com.example.ossdoc.domain.run.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunStage {
+    QUEUED(
+            0,
+            true,
+            "분석 요청이 대기 중입니다."
+    ),
+
+    SNAPSHOT(
+            10,
+            true,
+            "레포지토리 스냅샷을 준비 중입니다."
+    ),
+
+    BUILD(
+            25,
+            true,
+            "빌드 환경을 분석 중입니다."
+    ),
+
+    EXTRACTION(
+            45,
+            true,
+            "소스 코드와 바이트코드를 분석 중입니다."
+    ),
+
+    GRAPHSTORE(
+            65,
+            true,
+            "코드 구조 그래프를 저장 중입니다."
+    ),
+
+    CLUSTER(
+            80,
+            false,
+            "주요 모듈과 군집을 분석 중입니다."
+    ),
+
+    CLASSMAP(
+            95,
+            false,
+            "클래스 다이어그램을 생성 중입니다."
+    ),
+
+    DONE(
+            100,
+            false,
+            "분석이 완료되었습니다."
+    ),
+
+    FAILED(
+            100,
+            true,
+            "분석에 실패했습니다."
+    );
+
+    private final int progress;
+    private final boolean required;
+    private final String defaultMessage;
+}

--- a/src/main/java/com/example/ossdoc/domain/run/enums/RunStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/run/enums/RunStatus.java
@@ -1,5 +1,21 @@
 package com.example.ossdoc.domain.run.enums;
 
 public enum RunStatus {
-    QUEUED, RUNNING, SUCCESS, FAILED
+    QUEUED,
+    RUNNING,
+    SUCCESS,
+
+    /*
+     * 필수 단계는 성공했지만 선택 단계 일부가 실패한 상태.
+     *
+     * 예:
+     * - SNAPSHOT / BUILD / EXTRACTION / GRAPHSTORE 성공
+     * - CLUSTER 실패
+     * - CLASSMAP 성공 또는 실패
+     *
+     * 프론트는 성공한 artifact는 보여주고,
+     * 실패한 영역은 "~에 실패했습니다."로 표시.
+     */
+    PARTIAL_SUCCESS,
+    FAILED
 }

--- a/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/run/exception/code/RunErrorCode.java
@@ -9,11 +9,66 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum RunErrorCode implements BaseCode {
-    INVALID_REPO_URL(HttpStatus.BAD_REQUEST, "RUN_400_001", "Invalid GitHub repo URL."),
-    GITHUB_API_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_001", "Failed to resolve repo info from GitHub."),
-    DOWNLOAD_FAILED(HttpStatus.BAD_GATEWAY, "RUN_502_002", "Failed to download repository zip."),
-    UNZIP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_001", "Failed to unzip repository."),
-    JOB_MANIFEST_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RUN_500_002", "Failed to write job_manifest.json");
+
+    INVALID_REPO_URL(
+            HttpStatus.BAD_REQUEST,
+            "RUN400_1",
+            "GitHub 레포지토리 URL 형식이 올바르지 않습니다."
+    ),
+
+    GITHUB_API_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "RUN502_1",
+            "GitHub 레포지토리 정보를 조회하지 못했습니다."
+    ),
+
+    DOWNLOAD_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "RUN502_2",
+            "레포지토리 ZIP 다운로드에 실패했습니다."
+    ),
+
+    UNZIP_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "RUN500_1",
+            "레포지토리 압축 해제에 실패했습니다."
+    ),
+
+    JOB_MANIFEST_WRITE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "RUN500_2",
+            "job_manifest.json 작성에 실패했습니다."
+    ),
+
+    RUN_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "RUN404_1",
+            "존재하지 않는 run 입니다."
+    ),
+
+    RUN_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "RUN403_1",
+            "해당 run 접근 권한이 없습니다."
+    ),
+
+    PIPELINE_JOB_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "RUN404_2",
+            "존재하지 않는 파이프라인 작업입니다."
+    ),
+
+    PIPELINE_ALREADY_EXISTS(
+            HttpStatus.CONFLICT,
+            "RUN409_1",
+            "이미 파이프라인 작업이 존재합니다."
+    ),
+
+    PIPELINE_EXECUTION_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "RUN500_3",
+            "분석 파이프라인 실행에 실패했습니다."
+    );
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ossdoc/domain/run/repository/RepoRunRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/run/repository/RepoRunRepository.java
@@ -1,8 +1,13 @@
-// domain/run/repository/RepoRunRepository.java
 package com.example.ossdoc.domain.run.repository;
 
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RepoRunRepository extends JpaRepository<RepoRun, String> {
+    /*
+     * 진행률 조회 시 현재 로그인 사용자가 소유한 run인지 검증합니다.
+     */
+    Optional<RepoRun> findByRunIdAndOwner_Id(String runId, Long ownerId);
 }

--- a/src/main/java/com/example/ossdoc/domain/run/repository/RunPipelineJobRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/run/repository/RunPipelineJobRepository.java
@@ -1,0 +1,46 @@
+package com.example.ossdoc.domain.run.repository;
+
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface RunPipelineJobRepository extends JpaRepository<RunPipelineJob, Long> {
+
+    boolean existsByRun_RunId(String runId);
+
+    Optional<RunPipelineJob> findByRun_RunId(String runId);
+
+    /*
+     * PostgreSQL SKIP LOCKED 기반 작업 선점 쿼리입니다.
+     *
+     * 여러 서버 인스턴스가 동시에 떠 있어도 하나의 worker만 job을 가져갑니다.
+     * 작업 중 서버가 죽으면 locked_until 만료 후 다른 worker가 다시 가져갈 수 있습니다.
+     */
+    @Query(
+            value = """
+                    SELECT *
+                    FROM run_pipeline_job
+                    WHERE job_id IN (
+                        SELECT job_id
+                        FROM run_pipeline_job
+                        WHERE
+                            (
+                                status IN ('QUEUED', 'RETRYING')
+                                AND next_run_at <= CURRENT_TIMESTAMP
+                            )
+                            OR
+                            (
+                                status = 'RUNNING'
+                                AND locked_until < CURRENT_TIMESTAMP
+                            )
+                        ORDER BY created_at ASC
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT 1
+                    )
+                    """,
+            nativeQuery = true
+    )
+    Optional<RunPipelineJob> findNextRunnableJobForUpdate();
+}

--- a/src/main/java/com/example/ossdoc/domain/run/repository/RunPipelineStepExecutionRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/run/repository/RunPipelineStepExecutionRepository.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.domain.run.repository;
+
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.entity.RunPipelineStepExecution;
+import com.example.ossdoc.domain.run.enums.RunStage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RunPipelineStepExecutionRepository extends JpaRepository<RunPipelineStepExecution, Long> {
+
+    Optional<RunPipelineStepExecution> findByJobAndStage(
+            RunPipelineJob job,
+            RunStage stage
+    );
+
+    List<RunPipelineStepExecution> findAllByRun_RunIdOrderByStepIdAsc(String runId);
+}

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -1,24 +1,17 @@
 package com.example.ossdoc.domain.run.service;
 
-import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
-import com.example.ossdoc.domain.artifact.service.ArtifactService;
 import com.example.ossdoc.domain.auth.exception.AuthException;
 import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
-import com.example.ossdoc.domain.run.dto.RepoRunCreateRequest;
-import com.example.ossdoc.domain.run.dto.RepoRunCreateResponse;
+import com.example.ossdoc.domain.run.dto.request.RepoRunCreateRequest;
+import com.example.ossdoc.domain.run.dto.response.RepoRunCreateResponse;
 import com.example.ossdoc.domain.run.entity.RepoRun;
-import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.domain.run.support.GithubClient;
 import com.example.ossdoc.domain.run.support.GithubRepoRef;
 import com.example.ossdoc.domain.run.support.GithubUrlParser;
-import com.example.ossdoc.domain.run.support.JobManifestWriter;
 import com.example.ossdoc.domain.run.support.WorkspaceManager;
-import com.example.ossdoc.domain.run.support.ZipUtils;
 import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.domain.user.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,11 +28,9 @@ public class RepoRunService {
 
     private final RepoRunRepository repoRunRepository;
     private final UserRepository userRepository;
-    private final ArtifactService artifactService;
     private final GithubClient githubClient;
     private final WorkspaceManager workspaceManager;
-    private final JobManifestWriter jobManifestWriter;
-    private final ObjectMapper objectMapper;
+    private final RunPipelineQueueService pipelineQueueService;
 
     @Transactional
     public RepoRunCreateResponse createRun(RepoRunCreateRequest req, Long userId) {
@@ -47,6 +38,7 @@ public class RepoRunService {
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
+
         log.info(
                 "Create run requested userId={}, owner={}, repo={}, requestedRef={}",
                 userId,
@@ -56,12 +48,24 @@ public class RepoRunService {
         );
 
         String ref = parsed.getRef();
+
         if (ref == null || ref.isBlank()) {
             ref = githubClient.resolveDefaultBranch(parsed.getOwner(), parsed.getRepo());
-            log.info("Resolved default branch owner={}, repo={}, ref={}", parsed.getOwner(), parsed.getRepo(), ref);
+
+            log.info(
+                    "Resolved default branch owner={}, repo={}, ref={}",
+                    parsed.getOwner(),
+                    parsed.getRepo(),
+                    ref
+            );
         }
 
-        String commitSha = githubClient.resolveCommitSha(parsed.getOwner(), parsed.getRepo(), ref);
+        String commitSha = githubClient.resolveCommitSha(
+                parsed.getOwner(),
+                parsed.getRepo(),
+                ref
+        );
+
         log.info(
                 "Resolved commit SHA owner={}, repo={}, ref={}, sha={}",
                 parsed.getOwner(),
@@ -70,43 +74,40 @@ public class RepoRunService {
                 abbreviateSha(commitSha)
         );
 
-        String runId = "run_" + OffsetDateTime.now().toLocalDate().toString().replace("-", "")
-                + "_" + UUID.randomUUID().toString().substring(0, 8);
+        String runId = "run_"
+                + OffsetDateTime.now().toLocalDate().toString().replace("-", "")
+                + "_"
+                + UUID.randomUUID().toString().substring(0, 8);
+
         Path wsRoot = workspaceManager.workspaceRoot(runId);
+
         log.info("Workspace prepared runId={}, workspaceRoot={}", runId, wsRoot);
-
-        Path zipPath = wsRoot.resolve("repo.zip");
-        githubClient.downloadZip(parsed.getOwner(), parsed.getRepo(), commitSha, zipPath);
-
-        Path unzipRoot = wsRoot.resolve("repo");
-        ZipUtils.unzip(zipPath, unzipRoot);
-        log.info("Repository snapshot ready runId={}, zipPath={}, unzipRoot={}", runId, zipPath, unzipRoot);
 
         RepoRun run = new RepoRun(
                 runId,
                 owner,
                 req.getRepoUrl(),
+                parsed.getOwner(),
+                parsed.getRepo(),
+                ref,
                 commitSha,
-                RunStatus.QUEUED,
-                null,
-                null,
-                null,
-                null,
                 wsRoot.toString()
         );
+
         repoRunRepository.save(run);
 
-        ObjectNode meta = objectMapper.createObjectNode();
-        meta.put("ref", ref);
-        meta.put("commitSha", commitSha);
-        meta.put("generatedAt", OffsetDateTime.now().toString());
+        /*
+         * 프론트가 build/extraction/graphstore/cluster/classMap API를 직접 호출하지 않도록,
+         * run 생성과 동시에 pipeline job을 큐에 넣습니다.
+         */
+        pipelineQueueService.enqueue(run, userId);
 
-        Path artifactsDir = workspaceManager.artifactsDir(wsRoot);
-        jobManifestWriter.write(artifactsDir, meta);
-
-        artifactService.saveJsonArtifact(run, ArtifactKind.JOB_MANIFEST, "0.1",
-                "job_manifest.json", meta);
-        log.info("Run queued runId={}, status={}, sha={}", runId, run.getStatus(), abbreviateSha(commitSha));
+        log.info(
+                "Run queued runId={}, status={}, sha={}",
+                runId,
+                run.getStatus(),
+                abbreviateSha(commitSha)
+        );
 
         return RepoRunCreateResponse.builder()
                 .runId(runId)
@@ -120,6 +121,7 @@ public class RepoRunService {
         if (sha == null || sha.isBlank()) {
             return "<empty>";
         }
+
         return sha.length() <= 8 ? sha : sha.substring(0, 8);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineExecutor.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineExecutor.java
@@ -1,0 +1,336 @@
+package com.example.ossdoc.domain.run.service;
+
+import com.example.ossdoc.domain.build.service.BuildResolveService;
+import com.example.ossdoc.domain.classmap.dto.request.ClassMapBuildRequest;
+import com.example.ossdoc.domain.classmap.service.ClassMapBuildService;
+import com.example.ossdoc.domain.cluster.dto.request.ClusterBuildRequest;
+import com.example.ossdoc.domain.cluster.dto.response.ClusterParameterRecommendResponse;
+import com.example.ossdoc.domain.cluster.service.ClusterBuildService;
+import com.example.ossdoc.domain.cluster.service.ClusterParameterRecommendService;
+import com.example.ossdoc.domain.extraction.dto.request.FactsExtractRequest;
+import com.example.ossdoc.domain.extraction.facade.FactsExtractionFacade;
+import com.example.ossdoc.domain.graphstore.dto.request.GraphStoreIngestRequest;
+import com.example.ossdoc.domain.graphstore.service.GraphStoreIngestService;
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.enums.RunStage;
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.example.ossdoc.domain.run.repository.RunPipelineJobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * 실제 파이프라인 실행 오케스트레이터입니다.
+ *
+ * 필수 단계:
+ * SNAPSHOT → BUILD → EXTRACTION → GRAPHSTORE
+ *
+ * 선택 단계:
+ * CLUSTER → CLASSMAP
+ *
+ * 필수 단계 실패: FAILED
+ * 선택 단계 실패: PARTIAL_SUCCESS
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunPipelineExecutor {
+
+    private final RunPipelineJobRepository jobRepository;
+    private final RunPipelineStepService stepService;
+
+    private final RunSnapshotService runSnapshotService;
+    private final BuildResolveService buildResolveService;
+    private final FactsExtractionFacade factsExtractionFacade;
+    private final GraphStoreIngestService graphStoreIngestService;
+
+    private final ClusterParameterRecommendService clusterParameterRecommendService;
+    private final ClusterBuildService clusterBuildService;
+    private final ClassMapBuildService classMapBuildService;
+
+    public void execute(Long jobId) {
+        RunPipelineJob job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new RunException(RunErrorCode.PIPELINE_JOB_NOT_FOUND));
+
+        String runId = job.getRun().getRunId();
+        Long userId = job.getUserId();
+
+        log.info("[PIPELINE] execute start. jobId={}, runId={}", jobId, runId);
+
+        List<String> optionalFailures = new ArrayList<>();
+
+        try {
+            executeRequired(
+                    jobId,
+                    RunStage.SNAPSHOT,
+                    "레포지토리 스냅샷을 준비 중입니다.",
+                    () -> runSnapshotService.prepareSnapshot(runId)
+            );
+
+            executeRequired(
+                    jobId,
+                    RunStage.BUILD,
+                    "빌드 환경을 분석 중입니다.",
+                    () -> buildResolveService.resolve(runId)
+            );
+
+            executeRequired(
+                    jobId,
+                    RunStage.EXTRACTION,
+                    "소스 코드와 바이트코드를 분석 중입니다.",
+                    () -> factsExtractionFacade.extract(
+                            FactsExtractRequest.builder()
+                                    .runId(runId)
+                                    .mode(null)
+                                    .includeObservations(true)
+                                    .includeTests(false)
+                                    .failFast(false)
+                                    .targetModules(List.of())
+                                    .includeGlobs(List.of())
+                                    .excludeGlobs(List.of())
+                                    .build()
+                    )
+            );
+
+            executeRequired(
+                    jobId,
+                    RunStage.GRAPHSTORE,
+                    "코드 구조 그래프를 저장 중입니다.",
+                    () -> graphStoreIngestService.ingest(
+                            GraphStoreIngestRequest.builder()
+                                    .runId(runId)
+                                    .artifactId(null)
+                                    .build(),
+                            userId
+                    )
+            );
+
+            /*
+             * GRAPHSTORE 완료 후, 실제 그래프 규모를 기준으로
+             * 군집화와 클래스맵 추천 파라미터를 한 번 계산합니다.
+             *
+             * 이후 CLUSTER와 CLASSMAP은 같은 추천 기준을 공유합니다.
+             */
+            PipelineAnalysisParameters parameters =
+                    resolveRecommendedParameters(runId);
+
+            executeOptional(
+                    jobId,
+                    RunStage.CLUSTER,
+                    "주요 모듈과 군집을 분석 중입니다.",
+                    "군집화 생성에 실패했습니다.",
+                    optionalFailures,
+                    () -> clusterBuildService.build(
+                            ClusterBuildRequest.builder()
+                                    .runId(runId)
+                                    .resolution(parameters.resolution())
+                                    .iterations(parameters.iterations())
+                                    .minClusterSize(parameters.minClusterSize())
+                                    .topK(parameters.topK())
+                                    .build()
+                    )
+            );
+
+            executeOptional(
+                    jobId,
+                    RunStage.CLASSMAP,
+                    "클래스 다이어그램을 생성 중입니다.",
+                    "클래스 다이어그램 생성에 실패했습니다.",
+                    optionalFailures,
+                    () -> classMapBuildService.build(
+                            ClassMapBuildRequest.builder()
+                                    .runId(runId)
+                                    .maxNodes(parameters.maxNodes())
+                                    .maxEdges(parameters.maxEdges())
+                                    .startHereTopN(parameters.startHereTopN())
+                                    .build(),
+                            userId
+                    )
+            );
+
+            if (optionalFailures.isEmpty()) {
+                stepService.markRunSuccess(jobId);
+            } else {
+                stepService.markRunPartialSuccess(
+                        jobId,
+                        String.join(" / ", optionalFailures)
+                );
+            }
+        } catch (Exception e) {
+            log.error("[PIPELINE] Required step failed. jobId={}, runId={}", jobId, runId, e);
+
+            stepService.markRunFailed(
+                    jobId,
+                    "필수 분석 단계 실행 중 오류가 발생했습니다.",
+                    safeInternalError(e)
+            );
+        }
+    }
+
+    /**
+     * 추천 서비스가 정상 동작하면 추천값을 사용하고,
+     * 만약 추천 계산 자체가 실패하더라도 파이프라인 전체가 멈추지 않도록
+     * 기존 자동 파이프라인 기본값으로 안전하게 fallback 합니다.
+     */
+    private PipelineAnalysisParameters resolveRecommendedParameters(String runId) {
+        try {
+            ClusterParameterRecommendResponse recommendation =
+                    clusterParameterRecommendService.recommend(runId);
+
+            ClusterParameterRecommendResponse.ClusterRecommended cluster =
+                    recommendation.getClusterRecommended();
+
+            ClusterParameterRecommendResponse.ClassMapRecommended classMap =
+                    recommendation.getClassMapRecommended();
+
+            log.info(
+                    """
+                    [PIPELINE] recommended parameters resolved. \
+                    runId={}, sizeTier={}, typeSymbolCount={}, edgeCount={}, edgePerType={}, \
+                    cluster=[resolution={}, iterations={}, minClusterSize={}, topK={}], \
+                    classMap=[maxNodes={}, maxEdges={}, startHereTopN={}]
+                    """,
+                    runId,
+                    recommendation.getSizeTier(),
+                    recommendation.getTypeSymbolCount(),
+                    recommendation.getEdgeCount(),
+                    recommendation.getEdgePerType(),
+                    cluster.getResolution(),
+                    cluster.getIterations(),
+                    cluster.getMinClusterSize(),
+                    cluster.getTopK(),
+                    classMap.getMaxNodes(),
+                    classMap.getMaxEdges(),
+                    classMap.getStartHereTopN()
+            );
+
+            return new PipelineAnalysisParameters(
+                    cluster.getResolution(),
+                    cluster.getIterations(),
+                    cluster.getMinClusterSize(),
+                    cluster.getTopK(),
+                    classMap.getMaxNodes(),
+                    classMap.getMaxEdges(),
+                    classMap.getStartHereTopN()
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "[PIPELINE] parameter recommendation failed. fallback defaults will be used. runId={}",
+                    runId,
+                    e
+            );
+
+            /*
+             * fallback:
+             * 추천 서비스 장애가 cluster/classMap 전체 실패로 번지지 않게
+             * 기존 자동 파이프라인 값을 사용합니다.
+             */
+            return PipelineAnalysisParameters.fallbackDefaults();
+        }
+    }
+
+    private String safeInternalError(Exception e) {
+        Throwable root = e;
+
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+
+        String message = root.getMessage();
+
+        if (message == null || message.isBlank()) {
+            message = e.getMessage();
+        }
+
+        if (message == null || message.isBlank()) {
+            return "분석 파이프라인 실행 중 알 수 없는 오류가 발생했습니다.";
+        }
+
+        int limit = 4000;
+        return message.length() <= limit ? message : message.substring(0, limit);
+    }
+
+    private void executeRequired(
+            Long jobId,
+            RunStage stage,
+            String message,
+            PipelineRunnable runnable
+    ) {
+        log.info("[PIPELINE] required step start. jobId={}, stage={}", jobId, stage);
+
+        stepService.startStep(jobId, stage, message);
+
+        try {
+            runnable.run();
+            stepService.succeedStep(jobId, stage, stage.getDefaultMessage());
+        } catch (Exception e) {
+            stepService.failStep(jobId, stage, safeMessage(e));
+            throw e;
+        }
+    }
+
+    private void executeOptional(
+            Long jobId,
+            RunStage stage,
+            String message,
+            String failureMessage,
+            List<String> optionalFailures,
+            PipelineRunnable runnable
+    ) {
+        log.info("[PIPELINE] optional step start. jobId={}, stage={}", jobId, stage);
+
+        stepService.startStep(jobId, stage, message);
+
+        try {
+            runnable.run();
+            stepService.succeedStep(jobId, stage, stage.getDefaultMessage());
+        } catch (Exception e) {
+            log.warn("[PIPELINE] Optional step failed. stage={}, jobId={}", stage, jobId, e);
+
+            stepService.failStep(jobId, stage, failureMessage);
+            optionalFailures.add(failureMessage);
+        }
+    }
+
+    private String safeMessage(Exception e) {
+        if (e == null || e.getMessage() == null || e.getMessage().isBlank()) {
+            return "분석 파이프라인 실행 중 오류가 발생했습니다.";
+        }
+
+        return e.getMessage();
+    }
+
+    /**
+     * 파이프라인에서 실제로 사용할 군집화/클래스맵 파라미터 묶음입니다.
+     */
+    private record PipelineAnalysisParameters(
+            double resolution,
+            int iterations,
+            int minClusterSize,
+            int topK,
+            int maxNodes,
+            int maxEdges,
+            int startHereTopN
+    ) {
+        private static PipelineAnalysisParameters fallbackDefaults() {
+            return new PipelineAnalysisParameters(
+                    0.012,
+                    10,
+                    3,
+                    30,
+                    120,
+                    240,
+                    8
+            );
+        }
+    }
+
+    @FunctionalInterface
+    private interface PipelineRunnable {
+        void run();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineQueueService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineQueueService.java
@@ -1,0 +1,46 @@
+package com.example.ossdoc.domain.run.service;
+
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.example.ossdoc.domain.run.repository.RunPipelineJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/*
+ * 파이프라인 Job 큐 관리 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class RunPipelineQueueService {
+
+    private static final int LOCK_MINUTES = 30;
+
+    private final RunPipelineJobRepository jobRepository;
+
+    @Transactional
+    public RunPipelineJob enqueue(RepoRun run, Long userId) {
+        if (jobRepository.existsByRun_RunId(run.getRunId())) {
+            throw new RunException(RunErrorCode.PIPELINE_ALREADY_EXISTS);
+        }
+
+        return jobRepository.save(RunPipelineJob.create(run, userId));
+    }
+
+    @Transactional
+    public Optional<RunPipelineJob> claimNextJob(String workerId) {
+        Optional<RunPipelineJob> candidate = jobRepository.findNextRunnableJobForUpdate();
+
+        candidate.ifPresent(job -> {
+            LocalDateTime now = LocalDateTime.now();
+            job.claim(workerId, now, now.plusMinutes(LOCK_MINUTES));
+        });
+
+        return candidate;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineStepService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunPipelineStepService.java
@@ -1,0 +1,92 @@
+package com.example.ossdoc.domain.run.service;
+
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.entity.RunPipelineStepExecution;
+import com.example.ossdoc.domain.run.enums.RunStage;
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.example.ossdoc.domain.run.repository.RunPipelineJobRepository;
+import com.example.ossdoc.domain.run.repository.RunPipelineStepExecutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+ * 단계별 상태 저장 서비스입니다.
+ *
+ * 각 단계 시작/성공/실패는 REQUIRES_NEW로 저장합니다.
+ * 그래서 긴 작업 중에도 프론트 polling이 진행률을 볼 수 있습니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class RunPipelineStepService {
+
+    private final RunPipelineJobRepository jobRepository;
+    private final RunPipelineStepExecutionRepository stepRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void startStep(Long jobId, RunStage stage, String message) {
+        RunPipelineJob job = findJob(jobId);
+        RepoRun run = job.getRun();
+
+        RunPipelineStepExecution step = findOrCreateStep(job, run, stage);
+        step.start(message);
+
+        /*
+         * 진행 상태는 repo_run이 아니라 run_pipeline_job에 저장합니다.
+         */
+        job.updateProgress(stage, message);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void succeedStep(Long jobId, RunStage stage, String message) {
+        RunPipelineJob job = findJob(jobId);
+
+        RunPipelineStepExecution step = findOrCreateStep(job, job.getRun(), stage);
+        step.succeed(message);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void failStep(Long jobId, RunStage stage, String message) {
+        RunPipelineJob job = findJob(jobId);
+
+        RunPipelineStepExecution step = findOrCreateStep(job, job.getRun(), stage);
+        step.fail(message);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRunSuccess(Long jobId) {
+        RunPipelineJob job = findJob(jobId);
+        job.markSuccess();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRunPartialSuccess(Long jobId, String message) {
+        RunPipelineJob job = findJob(jobId);
+        job.markPartialSuccess(message);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRunFailed(Long jobId, String userMessage, String internalError) {
+        RunPipelineJob job = findJob(jobId);
+        job.markFailed(userMessage, internalError);
+    }
+
+    private RunPipelineJob findJob(Long jobId) {
+        return jobRepository.findById(jobId)
+                .orElseThrow(() -> new RunException(RunErrorCode.PIPELINE_JOB_NOT_FOUND));
+    }
+
+    private RunPipelineStepExecution findOrCreateStep(
+            RunPipelineJob job,
+            RepoRun run,
+            RunStage stage
+    ) {
+        return stepRepository.findByJobAndStage(job, stage)
+                .orElseGet(() -> stepRepository.save(
+                        RunPipelineStepExecution.create(job, run, stage)
+                ));
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
@@ -1,0 +1,82 @@
+package com.example.ossdoc.domain.run.service;
+
+import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
+import com.example.ossdoc.domain.run.dto.response.RepoRunProgressResponse;
+import com.example.ossdoc.domain.run.dto.response.RunArtifactIdsResponse;
+import com.example.ossdoc.domain.run.dto.response.RunFailedStepResponse;
+import com.example.ossdoc.domain.run.dto.response.RunStepProgressResponse;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.enums.PipelineStepStatus;
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.domain.run.repository.RunPipelineJobRepository;
+import com.example.ossdoc.domain.run.repository.RunPipelineStepExecutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/*
+ * 프론트 polling용 진행 상태 조회 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class RunProgressQueryService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final RunPipelineJobRepository jobRepository;
+    private final RunPipelineStepExecutionRepository stepRepository;
+    private final ArtifactRepository artifactRepository;
+
+    @Transactional(readOnly = true)
+    public RepoRunProgressResponse getProgress(String runId, Long userId) {
+        RepoRun run = repoRunRepository.findByRunIdAndOwner_Id(runId, userId)
+                .orElseThrow(() -> new RunException(RunErrorCode.RUN_FORBIDDEN));
+
+        RunPipelineJob job = jobRepository.findByRun_RunId(runId)
+                .orElseThrow(() -> new RunException(RunErrorCode.PIPELINE_JOB_NOT_FOUND));
+
+        var stepEntities = stepRepository.findAllByRun_RunIdOrderByStepIdAsc(runId);
+
+        List<RunStepProgressResponse> steps = stepEntities.stream()
+                .map(RunStepProgressResponse::from)
+                .toList();
+
+        List<RunFailedStepResponse> failedSteps = stepEntities.stream()
+                .filter(step -> step.getStatus() == PipelineStepStatus.FAILED)
+                .map(step -> RunFailedStepResponse.builder()
+                        .stage(step.getStage().name())
+                        .message(step.getErrorMessage())
+                        .build())
+                .toList();
+
+        RunArtifactIdsResponse artifacts = RunArtifactIdsResponse.builder()
+                .jobManifestArtifactId(latestArtifactId(runId, ArtifactKind.JOB_MANIFEST))
+                .buildManifestArtifactId(latestArtifactId(runId, ArtifactKind.BUILD_MANIFEST))
+                .factsArtifactId(latestArtifactId(runId, ArtifactKind.FACTS_JSON))
+                .graphStatsArtifactId(latestArtifactId(runId, ArtifactKind.GRAPH_STATS))
+                .rankingsArtifactId(latestArtifactId(runId, ArtifactKind.RANKINGS_JSON))
+                .subsystemsArtifactId(latestArtifactId(runId, ArtifactKind.SUBSYSTEMS_JSON))
+                .classDiagramArtifactId(latestArtifactId(runId, ArtifactKind.CLASS_DIAGRAM_JSON))
+                .build();
+
+        return RepoRunProgressResponse.of(
+                run,
+                job,
+                artifacts,
+                steps,
+                failedSteps
+        );
+    }
+
+    private Long latestArtifactId(String runId, ArtifactKind kind) {
+        return artifactRepository.findTopByRun_RunIdAndKindOrderByCreatedAtDesc(runId, kind)
+                .map(Artifact::getArtifactId)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunSnapshotService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunSnapshotService.java
@@ -1,0 +1,85 @@
+package com.example.ossdoc.domain.run.service;
+
+import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
+import com.example.ossdoc.domain.artifact.service.ArtifactService;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.exception.RunException;
+import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.domain.run.support.GithubClient;
+import com.example.ossdoc.domain.run.support.JobManifestWriter;
+import com.example.ossdoc.domain.run.support.WorkspaceManager;
+import com.example.ossdoc.domain.run.support.ZipUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+
+/*
+ * SNAPSHOT 단계 서비스입니다.
+ *
+ * repo zip 다운로드, 압축 해제, job_manifest.json 생성을 담당합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunSnapshotService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final GithubClient githubClient;
+    private final WorkspaceManager workspaceManager;
+    private final JobManifestWriter jobManifestWriter;
+    private final ArtifactService artifactService;
+    private final ObjectMapper objectMapper;
+
+    public void prepareSnapshot(String runId) {
+        RepoRun run = repoRunRepository.findById(runId)
+                .orElseThrow(() -> new RunException(RunErrorCode.RUN_NOT_FOUND));
+
+        Path workspaceRoot = Path.of(run.getWorkspaceRoot());
+        Path zipPath = workspaceRoot.resolve("repo.zip");
+        Path unzipRoot = workspaceRoot.resolve("repo");
+
+        githubClient.downloadZip(
+                run.getRepoOwner(),
+                run.getRepoName(),
+                run.getCommitSha(),
+                zipPath
+        );
+
+        ZipUtils.unzip(zipPath, unzipRoot);
+
+        log.info(
+                "[SNAPSHOT] Repository snapshot ready runId={}, zipPath={}, unzipRoot={}",
+                runId,
+                zipPath,
+                unzipRoot
+        );
+
+        ObjectNode meta = objectMapper.createObjectNode();
+        meta.put("runId", runId);
+        meta.put("repoUrl", run.getRepoUrl());
+        meta.put("owner", run.getRepoOwner());
+        meta.put("repo", run.getRepoName());
+        meta.put("ref", run.getResolvedRef());
+        meta.put("commitSha", run.getCommitSha());
+        meta.put("workspaceRoot", workspaceRoot.toString());
+        meta.put("generatedAt", OffsetDateTime.now().toString());
+
+        Path artifactsDir = workspaceManager.artifactsDir(workspaceRoot);
+
+        jobManifestWriter.write(artifactsDir, meta);
+
+        artifactService.saveJsonArtifact(
+                run,
+                ArtifactKind.JOB_MANIFEST,
+                "0.1",
+                "job_manifest.json",
+                meta
+        );
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/worker/RunPipelineWorker.java
+++ b/src/main/java/com/example/ossdoc/domain/run/worker/RunPipelineWorker.java
@@ -1,0 +1,61 @@
+package com.example.ossdoc.domain.run.worker;
+
+import com.example.ossdoc.domain.run.entity.RunPipelineJob;
+import com.example.ossdoc.domain.run.service.RunPipelineExecutor;
+import com.example.ossdoc.domain.run.service.RunPipelineQueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.UUID;
+
+/*
+ * DB 기반 파이프라인 worker입니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RunPipelineWorker {
+
+    private final RunPipelineQueueService queueService;
+    private final RunPipelineExecutor executor;
+
+    @Value("${ossdoc.pipeline.worker.max-jobs-per-tick:1}")
+    private int maxJobsPerTick;
+
+    private final String workerId = buildWorkerId();
+
+    @Scheduled(fixedDelayString = "${ossdoc.pipeline.worker.fixed-delay-ms:2000}")
+    public void poll() {
+        for (int i = 0; i < maxJobsPerTick; i++) {
+            Optional<RunPipelineJob> claimed = queueService.claimNextJob(workerId);
+
+            if (claimed.isEmpty()) {
+                return;
+            }
+
+            RunPipelineJob job = claimed.get();
+
+            log.info(
+                    "[PIPELINE_WORKER] Claimed job. workerId={}, jobId={}, runId={}",
+                    workerId,
+                    job.getJobId(),
+                    job.getRun().getRunId()
+            );
+
+            executor.execute(job.getJobId());
+        }
+    }
+
+    private String buildWorkerId() {
+        try {
+            return InetAddress.getLocalHost().getHostName() + "-" + UUID.randomUUID();
+        } catch (Exception e) {
+            return "worker-" + UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/config/PipelineWorkerConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/PipelineWorkerConfig.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/*
+ * DB 기반 파이프라인 worker를 주기적으로 실행하기 위한 설정입니다.
+ */
+@Configuration
+@EnableScheduling
+public class PipelineWorkerConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,10 @@ build:
 ossdoc:
   workspace:
     base-dir: ${OSSDOC_WORKSPACE_BASE_DIR:C:/data/ossdoc}
+  pipeline:
+    worker:
+      fixed-delay-ms: ${PIPELINE_WORKER_FIXED_DELAY_MS:2000}
+      max-jobs-per-tick: ${PIPELINE_WORKER_MAX_JOBS_PER_TICK:1}
 
 app:
   cors:


### PR DESCRIPTION
## 개요

사용자가 레포지토리 분석을 요청하면 프론트에서 각 단계를 개별 호출하지 않아도, 백엔드에서 전체 분석 파이프라인이 자동으로 실행되도록 개선했습니다.  
또한 프론트에서 현재 분석 단계와 진행률을 조회할 수 있도록 진행 상태 조회 API를 추가하고, 선택 단계 실패 시에도 성공한 중간 결과를 제공할 수 있도록 부분 성공 처리를 도입했습니다.

---

## 주요 변경 사항

### 1. 자동 분석 파이프라인 추가
- `run` 생성 이후 별도 수동 호출 없이 백엔드에서 전체 파이프라인이 자동 실행되도록 구성했습니다.
- 실행 흐름:
  - `SNAPSHOT`
  - `BUILD`
  - `EXTRACTION`
  - `GRAPHSTORE`
  - `CLUSTER`
  - `CLASSMAP`
- DB 기반 worker 구조를 추가하여 파이프라인 job을 순차적으로 실행하도록 구현했습니다.

### 2. 파이프라인 실행 상태 관리 구조 추가
- `run_pipeline_job`
  - 현재 단계, 진행률, 상태 메시지, 실패 메시지 등 파이프라인의 현재 상태를 관리합니다.
- `run_pipeline_step_execution`
  - 단계별 실행 결과와 성공/실패 이력을 관리합니다.
- `repo_run`
  - run의 대표 상태만 유지하도록 역할을 분리했습니다.

### 3. 진행 상태 조회 API 추가
- 프론트에서 분석 진행 상황을 polling할 수 있도록 API를 추가했습니다.
- 추가 API:
  - `GET /api/v1/runs/{runId}/progress`
- 응답에 포함되는 정보:
  - 현재 상태
  - 현재 단계
  - 진행률
  - 단계별 실행 결과
  - 실패 단계 정보
  - 생성된 artifact id 목록

### 4. 부분 성공 처리 추가
- 필수 단계 실패 시 전체 분석을 `FAILED`로 처리합니다.
- 선택 단계인 `CLUSTER`, `CLASSMAP` 실패 시에는 전체 분석을 중단하지 않고 `PARTIAL_SUCCESS`로 처리합니다.
- 예:
  - 군집화 실패
  - 클래스 다이어그램 생성 성공
  - → 클래스 다이어그램 결과는 제공하고, 군집화 실패만 별도로 표시 가능

### 5. artifact JSON 응답 보완
- artifact 조회 API에서 `JsonNode` 메타 정보만 내려가던 문제를 수정했습니다.
- 실제 JSON 본문이 `content`로 정상 반환되도록 개선하여, 프론트에서 `class_diagram.json` 내용을 정상적으로 렌더링할 수 있게 했습니다.

### 6. public API 후보 동기화 로직 보완
- `sample`, `samples`, `example`, `demo` 등의 패키지명을 단순 포함했다는 이유만으로 실제 메인 로직이 제외되던 문제를 수정했습니다.
- 테스트 코드만 제외하고, 실제 오픈소스의 서비스 로직은 군집화 대상에 포함되도록 필터 기준을 보완했습니다.

### 7. 추천 파라미터 자동 연동
- 기존 `clusters/recommend`의 추천 로직을 자동 파이프라인 내부에서도 재사용할 수 있도록 개선했습니다.
- `GRAPHSTORE` 완료 후 저장소 규모에 맞는 추천값을 계산하고,
  - 군집화 파라미터
  - 클래스 다이어그램 파라미터
  에 자동 반영하도록 수정했습니다.

---

## API 변경 사항

### 추가
- `GET /api/v1/runs/{runId}/progress`

### 동작 변경
- `POST /api/v1/runs`
  - 기존: run 생성 중심
  - 변경: run 생성 후 백엔드 자동 파이프라인 실행 시작

---

## 기대 효과

- 프론트는 레포지토리 분석 요청 1회만 수행하면 되어 연동 복잡도가 줄어듭니다.
- 사용자는 현재 분석 단계와 진행률을 실시간으로 확인할 수 있습니다.
- 일부 선택 단계가 실패하더라도 성공한 분석 결과는 계속 제공할 수 있습니다.
- 저장소 규모에 맞는 추천 파라미터를 자동 적용하여 군집화 및 클래스 다이어그램 생성 품질을 개선할 수 있습니다.

---

## 확인 사항

- run 생성 후 `SNAPSHOT → BUILD → EXTRACTION → GRAPHSTORE → CLUSTER → CLASSMAP` 순서로 자동 실행되는 것 확인
- `progress` API를 통해 단계별 상태 및 진행률 응답 확인
- `CLUSTER` 실패 시 `PARTIAL_SUCCESS` 처리 및 `CLASSMAP` 결과 제공 확인
- artifact 조회 API에서 실제 `class_diagram.json` 본문이 정상 반환되는 것 확인
- public API 후보 동기화 보완 후 군집화가 정상 수행되는 것 확인
- 추천 파라미터가 자동 파이프라인에 반영되는 것 확인

---

## 관련 작업

- 프론트엔드에서는 `POST /api/v1/runs` 이후 `GET /api/v1/runs/{runId}/progress`를 polling하여 진행 상태를 표시할 수 있습니다.
- 분석 완료 후 응답에 포함된 artifact id를 이용해 결과 산출물을 조회할 수 있습니다.