### PR TITLE
[Refactor/#45] Rule candidate 노출 정책/품질 라벨/재마이닝(forceRebuild) 전략 개선

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EdgeRepository.java
@@ -29,4 +29,9 @@ public interface EdgeRepository extends JpaRepository<Edge, Long> {
      * - 그래프 밀도(대략) 계산에 사용해 추천 파라미터를 보정한다.
      */
     long countByRun_RunId(String runId);
+
+    /**
+     * run 범위에서 마지막으로 갱신된 edge 1건을 조회한다.
+     */
+    Optional<Edge> findTopByRun_RunIdOrderByUpdatedAtDesc(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/EvidenceRepository.java
@@ -38,4 +38,9 @@ public interface EvidenceRepository extends JpaRepository<Evidence, Long> {
             Integer endLine,
             String snippet
     );
+
+    /**
+     * run 범위에서 가장 최근에 적재된 evidence 1건을 조회한다.
+     */
+    Optional<Evidence> findTopByRun_RunIdOrderByCreatedAtDesc(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
@@ -28,4 +28,9 @@ public interface SymbolRepository extends JpaRepository<SymbolEntity, String> {
      * - 군집화/클래스맵 파라미터 추천 시 그래프 크기 판단의 기준값으로 사용한다.
      */
     long countByRun_RunIdAndSymbolKind(String runId, SymbolKind symbolKind);
+
+    /**
+     * run 범위에서 마지막으로 갱신된 symbol 1건을 조회한다.
+     */
+    Optional<SymbolEntity> findTopByRun_RunIdOrderByUpdatedAtDesc(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidateDisplayPolicyJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidateDisplayPolicyJson.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.rule.dto.json;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RuleCandidateDisplayPolicyJson(
+        String sizeTier,
+        int totalCandidates,
+        int targetMin,
+        int targetMax,
+        int recommendedPrimaryCount,
+        List<Long> primaryCandidateIds,
+        List<Long> exploratoryCandidateIds
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidateItem.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidateItem.java
@@ -31,6 +31,11 @@ public record RuleCandidateItem(
         JsonNode impact,
         JsonNode meta,
 
+        Boolean estimated,
+        String qualityLabel,
+        String qualityReason,
+        Integer evidenceCount,
+
         List<RuleCandidateEvidenceJson> evidences
 ) {
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidatesJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidatesJson.java
@@ -10,6 +10,7 @@ public record RuleCandidatesJson(
         String runId,
         String generatedAt,
         RuleCandidateSummaryJson summary,
+        RuleCandidateDisplayPolicyJson displayPolicy,
         List<RuleCandidateItem> candidates
 ) {
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/request/RuleCandidateMineRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/request/RuleCandidateMineRequest.java
@@ -8,6 +8,13 @@ public record RuleCandidateMineRequest(
         Long factsArtifactId,
         Boolean forceRebuild
 ) {
+    /**
+     * forceRebuild 값이 요청 본문에 명시되었는지 여부를 반환한다.
+     */
+    public boolean hasForceRebuildFlag() {
+        return forceRebuild != null;
+    }
+
     public boolean isForceRebuild() {
         return Boolean.TRUE.equals(forceRebuild);
     }

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/response/RuleCandidateMineResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/response/RuleCandidateMineResponse.java
@@ -9,6 +9,7 @@ public record RuleCandidateMineResponse(
         int totalCandidates,
         int highConfidenceCount,
         int mediumConfidenceCount,
-        int lowConfidenceCount
+        int lowConfidenceCount,
+        boolean forceRebuildApplied
 ) {
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/repository/RuleMiningSignalRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/repository/RuleMiningSignalRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface RuleMiningSignalRepository extends JpaRepository<RuleMiningSignal, Long> {
 
@@ -39,6 +40,11 @@ public interface RuleMiningSignalRepository extends JpaRepository<RuleMiningSign
             String runId,
             Long evidenceId
     );
+
+    /**
+     * run 범위에서 가장 최근에 생성된 룰 신호 1건을 조회한다.
+     */
+    Optional<RuleMiningSignal> findTopByRun_RunIdOrderByCreatedAtDesc(String runId);
 
     void deleteAllByRun_RunId(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,8 +37,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RuleCandidateArtifactPublisher {
 
-    private static final String SCHEMA_VERSION = "1.1";
+    private static final String SCHEMA_VERSION = "1.2";
     private static final String RELATIVE_PATH = "rule/rule_candidates.json";
+    private static final BigDecimal LOW_SCORE_THRESHOLD = new BigDecimal("0.6000");
+    private static final Set<String> PRIMARY_EVIDENCE_ROLES = Set.of(
+            "IF_CONDITION",
+            "THROW_STATEMENT",
+            "RETURN_STATEMENT",
+            "ERROR_RESPONSE",
+            "REPOSITORY_SAVE",
+            "REPOSITORY_UPDATE",
+            "REPOSITORY_DELETE",
+            "ASSERTION_CALL",
+            "REQUIRE_CALL"
+    );
 
     private final RuleCandidateRepository ruleCandidateRepository;
     private final RuleCandidateEvidenceRepository ruleCandidateEvidenceRepository;
@@ -64,7 +77,8 @@ public class RuleCandidateArtifactPublisher {
             List<RuleCandidateEvidence> evidences =
                     evidencesByCandidateId.getOrDefault(candidate.getCandidateId(), List.of());
 
-            items.add(toItem(candidate, evidences));
+            CandidateQuality quality = evaluateQuality(candidate, evidences);
+            items.add(toItem(candidate, evidences, quality));
         }
 
         long edgeCount = edgeRepository.countByRun_RunId(run.getRunId());
@@ -136,9 +150,11 @@ public class RuleCandidateArtifactPublisher {
 
     private RuleCandidateItem toItem(
             RuleCandidate candidate,
-            List<RuleCandidateEvidence> evidences
+            List<RuleCandidateEvidence> evidences,
+            CandidateQuality quality
     ) {
         SymbolEntity subject = candidate.getSubjectSymbol();
+        List<RuleCandidateEvidenceJson> evidenceJson = toEvidenceJsonList(evidences);
 
         return RuleCandidateItem.builder()
                 .candidateId(candidate.getCandidateId())
@@ -159,8 +175,48 @@ public class RuleCandidateArtifactPublisher {
                 .summary(candidate.getSummary())
                 .impact(candidate.getImpact())
                 .meta(candidate.getMeta())
-                .evidences(toEvidenceJsonList(evidences))
+                .estimated(quality.estimated())
+                .qualityLabel(quality.estimated() ? "ESTIMATED" : "CONFIRMED")
+                .qualityReason(quality.reason())
+                .evidenceCount(evidenceJson.size())
+                .evidences(evidenceJson)
                 .build();
+    }
+
+    /**
+     * 근거가 약한 후보를 추정(ESTIMATED)으로 분리해,
+     * UI에서 사용자에게 신뢰도 상태를 명확히 보여주기 위한 판단 로직.
+     */
+    private CandidateQuality evaluateQuality(RuleCandidate candidate, List<RuleCandidateEvidence> evidences) {
+        int evidenceCount = evidences == null ? 0 : evidences.size();
+        int primaryEvidenceCount = countPrimaryEvidence(evidences);
+
+        boolean lowConfidence = candidate.getConfidence() == RuleCandidateConfidence.LOW;
+        boolean sparseEvidence = evidenceCount == 0 || (evidenceCount == 1 && primaryEvidenceCount == 0);
+        boolean lowScore = candidate.getScore() != null
+                && candidate.getScore().compareTo(LOW_SCORE_THRESHOLD) < 0;
+        boolean weakSupport = candidate.getSupportCount() == null || candidate.getSupportCount() <= 1;
+
+        if (lowConfidence) {
+            return new CandidateQuality(true, "LOW confidence");
+        }
+        if (sparseEvidence) {
+            return new CandidateQuality(true, "insufficient evidence links");
+        }
+        if (lowScore && weakSupport) {
+            return new CandidateQuality(true, "low score and weak support");
+        }
+        return new CandidateQuality(false, "sufficient evidence");
+    }
+
+    private int countPrimaryEvidence(List<RuleCandidateEvidence> evidences) {
+        if (evidences == null || evidences.isEmpty()) {
+            return 0;
+        }
+        return (int) evidences.stream()
+                .map(RuleCandidateEvidence::getRole)
+                .filter(role -> role != null && PRIMARY_EVIDENCE_ROLES.contains(role))
+                .count();
     }
 
     /**
@@ -267,5 +323,8 @@ public class RuleCandidateArtifactPublisher {
             int bounded = Math.max(0, Math.min(values.length - 1, index));
             return values[bounded];
         }
+    }
+
+    private record CandidateQuality(boolean estimated, String reason) {
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
@@ -4,6 +4,8 @@ import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.service.ArtifactService;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.rule.dto.json.RuleCandidateDisplayPolicyJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateEvidenceJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateItem;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateSummaryJson;
@@ -23,8 +25,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -32,11 +36,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RuleCandidateArtifactPublisher {
 
-    private static final String SCHEMA_VERSION = "1.0";
+    private static final String SCHEMA_VERSION = "1.1";
     private static final String RELATIVE_PATH = "rule/rule_candidates.json";
 
     private final RuleCandidateRepository ruleCandidateRepository;
     private final RuleCandidateEvidenceRepository ruleCandidateEvidenceRepository;
+    private final EdgeRepository edgeRepository;
     private final ArtifactService artifactService;
     private final ObjectMapper objectMapper;
 
@@ -62,11 +67,15 @@ public class RuleCandidateArtifactPublisher {
             items.add(toItem(candidate, evidences));
         }
 
+        long edgeCount = edgeRepository.countByRun_RunId(run.getRunId());
+        RuleCandidateDisplayPolicyJson displayPolicy = buildDisplayPolicy(candidateIds, edgeCount);
+
         RuleCandidatesJson output = RuleCandidatesJson.builder()
                 .schemaVersion(SCHEMA_VERSION)
                 .runId(run.getRunId())
                 .generatedAt(OffsetDateTime.now().toString())
                 .summary(summary)
+                .displayPolicy(displayPolicy)
                 .candidates(items)
                 .build();
 
@@ -81,10 +90,11 @@ public class RuleCandidateArtifactPublisher {
         );
 
         log.info(
-                "[RULE-MINING] rule_candidates.json published. runId={}, artifactId={}, candidates={}",
+                "[RULE-MINING] rule_candidates.json published. runId={}, artifactId={}, candidates={}, primary={}",
                 run.getRunId(),
                 artifact.getArtifactId(),
-                candidates.size()
+                candidates.size(),
+                displayPolicy.recommendedPrimaryCount()
         );
 
         return artifact;
@@ -153,6 +163,57 @@ public class RuleCandidateArtifactPublisher {
                 .build();
     }
 
+    /**
+     * 후보 노출량이 너무 많거나 적지 않도록 1차 화면 표시 정책을 계산한다.
+     */
+    private RuleCandidateDisplayPolicyJson buildDisplayPolicy(List<Long> orderedCandidateIds, long edgeCount) {
+        int total = orderedCandidateIds.size();
+        DisplayTier tier = resolveDisplayTier(total, edgeCount);
+
+        List<Long> primaryIds = new ArrayList<>();
+        for (Long candidateId : orderedCandidateIds) {
+            if (primaryIds.size() >= tier.targetMax()) {
+                break;
+            }
+            primaryIds.add(candidateId);
+        }
+
+        if (primaryIds.isEmpty() && !orderedCandidateIds.isEmpty()) {
+            primaryIds.add(orderedCandidateIds.get(0));
+        }
+
+        Set<Long> primaryIdSet = new HashSet<>(primaryIds);
+        List<Long> exploratoryIds = orderedCandidateIds.stream()
+                .filter(id -> !primaryIdSet.contains(id))
+                .toList();
+
+        return RuleCandidateDisplayPolicyJson.builder()
+                .sizeTier(tier.name())
+                .totalCandidates(total)
+                .targetMin(tier.targetMin())
+                .targetMax(tier.targetMax())
+                .recommendedPrimaryCount(primaryIds.size())
+                .primaryCandidateIds(primaryIds)
+                .exploratoryCandidateIds(exploratoryIds)
+                .build();
+    }
+
+    private DisplayTier resolveDisplayTier(int totalCandidates, long edgeCount) {
+        DisplayTier baseTier;
+        if (totalCandidates <= 40) {
+            baseTier = DisplayTier.SMALL;
+        } else if (totalCandidates <= 120) {
+            baseTier = DisplayTier.MEDIUM;
+        } else if (totalCandidates <= 260) {
+            baseTier = DisplayTier.LARGE;
+        } else {
+            baseTier = DisplayTier.XLARGE;
+        }
+
+        int boost = edgeCount >= 30_000 ? 2 : edgeCount >= 12_000 ? 1 : 0;
+        return DisplayTier.byIndex(baseTier.ordinal() + boost);
+    }
+
     private List<RuleCandidateEvidenceJson> toEvidenceJsonList(List<RuleCandidateEvidence> evidences) {
         if (evidences == null || evidences.isEmpty()) {
             return List.of();
@@ -177,5 +238,34 @@ public class RuleCandidateArtifactPublisher {
                 .snippet(evidence.getSnippet())
                 .note(evidence.getNote())
                 .build();
+    }
+
+    private enum DisplayTier {
+        SMALL(10, 14),
+        MEDIUM(14, 22),
+        LARGE(22, 35),
+        XLARGE(30, 45);
+
+        private final int targetMin;
+        private final int targetMax;
+
+        DisplayTier(int targetMin, int targetMax) {
+            this.targetMin = targetMin;
+            this.targetMax = targetMax;
+        }
+
+        int targetMin() {
+            return targetMin;
+        }
+
+        int targetMax() {
+            return targetMax;
+        }
+
+        static DisplayTier byIndex(int index) {
+            DisplayTier[] values = DisplayTier.values();
+            int bounded = Math.max(0, Math.min(values.length - 1, index));
+            return values[bounded];
+        }
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateMiningService.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateMiningService.java
@@ -1,12 +1,19 @@
 package com.example.ossdoc.domain.rule.service;
 
 import com.example.ossdoc.domain.artifact.entity.Artifact;
+import com.example.ossdoc.domain.graphstore.entity.Edge;
+import com.example.ossdoc.domain.graphstore.entity.Evidence;
+import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.graphstore.repository.EvidenceRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolRepository;
 import com.example.ossdoc.domain.rule.dto.request.RuleCandidateMineRequest;
 import com.example.ossdoc.domain.rule.dto.response.RuleCandidateMineResponse;
 import com.example.ossdoc.domain.rule.enums.RuleCandidateConfidence;
 import com.example.ossdoc.domain.rule.exception.RuleCandidateException;
 import com.example.ossdoc.domain.rule.exception.code.RuleCandidateErrorCode;
 import com.example.ossdoc.domain.rule.repository.RuleCandidateRepository;
+import com.example.ossdoc.domain.rule.repository.RuleMiningSignalRepository;
 import com.example.ossdoc.domain.rule.service.miner.RuleCandidateMiner;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
@@ -15,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
@@ -28,6 +36,10 @@ public class RuleCandidateMiningService {
     private final List<RuleCandidateMiner> miners;
     private final RuleCandidateRepository ruleCandidateRepository;
     private final RuleCandidateArtifactPublisher ruleCandidateArtifactPublisher;
+    private final RuleMiningSignalRepository ruleMiningSignalRepository;
+    private final EdgeRepository edgeRepository;
+    private final SymbolRepository symbolRepository;
+    private final EvidenceRepository evidenceRepository;
 
     @Transactional
     public RuleCandidateMineResponse mine(RuleCandidateMineRequest request, Long userId) {
@@ -38,10 +50,12 @@ public class RuleCandidateMiningService {
 
         validateRunOwner(run, userId);
 
+        boolean forceRebuildApplied = determineForceRebuild(run.getRunId(), request);
+
         RuleMiningSignalIngestService.RuleMiningSignalIngestResult ingestResult =
                 ruleMiningSignalIngestService.ingest(
                         request.runId(),
-                        request.isForceRebuild()
+                        forceRebuildApplied
                 );
 
         int minedCandidateCount = runMiners(run);
@@ -70,11 +84,13 @@ public class RuleCandidateMiningService {
                                 RuleCandidateConfidence.LOW
                         )
                 ))
+                .forceRebuildApplied(forceRebuildApplied)
                 .build();
 
         log.info(
-                "[RULE-MINING] mining completed. runId={}, skippedSignalIngest={}, signals={}, minedCandidates={}, artifactId={}",
+                "[RULE-MINING] mining completed. runId={}, forceRebuildApplied={}, skippedSignalIngest={}, signals={}, minedCandidates={}, artifactId={}",
                 run.getRunId(),
+                forceRebuildApplied,
                 ingestResult.skipped(),
                 ingestResult.totalSignals(),
                 minedCandidateCount,
@@ -93,6 +109,80 @@ public class RuleCandidateMiningService {
                 .sorted(Comparator.comparing(miner -> miner.supports().name()))
                 .mapToInt(miner -> miner.mine(run))
                 .sum();
+    }
+
+    /**
+     * forceRebuild 적용값을 결정한다.
+     * 1) 요청에 명시값이 있으면 사용자 의도를 우선한다.
+     * 2) 명시값이 없으면 그래프 최신성 비교 결과로 자동 결정한다.
+     */
+    private boolean determineForceRebuild(String runId, RuleCandidateMineRequest request) {
+        if (request.hasForceRebuildFlag()) {
+            return request.isForceRebuild();
+        }
+        return isGraphDataFresherThanSignals(runId);
+    }
+
+    /**
+     * 그래프 데이터(Edge/Symbol/Evidence)가 기존 룰 신호보다 최신이면
+     * 신호를 다시 구성하도록 true를 반환한다.
+     */
+    private boolean isGraphDataFresherThanSignals(String runId) {
+        LocalDateTime lastSignalCreatedAt = ruleMiningSignalRepository
+                .findTopByRun_RunIdOrderByCreatedAtDesc(runId)
+                .map(signal -> signal.getCreatedAt())
+                .orElse(null);
+
+        if (lastSignalCreatedAt == null) {
+            return false;
+        }
+
+        LocalDateTime lastGraphUpdatedAt = latestGraphDataTimestamp(runId);
+        if (lastGraphUpdatedAt == null) {
+            return false;
+        }
+
+        return lastGraphUpdatedAt.isAfter(lastSignalCreatedAt);
+    }
+
+    /**
+     * run 기준으로 그래프 관련 데이터의 최신 시각을 계산한다.
+     */
+    private LocalDateTime latestGraphDataTimestamp(String runId) {
+        LocalDateTime edgeUpdatedAt = edgeRepository.findTopByRun_RunIdOrderByUpdatedAtDesc(runId)
+                .map(this::edgeUpdatedAt)
+                .orElse(null);
+
+        LocalDateTime symbolUpdatedAt = symbolRepository.findTopByRun_RunIdOrderByUpdatedAtDesc(runId)
+                .map(SymbolEntity::getUpdatedAt)
+                .orElse(null);
+
+        LocalDateTime evidenceCreatedAt = evidenceRepository.findTopByRun_RunIdOrderByCreatedAtDesc(runId)
+                .map(Evidence::getCreatedAt)
+                .orElse(null);
+
+        return maxTimestamp(edgeUpdatedAt, symbolUpdatedAt, evidenceCreatedAt);
+    }
+
+    /**
+     * Edge는 updatedAt이 비어 있을 수 있어 createdAt으로 안전 폴백한다.
+     */
+    private LocalDateTime edgeUpdatedAt(Edge edge) {
+        if (edge == null) {
+            return null;
+        }
+        return edge.getUpdatedAt() != null ? edge.getUpdatedAt() : edge.getCreatedAt();
+    }
+
+    private LocalDateTime maxTimestamp(LocalDateTime first, LocalDateTime second, LocalDateTime third) {
+        LocalDateTime max = first;
+        if (second != null && (max == null || second.isAfter(max))) {
+            max = second;
+        }
+        if (third != null && (max == null || third.isAfter(max))) {
+            max = third;
+        }
+        return max;
     }
 
     private void validateRequest(RuleCandidateMineRequest request, Long userId) {


### PR DESCRIPTION
## 변경 배경
Rule Mining 결과를 그대로 노출하면 후보가 과다해 사용자 해석이 어렵고, 근거가 약한 후보와 확정 후보의 구분이 부족했습니다.  
또한 매번 재마이닝을 강제하면 응답 지연이 커져 파이프라인 체감 성능이 떨어지는 문제가 있었습니다.

## 변경 내용 (우선순위 3개 반영)

1. Rule Candidate 노출 정책(displayPolicy) 추가
- `rule_candidates.json`에 `displayPolicy`를 추가했습니다.
- 포함 필드:
  - `sizeTier`
  - `targetMin`, `targetMax`
  - `recommendedPrimaryCount`
  - `primaryCandidateIds`
  - `exploratoryCandidateIds`
- 후보 수 + 그래프 엣지 규모 기반으로 1차 노출량을 자동 계산하도록 반영했습니다.

2. 후보 품질 라벨(estimated/confirmed) 및 근거 기반 분류 추가
- 각 candidate에 아래 필드를 추가했습니다.
  - `estimated`
  - `qualityLabel` (`ESTIMATED` / `CONFIRMED`)
  - `qualityReason`
  - `evidenceCount`
- LOW confidence, 근거 부족, low score + weak support 조건을 기반으로 추정 후보를 분리했습니다.
- 프론트에서 “확정 정보 vs 추정 정보”를 명확히 구분해 노출할 수 있습니다.

3. forceRebuild 조건부 적용 + 최신성 기반 자동 판단
- `forceRebuild`를 nullable로 받고, 요청 본문 명시 여부를 구분하도록 변경했습니다.
- 요청에서 명시하지 않은 경우:
  - 그래프 데이터(edge/symbol/evidence)가 기존 signal보다 최신일 때만 재구축
  - 그렇지 않으면 기존 signal 재사용
- 응답에 `forceRebuildApplied`를 포함해 실제 적용 여부를 반환합니다.

## 기대 효과
- 과다 출력 완화: 기본 노출 대상 자동 축소로 가독성 개선
- 신뢰도 개선: 추정/확정 분리로 사용자 오해 감소
- 성능 개선: 불필요한 재마이닝 감소로 평균 응답시간 단축
