### PR TITLE
Refactor/#57 LLM 입력 산출물 보강 및 fileTree/coreMethods 설명 품질 안정화

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/enums/ArtifactKind.java
@@ -9,6 +9,7 @@ public enum ArtifactKind {
 
     // Rule Candidate Mining 결과물
     RULE_CANDIDATES_JSON,
+    SYMBOL_SOURCE_INDEX_JSON,
 
     // LLM 정제 결과물
     LLM_REFINED_RULES,

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedNode.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ProjectedNode.java
@@ -2,16 +2,26 @@ package com.example.ossdoc.domain.cluster.model;
 
 import lombok.Builder;
 import lombok.Getter;
-/* ProjectedNode.java : 군집화 알고리즘에 넣기 전, DB에 SymbolEntity를 군집화용으로 변환한 노드
-* 즉, 군집화에 필요한 최소 정보만 들고 있는 가벼운 객체
-* */
+
+/*
+ * ProjectedNode:
+ * - 그래프/랭킹 계산에 필요한 SymbolEntity 핵심 정보를 담는 경량 투영 객체.
+ * - rankings.json 보강을 위해 symbol kind, owner, source span 메타를 함께 운반한다.
+ */
 @Getter
 @Builder
 public class ProjectedNode {
     private String symbolId;
-    private String qualifiedName; //rankingJson 생성에 필요
+    private String qualifiedName; // rankingJson 생성 시 표시 이름
     private String simpleName;
-    private String packageName; //subsystem 이름
-    private String moduleId; //같은 모듈끼리 묶을때 필요
-    private boolean publicApi; //entry symbol 판단
+    private String packageName; // subsystem 라벨링 단위
+    private String moduleId; // 동일 모듈 묶음 계산 시 사용
+    private boolean publicApi; // entry symbol 가중치 판단
+
+    // rankings.json 보강용 메타데이터
+    private String symbolKind;
+    private String ownerSymbol;
+    private String sourceFile;
+    private Integer sourceStartLine;
+    private Integer sourceEndLine;
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SymbolRankingItem.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/model/ranking/SymbolRankingItem.java
@@ -1,10 +1,13 @@
 package com.example.ossdoc.domain.cluster.model.ranking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SymbolRankingItem {
     private int rank;
     private String symbolId;
@@ -16,4 +19,31 @@ public class SymbolRankingItem {
     private double apiScore;
     private double evidenceScore;
     private double subsystemCentralityScore;
+
+    /*
+     * rankings.json 보강 필드:
+     * - LLM이 "어디를 설명하는지" 추적할 수 있도록 심볼 종류/소유자/소스 위치를 포함한다.
+     */
+    @JsonProperty("symbol_kind")
+    private String symbolKind;
+
+    @JsonProperty("owner_symbol")
+    private String ownerSymbol;
+
+    @JsonProperty("source_file")
+    private String sourceFile;
+
+    @JsonProperty("line_range")
+    private LineRange lineRange;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class LineRange {
+        @JsonProperty("start_line")
+        private Integer startLine;
+
+        @JsonProperty("end_line")
+        private Integer endLine;
+    }
 }

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/GraphProjectionService.java
@@ -70,6 +70,12 @@ public class GraphProjectionService {
                     .packageName(packageName)
                     .moduleId(symbol.getModule() == null ? null : symbol.getModule().getModuleId())
                     .publicApi(publicApiSymbolIds.contains(symbol.getSymbolId()))
+                    // rankings.json에서 "설명 가능한 위치"를 만들기 위한 메타데이터를 함께 투영한다.
+                    .symbolKind(symbol.getSymbolKind() == null ? null : symbol.getSymbolKind().name())
+                    .ownerSymbol(symbol.getOwner() == null ? null : symbol.getOwner().getQualifiedName())
+                    .sourceFile(symbol.getSourceFile() == null ? null : symbol.getSourceFile().getPath())
+                    .sourceStartLine(symbol.getSourceStartLine())
+                    .sourceEndLine(symbol.getSourceEndLine())
                     .build());
 
             nodeIndexMap.put(symbol.getSymbolId(), i);

--- a/src/main/java/com/example/ossdoc/domain/cluster/service/SymbolScoringService.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/service/SymbolScoringService.java
@@ -63,6 +63,11 @@ public class SymbolScoringService {
                     .apiScore(api)
                     .evidenceScore(evidence)
                     .subsystemCentralityScore(subsystemCentrality)
+                    // rankings.json에 위치 기반 설명 앵커를 실어준다.
+                    .symbolKind(node.getSymbolKind())
+                    .ownerSymbol(node.getOwnerSymbol())
+                    .sourceFile(node.getSourceFile())
+                    .lineRange(buildLineRange(node.getSourceStartLine(), node.getSourceEndLine()))
                     .build());
         }
 
@@ -89,9 +94,23 @@ public class SymbolScoringService {
                     .apiScore(item.getApiScore())
                     .evidenceScore(item.getEvidenceScore())
                     .subsystemCentralityScore(item.getSubsystemCentralityScore())
+                    .symbolKind(item.getSymbolKind())
+                    .ownerSymbol(item.getOwnerSymbol())
+                    .sourceFile(item.getSourceFile())
+                    .lineRange(item.getLineRange())
                     .build());
         }
         return ranked;
+    }
+
+    private SymbolRankingItem.LineRange buildLineRange(Integer startLine, Integer endLine) {
+        if (startLine == null && endLine == null) {
+            return null;
+        }
+        return SymbolRankingItem.LineRange.builder()
+                .startLine(startLine)
+                .endLine(endLine)
+                .build();
     }
 
     /**

--- a/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/graphstore/repository/SymbolRepository.java
@@ -3,6 +3,8 @@ package com.example.ossdoc.domain.graphstore.repository;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
 import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,18 @@ public interface SymbolRepository extends JpaRepository<SymbolEntity, String> {
     List<SymbolEntity> findAllByRun_RunId(String runId);
 
     List<SymbolEntity> findAllByRun_RunIdAndSymbolKind(String runId, SymbolKind symbolkind);
+
+    /**
+     * symbol_source_index 생성 시 owner/sourceFile 접근 N+1을 줄이기 위한 fetch 조회.
+     */
+    @Query("""
+            select s
+            from SymbolEntity s
+            left join fetch s.owner
+            left join fetch s.sourceFile
+            where s.run.runId = :runId
+            """)
+    List<SymbolEntity> findAllWithOwnerAndSourceByRunId(@Param("runId") String runId);
 
     /**
      * 군집화 투영 단계에서 노드 인덱스를 재현 가능하게 만들기 위해 정렬된 순서로 조회한다.

--- a/src/main/java/com/example/ossdoc/domain/publicapi/model/EntryPointCandidate.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/model/EntryPointCandidate.java
@@ -10,8 +10,22 @@ import java.util.List;
 public class EntryPointCandidate {
     private String symbolId;
     private String qualifiedName;
+    /**
+     * owner_type_fqn:
+     * - 현재 entry point는 TYPE 단위라 기본적으로 자기 자신 FQN을 owner로 둔다.
+     * - 향후 method 단위 entry 확장 시 owner type 앵커로 그대로 재사용한다.
+     */
+    private String ownerTypeFqn;
     private String simpleName;
     private String typeKind;           // "class" | "interface" | "enum" | "record"
+    /**
+     * LLM 파일 트리/코드 위치 앵커용 메타데이터.
+     * - sourceFile: 소스 파일 상대 경로
+     * - startLine/endLine: 심볼 선언 라인 범위
+     */
+    private String sourceFile;
+    private Integer startLine;
+    private Integer endLine;
     private String subsystemId;
     private String subsystemLabel;
     private String role;               // "PRIMARY" | "SECONDARY"

--- a/src/main/java/com/example/ossdoc/domain/publicapi/model/ExtensionPointCandidate.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/model/ExtensionPointCandidate.java
@@ -10,8 +10,20 @@ import java.util.List;
 public class ExtensionPointCandidate {
     private String symbolId;
     private String qualifiedName;
+    /**
+     * owner_type_fqn:
+     * - extension point는 TYPE 중심 결과이므로 기본 owner는 자기 자신 FQN.
+     * - 파일 트리/메서드 설명 조합 시 type 앵커로 사용한다.
+     */
+    private String ownerTypeFqn;
     private String simpleName;
     private String typeKind;               // "interface" | "abstract"
+    /**
+     * LLM 출력 품질 보강을 위한 코드 위치 메타.
+     */
+    private String sourceFile;
+    private Integer startLine;
+    private Integer endLine;
     private String subsystemId;
     private String subsystemLabel;
     private int linkedImplementorCount;

--- a/src/main/java/com/example/ossdoc/domain/publicapi/service/ApiMapBuildService.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/service/ApiMapBuildService.java
@@ -97,6 +97,15 @@ public class ApiMapBuildService {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("symbol_id",      ep.getSymbolId());
             node.put("qualified_name", ep.getQualifiedName());
+            /**
+             * LLM 앵커 필드:
+             * - owner_type_fqn: 클래스/메서드 설명 트리 병합 기준 키
+             * - source_file/start_line/end_line: 코드 위치 기반 설명 생성의 최소 단위
+             */
+            putNullable(node, "owner_type_fqn", ep.getOwnerTypeFqn());
+            putNullable(node, "source_file", ep.getSourceFile());
+            putNullableInt(node, "start_line", ep.getStartLine());
+            putNullableInt(node, "end_line", ep.getEndLine());
             node.put("simple_name",    ep.getSimpleName());
             node.put("type_kind",      ep.getTypeKind());
             node.put("role",           ep.getRole());
@@ -114,6 +123,10 @@ public class ApiMapBuildService {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("symbol_id",               xp.getSymbolId());
             node.put("qualified_name",           xp.getQualifiedName());
+            putNullable(node, "owner_type_fqn", xp.getOwnerTypeFqn());
+            putNullable(node, "source_file", xp.getSourceFile());
+            putNullableInt(node, "start_line", xp.getStartLine());
+            putNullableInt(node, "end_line", xp.getEndLine());
             node.put("simple_name",              xp.getSimpleName());
             node.put("type_kind",                xp.getTypeKind());
             node.put("confidence",               xp.getConfidence());
@@ -154,6 +167,11 @@ public class ApiMapBuildService {
         for (EntryPointCandidate ep : entryPoints) {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("symbol_id",  ep.getSymbolId());
+            node.put("qualified_name", ep.getQualifiedName());
+            putNullable(node, "owner_type_fqn", ep.getOwnerTypeFqn());
+            putNullable(node, "source_file", ep.getSourceFile());
+            putNullableInt(node, "start_line", ep.getStartLine());
+            putNullableInt(node, "end_line", ep.getEndLine());
             node.put("simple_name", ep.getSimpleName());
             node.put("type_kind",  ep.getTypeKind());
             node.put("role",       ep.getRole());
@@ -167,6 +185,11 @@ public class ApiMapBuildService {
         for (ExtensionPointCandidate xp : extensionPoints) {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("symbol_id",  xp.getSymbolId());
+            node.put("qualified_name", xp.getQualifiedName());
+            putNullable(node, "owner_type_fqn", xp.getOwnerTypeFqn());
+            putNullable(node, "source_file", xp.getSourceFile());
+            putNullableInt(node, "start_line", xp.getStartLine());
+            putNullableInt(node, "end_line", xp.getEndLine());
             node.put("simple_name", xp.getSimpleName());
             node.put("type_kind",  xp.getTypeKind());
             node.put("confidence", xp.getConfidence());
@@ -208,6 +231,14 @@ public class ApiMapBuildService {
     }
 
     private void putNullable(ObjectNode node, String key, String value) {
+        if (value == null || value.isBlank()) {
+            node.putNull(key);
+            return;
+        }
+        node.put(key, value);
+    }
+
+    private void putNullableInt(ObjectNode node, String key, Integer value) {
         if (value != null) {
             node.put(key, value);
         } else {

--- a/src/main/java/com/example/ossdoc/domain/publicapi/service/EntryPointDetectService.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/service/EntryPointDetectService.java
@@ -104,8 +104,12 @@ public class EntryPointDetectService {
             candidates.add(EntryPointCandidate.builder()
                     .symbolId(symbol.getSymbolId())
                     .qualifiedName(symbol.getQualifiedName())
+                    .ownerTypeFqn(resolveOwnerTypeFqn(symbol))
                     .simpleName(symbol.getSimpleName())
                     .typeKind(resolveTypeKind(symbol))
+                    .sourceFile(resolveSourceFilePath(symbol))
+                    .startLine(symbol.getSourceStartLine())
+                    .endLine(symbol.getSourceEndLine())
                     .subsystemId(subsystemId)
                     .subsystemLabel(subsystemLabel)
                     .role(result.role())
@@ -569,6 +573,25 @@ public class EntryPointDetectService {
         String javadoc = sig.path("javadoc").asText("").toLowerCase(Locale.ROOT);
         if (javadoc.isBlank()) return false;
         return JAVADOC_KEYWORDS.stream().anyMatch(javadoc::contains);
+    }
+
+    /**
+     * api_map / api_surface의 owner_type_fqn 앵커를 결정한다.
+     * - TYPE 단위 후보는 자기 자신의 FQN이 owner 역할을 수행한다.
+     */
+    private String resolveOwnerTypeFqn(SymbolEntity symbol) {
+        return symbol.getQualifiedName();
+    }
+
+    /**
+     * LLM이 파일 트리/근거 위치를 잃지 않도록 source_file 메타를 채운다.
+     * - sourceFile 연관이 없으면 빈 문자열로 내려서 null 분기 비용을 줄인다.
+     */
+    private String resolveSourceFilePath(SymbolEntity symbol) {
+        if (symbol.getSourceFile() == null || symbol.getSourceFile().getPath() == null) {
+            return "";
+        }
+        return symbol.getSourceFile().getPath();
     }
 
     private String extractSimpleName(String qualifiedOrSymbol) {

--- a/src/main/java/com/example/ossdoc/domain/publicapi/service/ExtensionPointDetectService.java
+++ b/src/main/java/com/example/ossdoc/domain/publicapi/service/ExtensionPointDetectService.java
@@ -142,8 +142,12 @@ public class ExtensionPointDetectService {
             candidates.add(ExtensionPointCandidate.builder()
                     .symbolId(symbol.getSymbolId())
                     .qualifiedName(symbol.getQualifiedName())
+                    .ownerTypeFqn(resolveOwnerTypeFqn(symbol))
                     .simpleName(symbol.getSimpleName())
                     .typeKind(typeKind)
+                    .sourceFile(resolveSourceFilePath(symbol))
+                    .startLine(symbol.getSourceStartLine())
+                    .endLine(symbol.getSourceEndLine())
                     .subsystemId(subsystemId)
                     .subsystemLabel(subsystemLabel)
                     .linkedImplementorCount(implementorCount)
@@ -620,6 +624,24 @@ public class ExtensionPointDetectService {
         if (symbol == null) return "";
         int colon = symbol.indexOf(':');
         return colon >= 0 ? symbol.substring(colon + 1) : symbol;
+    }
+
+    /**
+     * extension point 결과의 owner_type_fqn 앵커를 계산한다.
+     * - TYPE 중심 결과에서는 자기 자신의 qualifiedName을 owner로 사용한다.
+     */
+    private String resolveOwnerTypeFqn(SymbolEntity symbol) {
+        return symbol.getQualifiedName();
+    }
+
+    /**
+     * 파일 트리 문서 생성을 위해 타입의 소스 파일 경로를 전달한다.
+     */
+    private String resolveSourceFilePath(SymbolEntity symbol) {
+        if (symbol.getSourceFile() == null || symbol.getSourceFile().getPath() == null) {
+            return "";
+        }
+        return symbol.getSourceFile().getPath();
     }
 
     private String extractSimpleName(String qualifiedOrSymbol) {

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidatesJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleCandidatesJson.java
@@ -5,12 +5,18 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
+/*
+ * RuleCandidatesJson:
+ * - 기존 candidates(규칙 후보 목록)와 함께 methodCards(메서드 기능 카드)를 함께 제공한다.
+ * - 프론트/LLM이 "규칙 후보 중심 보기"와 "메서드 기능 설명 보기"를 동시에 구성할 수 있게 한다.
+ */
 public record RuleCandidatesJson(
         String schemaVersion,
         String runId,
         String generatedAt,
         RuleCandidateSummaryJson summary,
         RuleCandidateDisplayPolicyJson displayPolicy,
+        List<RuleMethodCardJson> methodCards,
         List<RuleCandidateItem> candidates
 ) {
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleMethodCardJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/RuleMethodCardJson.java
@@ -1,0 +1,55 @@
+package com.example.ossdoc.domain.rule.dto.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+/*
+ * RuleMethodCardJson:
+ * - rule_candidates.json의 method_cards 섹션 항목.
+ * - "메서드 기능 설명"을 위한 최소 단서(method_fqn/source_file/summary_hint)를 담는다.
+ */
+public record RuleMethodCardJson(
+        @JsonProperty("method_fqn")
+        String methodFqn,
+
+        @JsonProperty("method_symbol_id")
+        String methodSymbolId,
+
+        @JsonProperty("class_fqn")
+        String classFqn,
+
+        @JsonProperty("method_name")
+        String methodName,
+
+        @JsonProperty("source_file")
+        String sourceFile,
+
+        @JsonProperty("start_line")
+        Integer startLine,
+
+        @JsonProperty("end_line")
+        Integer endLine,
+
+        @JsonProperty("summary_hint")
+        String summaryHint,
+
+        @JsonProperty("scenario_hint")
+        String scenarioHint,
+
+        @JsonProperty("importance")
+        Integer importance,
+
+        @JsonProperty("signal_count")
+        Integer signalCount,
+
+        @JsonProperty("signal_types")
+        List<String> signalTypes,
+
+        @JsonProperty("avg_confidence_hint")
+        BigDecimal avgConfidenceHint
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/SymbolSourceIndexItemJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/SymbolSourceIndexItemJson.java
@@ -1,0 +1,43 @@
+package com.example.ossdoc.domain.rule.dto.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+/*
+ * SymbolSourceIndexItemJson:
+ * - symbol_source_index.json의 단일 심볼 앵커 정보.
+ * - LLM이 심볼 설명 시 "어디 코드인지" 추적할 수 있는 최소 필드를 담는다.
+ */
+public record SymbolSourceIndexItemJson(
+        @JsonProperty("symbol_id")
+        String symbolId,
+
+        @JsonProperty("fqn")
+        String fqn,
+
+        @JsonProperty("symbol_kind")
+        String symbolKind,
+
+        @JsonProperty("owner_type_fqn")
+        String ownerTypeFqn,
+
+        @JsonProperty("source_file")
+        String sourceFile,
+
+        @JsonProperty("start_line")
+        Integer startLine,
+
+        @JsonProperty("end_line")
+        Integer endLine,
+
+        @JsonProperty("evidence_ids")
+        List<Long> evidenceIds,
+
+        @JsonProperty("confidence")
+        BigDecimal confidence
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/rule/dto/json/SymbolSourceIndexJson.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/dto/json/SymbolSourceIndexJson.java
@@ -1,0 +1,20 @@
+package com.example.ossdoc.domain.rule.dto.json;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+/*
+ * SymbolSourceIndexJson:
+ * - symbol_id를 키로 코드 위치/근거 연결 정보를 제공하는 브릿지 산출물.
+ * - LLM 입력 조립에서 파일/라인 앵커 보강용으로 사용한다.
+ */
+public record SymbolSourceIndexJson(
+        String schemaVersion,
+        String runId,
+        String generatedAt,
+        Integer symbolCount,
+        List<SymbolSourceIndexItemJson> symbols
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/rule/repository/RuleMiningSignalRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/repository/RuleMiningSignalRepository.java
@@ -2,6 +2,8 @@ package com.example.ossdoc.domain.rule.repository;
 
 import com.example.ossdoc.domain.rule.entity.RuleMiningSignal;
 import com.example.ossdoc.domain.rule.enums.RuleMiningSignalType;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
@@ -45,6 +47,19 @@ public interface RuleMiningSignalRepository extends JpaRepository<RuleMiningSign
      * run 범위에서 가장 최근에 생성된 룰 신호 1건을 조회한다.
      */
     Optional<RuleMiningSignal> findTopByRun_RunIdOrderByCreatedAtDesc(String runId);
+
+    /**
+     * 메서드 기능 카드 생성을 위해 signal + symbol + sourceFile을 한 번에 로드한다.
+     */
+    @Query("""
+            select s
+            from RuleMiningSignal s
+            left join fetch s.symbol sym
+            left join fetch sym.sourceFile sf
+            where s.run.runId = :runId
+              and s.symbol is not null
+            """)
+    List<RuleMiningSignal> findAllWithSymbolAndSourceByRunId(@Param("runId") String runId);
 
     void deleteAllByRun_RunId(String runId);
 }

--- a/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
@@ -6,16 +6,21 @@ import com.example.ossdoc.domain.artifact.service.ArtifactService;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
 import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
 import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolEvidenceRepository;
+import com.example.ossdoc.domain.graphstore.repository.SymbolRepository;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateDisplayPolicyJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateEvidenceJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateItem;
 import com.example.ossdoc.domain.rule.dto.json.RuleMethodCardJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateSummaryJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidatesJson;
+import com.example.ossdoc.domain.rule.dto.json.SymbolSourceIndexItemJson;
+import com.example.ossdoc.domain.rule.dto.json.SymbolSourceIndexJson;
 import com.example.ossdoc.domain.rule.entity.RuleCandidate;
 import com.example.ossdoc.domain.rule.entity.RuleCandidateEvidence;
 import com.example.ossdoc.domain.rule.entity.RuleMiningSignal;
 import com.example.ossdoc.domain.rule.enums.RuleCandidateConfidence;
+import com.example.ossdoc.domain.rule.enums.RuleMiningSignalType;
 import com.example.ossdoc.domain.rule.repository.RuleCandidateEvidenceRepository;
 import com.example.ossdoc.domain.rule.repository.RuleCandidateRepository;
 import com.example.ossdoc.domain.rule.repository.RuleMiningSignalRepository;
@@ -46,6 +51,8 @@ public class RuleCandidateArtifactPublisher {
 
     private static final String SCHEMA_VERSION = "1.3";
     private static final String RELATIVE_PATH = "rule/rule_candidates.json";
+    private static final String SOURCE_INDEX_SCHEMA_VERSION = "1.0";
+    private static final String SOURCE_INDEX_RELATIVE_PATH = "analysis/symbol_source_index.json";
     private static final BigDecimal LOW_SCORE_THRESHOLD = new BigDecimal("0.6000");
     private static final int MAX_METHOD_CARDS = 80;
 
@@ -64,6 +71,8 @@ public class RuleCandidateArtifactPublisher {
     private final RuleCandidateRepository ruleCandidateRepository;
     private final RuleCandidateEvidenceRepository ruleCandidateEvidenceRepository;
     private final RuleMiningSignalRepository ruleMiningSignalRepository;
+    private final SymbolRepository symbolRepository;
+    private final SymbolEvidenceRepository symbolEvidenceRepository;
     private final EdgeRepository edgeRepository;
     private final ArtifactService artifactService;
     private final ObjectMapper objectMapper;
@@ -120,6 +129,20 @@ public class RuleCandidateArtifactPublisher {
                 content
         );
 
+        /*
+         * 우선순위 4: 심볼-소스 브릿지 인덱스를 함께 발행한다.
+         * - 실패해도 RULE 산출물 자체는 유지해 파이프라인 안정성을 지킨다.
+         */
+        try {
+            publishSymbolSourceIndex(run);
+        } catch (Exception e) {
+            log.warn(
+                    "[RULE-MINING] symbol_source_index publish failed. runId={}",
+                    run.getRunId(),
+                    e
+            );
+        }
+
         log.info(
                 "[RULE-MINING] rule_candidates.json published. runId={}, artifactId={}, candidates={}, methodCards={}, primary={}",
                 run.getRunId(),
@@ -130,6 +153,155 @@ public class RuleCandidateArtifactPublisher {
         );
 
         return artifact;
+    }
+
+    /**
+     * 우선순위 4 브릿지 산출물(symbol_source_index.json)을 생성/저장한다.
+     *
+     * - symbol_id 기준으로 fqn/소스 위치/근거 ID/evidence confidence를 한 번에 조회 가능하게 만든다.
+     * - LLM 입력 조립에서 api_map/rankings 누락 앵커를 보강하는 기반 데이터로 사용된다.
+     */
+    private void publishSymbolSourceIndex(RepoRun run) {
+        String runId = run.getRunId();
+        List<SymbolEntity> symbols = symbolRepository.findAllWithOwnerAndSourceByRunId(runId);
+        if (symbols == null || symbols.isEmpty()) {
+            return;
+        }
+
+        Map<String, SymbolCoverageAggregate> aggregateBySymbolId = new HashMap<>();
+        for (SymbolEntity symbol : symbols) {
+            if (symbol == null || symbol.getSymbolId() == null || symbol.getSymbolId().isBlank()) {
+                continue;
+            }
+            aggregateBySymbolId.put(symbol.getSymbolId(), new SymbolCoverageAggregate(symbol));
+        }
+        if (aggregateBySymbolId.isEmpty()) {
+            return;
+        }
+
+        // 1) symbol_evidence 기준으로 evidence id와 라인 범위를 누적한다.
+        List<com.example.ossdoc.domain.graphstore.entity.SymbolEvidence> symbolEvidences =
+                symbolEvidenceRepository.findAllWithEvidenceByRunId(runId);
+        for (com.example.ossdoc.domain.graphstore.entity.SymbolEvidence symbolEvidence : symbolEvidences) {
+            if (symbolEvidence == null || symbolEvidence.getSymbol() == null) {
+                continue;
+            }
+            SymbolCoverageAggregate aggregate =
+                    aggregateBySymbolId.get(symbolEvidence.getSymbol().getSymbolId());
+            if (aggregate == null || symbolEvidence.getEvidence() == null) {
+                continue;
+            }
+            aggregate.addEvidenceId(symbolEvidence.getEvidence().getEvidenceId());
+            aggregate.addLineRange(
+                    symbolEvidence.getEvidence().getStartLine(),
+                    symbolEvidence.getEvidence().getEndLine()
+            );
+        }
+
+        // 2) signal 기준으로 confidence 힌트와 보조 라인 범위를 누적한다.
+        List<RuleMiningSignal> signals = ruleMiningSignalRepository.findAllWithSymbolAndSourceByRunId(runId);
+        for (RuleMiningSignal signal : signals) {
+            if (signal == null || signal.getSymbol() == null) {
+                continue;
+            }
+            SymbolCoverageAggregate aggregate = aggregateBySymbolId.get(signal.getSymbol().getSymbolId());
+            if (aggregate == null) {
+                continue;
+            }
+            aggregate.addSignalType(signal.getSignalType());
+            aggregate.addSignalConfidence(signal.getConfidenceHint());
+            aggregate.addLineRange(signal.getStartLine(), signal.getEndLine());
+
+            if (signal.getEvidence() != null) {
+                aggregate.addEvidenceId(signal.getEvidence().getEvidenceId());
+                aggregate.addLineRange(
+                        signal.getEvidence().getStartLine(),
+                        signal.getEvidence().getEndLine()
+                );
+            }
+        }
+
+        List<SymbolSourceIndexItemJson> items = new ArrayList<>();
+        for (SymbolCoverageAggregate aggregate : aggregateBySymbolId.values()) {
+            SymbolEntity symbol = aggregate.symbol();
+            String fqn = safeText(symbol.getQualifiedName());
+            if (fqn.isBlank()) {
+                continue;
+            }
+
+            String sourceFile = symbol.getSourceFile() == null ? "" : safeText(symbol.getSourceFile().getPath());
+            Integer startLine = firstNonNull(symbol.getSourceStartLine(), aggregate.minStartLine());
+            Integer endLine = firstNonNull(symbol.getSourceEndLine(), aggregate.maxEndLine());
+
+            items.add(SymbolSourceIndexItemJson.builder()
+                    .symbolId(symbol.getSymbolId())
+                    .fqn(fqn)
+                    .symbolKind(symbol.getSymbolKind() == null ? "" : symbol.getSymbolKind().name())
+                    .ownerTypeFqn(resolveOwnerTypeFqn(symbol))
+                    .sourceFile(sourceFile)
+                    .startLine(startLine)
+                    .endLine(endLine)
+                    .evidenceIds(aggregate.sortedEvidenceIds())
+                    .confidence(aggregate.toConfidenceScore(sourceFile, startLine, endLine))
+                    .build());
+        }
+
+        items.sort(Comparator
+                .comparing(SymbolSourceIndexItemJson::fqn, Comparator.nullsLast(String::compareTo))
+                .thenComparing(SymbolSourceIndexItemJson::symbolId, Comparator.nullsLast(String::compareTo)));
+
+        SymbolSourceIndexJson output = SymbolSourceIndexJson.builder()
+                .schemaVersion(SOURCE_INDEX_SCHEMA_VERSION)
+                .runId(runId)
+                .generatedAt(OffsetDateTime.now().toString())
+                .symbolCount(items.size())
+                .symbols(List.copyOf(items))
+                .build();
+
+        artifactService.saveJsonArtifact(
+                run,
+                ArtifactKind.SYMBOL_SOURCE_INDEX_JSON,
+                SOURCE_INDEX_SCHEMA_VERSION,
+                SOURCE_INDEX_RELATIVE_PATH,
+                objectMapper.valueToTree(output)
+        );
+    }
+
+    /**
+     * owner 체인을 따라가며 가장 가까운 TYPE 심볼 FQN을 찾는다.
+     */
+    private String resolveOwnerTypeFqn(SymbolEntity symbol) {
+        if (symbol == null) {
+            return "";
+        }
+        if (symbol.getSymbolKind() == SymbolKind.TYPE) {
+            return safeText(symbol.getQualifiedName());
+        }
+
+        SymbolEntity cursor = symbol.getOwner();
+        while (cursor != null) {
+            if (cursor.getSymbolKind() == SymbolKind.TYPE) {
+                return safeText(cursor.getQualifiedName());
+            }
+            cursor = cursor.getOwner();
+        }
+        return "";
+    }
+
+    private String safeText(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private Integer firstNonNull(Integer... values) {
+        if (values == null) {
+            return null;
+        }
+        for (Integer value : values) {
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 
     /**
@@ -698,6 +870,107 @@ public class RuleCandidateArtifactPublisher {
                 return null;
             }
             return confidenceSum.divide(BigDecimal.valueOf(confidenceCount), 4, RoundingMode.HALF_UP);
+        }
+    }
+
+    /**
+     * symbol_source_index 한 행을 만들기 위한 중간 집계 객체.
+     */
+    private static class SymbolCoverageAggregate {
+        private final SymbolEntity symbol;
+        private final Set<Long> evidenceIds = new HashSet<>();
+        private final Set<RuleMiningSignalType> signalTypes = new HashSet<>();
+        private BigDecimal confidenceHintSum = BigDecimal.ZERO;
+        private int confidenceHintCount = 0;
+        private Integer minStartLine;
+        private Integer maxEndLine;
+
+        private SymbolCoverageAggregate(SymbolEntity symbol) {
+            this.symbol = symbol;
+        }
+
+        private SymbolEntity symbol() {
+            return symbol;
+        }
+
+        private void addEvidenceId(Long evidenceId) {
+            if (evidenceId != null) {
+                evidenceIds.add(evidenceId);
+            }
+        }
+
+        private void addSignalType(RuleMiningSignalType signalType) {
+            if (signalType != null) {
+                signalTypes.add(signalType);
+            }
+        }
+
+        private void addSignalConfidence(BigDecimal hint) {
+            if (hint == null) {
+                return;
+            }
+            confidenceHintSum = confidenceHintSum.add(hint);
+            confidenceHintCount++;
+        }
+
+        private void addLineRange(Integer startLine, Integer endLine) {
+            if (startLine != null) {
+                minStartLine = minStartLine == null ? startLine : Math.min(minStartLine, startLine);
+            }
+            if (endLine != null) {
+                maxEndLine = maxEndLine == null ? endLine : Math.max(maxEndLine, endLine);
+            }
+        }
+
+        private Integer minStartLine() {
+            return minStartLine;
+        }
+
+        private Integer maxEndLine() {
+            return maxEndLine;
+        }
+
+        private List<Long> sortedEvidenceIds() {
+            return evidenceIds.stream().sorted().toList();
+        }
+
+        /**
+         * 근거 커버리지 + signal confidence를 결합해 0~1 confidence를 계산한다.
+         */
+        private BigDecimal toConfidenceScore(String sourceFile, Integer startLine, Integer endLine) {
+            BigDecimal score = new BigDecimal("0.10");
+
+            boolean hasFile = sourceFile != null && !sourceFile.isBlank();
+            boolean hasSpan = startLine != null && endLine != null;
+            if (hasFile && hasSpan) {
+                score = score.add(new BigDecimal("0.35"));
+            } else if (hasFile) {
+                score = score.add(new BigDecimal("0.20"));
+            }
+
+            int evidenceCount = evidenceIds.size();
+            if (evidenceCount > 0) {
+                score = score.add(new BigDecimal(Math.min(0.30d, evidenceCount * 0.03d)));
+            }
+
+            if (confidenceHintCount > 0) {
+                BigDecimal avgHint = confidenceHintSum.divide(
+                        BigDecimal.valueOf(confidenceHintCount),
+                        4,
+                        RoundingMode.HALF_UP
+                );
+                score = score.add(avgHint.multiply(new BigDecimal("0.30")));
+            } else if (!signalTypes.isEmpty()) {
+                score = score.add(new BigDecimal("0.10"));
+            }
+
+            if (score.compareTo(BigDecimal.ONE) > 0) {
+                score = BigDecimal.ONE;
+            }
+            if (score.compareTo(new BigDecimal("0.05")) < 0) {
+                score = new BigDecimal("0.05");
+            }
+            return score.setScale(4, RoundingMode.HALF_UP);
         }
     }
 

--- a/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
+++ b/src/main/java/com/example/ossdoc/domain/rule/service/RuleCandidateArtifactPublisher.java
@@ -4,17 +4,21 @@ import com.example.ossdoc.domain.artifact.entity.Artifact;
 import com.example.ossdoc.domain.artifact.enums.ArtifactKind;
 import com.example.ossdoc.domain.artifact.service.ArtifactService;
 import com.example.ossdoc.domain.graphstore.entity.SymbolEntity;
+import com.example.ossdoc.domain.graphstore.enums.SymbolKind;
 import com.example.ossdoc.domain.graphstore.repository.EdgeRepository;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateDisplayPolicyJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateEvidenceJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateItem;
+import com.example.ossdoc.domain.rule.dto.json.RuleMethodCardJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidateSummaryJson;
 import com.example.ossdoc.domain.rule.dto.json.RuleCandidatesJson;
 import com.example.ossdoc.domain.rule.entity.RuleCandidate;
 import com.example.ossdoc.domain.rule.entity.RuleCandidateEvidence;
+import com.example.ossdoc.domain.rule.entity.RuleMiningSignal;
 import com.example.ossdoc.domain.rule.enums.RuleCandidateConfidence;
 import com.example.ossdoc.domain.rule.repository.RuleCandidateEvidenceRepository;
 import com.example.ossdoc.domain.rule.repository.RuleCandidateRepository;
+import com.example.ossdoc.domain.rule.repository.RuleMiningSignalRepository;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,8 +28,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +44,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RuleCandidateArtifactPublisher {
 
-    private static final String SCHEMA_VERSION = "1.2";
+    private static final String SCHEMA_VERSION = "1.3";
     private static final String RELATIVE_PATH = "rule/rule_candidates.json";
     private static final BigDecimal LOW_SCORE_THRESHOLD = new BigDecimal("0.6000");
+    private static final int MAX_METHOD_CARDS = 80;
 
     private static final Set<String> PRIMARY_EVIDENCE_ROLES = Set.of(
             "IF_CONDITION",
@@ -55,10 +63,15 @@ public class RuleCandidateArtifactPublisher {
 
     private final RuleCandidateRepository ruleCandidateRepository;
     private final RuleCandidateEvidenceRepository ruleCandidateEvidenceRepository;
+    private final RuleMiningSignalRepository ruleMiningSignalRepository;
     private final EdgeRepository edgeRepository;
     private final ArtifactService artifactService;
     private final ObjectMapper objectMapper;
 
+    /**
+     * run 기준으로 rule_candidates 아티팩트를 최종 조립/저장한다.
+     * - 후보(candidates) + 표시 정책(displayPolicy) + 메서드 카드(methodCards)를 한 번에 만든다.
+     */
     @Transactional
     public Artifact publish(RepoRun run) {
         List<RuleCandidate> candidates =
@@ -82,6 +95,8 @@ public class RuleCandidateArtifactPublisher {
             items.add(toItem(candidate, evidences, quality));
         }
 
+        List<RuleMethodCardJson> methodCards = buildMethodCards(run.getRunId(), candidates);
+
         long edgeCount = edgeRepository.countByRun_RunId(run.getRunId());
         RuleCandidateDisplayPolicyJson displayPolicy = buildDisplayPolicy(candidateIds, edgeCount);
 
@@ -91,6 +106,7 @@ public class RuleCandidateArtifactPublisher {
                 .generatedAt(OffsetDateTime.now().toString())
                 .summary(summary)
                 .displayPolicy(displayPolicy)
+                .methodCards(methodCards)
                 .candidates(items)
                 .build();
 
@@ -105,16 +121,20 @@ public class RuleCandidateArtifactPublisher {
         );
 
         log.info(
-                "[RULE-MINING] rule_candidates.json published. runId={}, artifactId={}, candidates={}, primary={}",
+                "[RULE-MINING] rule_candidates.json published. runId={}, artifactId={}, candidates={}, methodCards={}, primary={}",
                 run.getRunId(),
                 artifact.getArtifactId(),
                 candidates.size(),
+                methodCards.size(),
                 displayPolicy.recommendedPrimaryCount()
         );
 
         return artifact;
     }
 
+    /**
+     * 후보 ID 목록 기준으로 evidence 링크를 미리 로드하고 candidateId별로 묶는다.
+     */
     private Map<Long, List<RuleCandidateEvidence>> loadEvidencesByCandidateId(List<Long> candidateIds) {
         if (candidateIds == null || candidateIds.isEmpty()) {
             return Map.of();
@@ -125,6 +145,9 @@ public class RuleCandidateArtifactPublisher {
                 .collect(Collectors.groupingBy(evidence -> evidence.getCandidate().getCandidateId()));
     }
 
+    /**
+     * 후보 전체 통계(신뢰도별 개수)를 계산해 summary 블록을 만든다.
+     */
     private RuleCandidateSummaryJson buildSummary(List<RuleCandidate> candidates) {
         if (candidates == null || candidates.isEmpty()) {
             return RuleCandidateSummaryJson.builder()
@@ -157,6 +180,9 @@ public class RuleCandidateArtifactPublisher {
                 .build();
     }
 
+    /**
+     * RuleCandidate 엔티티 + evidence 목록을 API/JSON 응답용 아이템으로 변환한다.
+     */
     private RuleCandidateItem toItem(
             RuleCandidate candidate,
             List<RuleCandidateEvidence> evidences,
@@ -192,6 +218,10 @@ public class RuleCandidateArtifactPublisher {
                 .build();
     }
 
+    /**
+     * 후보를 ESTIMATED/CONFIRMED로 분류한다.
+     * - confidence, evidence 밀도, score/support를 함께 평가한다.
+     */
     private CandidateQuality evaluateQuality(RuleCandidate candidate, List<RuleCandidateEvidence> evidences) {
         int evidenceCount = evidences == null ? 0 : evidences.size();
         int primaryEvidenceCount = countPrimaryEvidence(evidences);
@@ -214,6 +244,9 @@ public class RuleCandidateArtifactPublisher {
         return new CandidateQuality(false, "sufficient evidence");
     }
 
+    /**
+     * evidence 중 핵심 역할(primary role) 개수를 계산한다.
+     */
     private int countPrimaryEvidence(List<RuleCandidateEvidence> evidences) {
         if (evidences == null || evidences.isEmpty()) {
             return 0;
@@ -225,6 +258,9 @@ public class RuleCandidateArtifactPublisher {
                 .count();
     }
 
+    /**
+     * 화면 기본 노출 개수를 정하기 위한 displayPolicy를 계산한다.
+     */
     private RuleCandidateDisplayPolicyJson buildDisplayPolicy(List<Long> orderedCandidateIds, long edgeCount) {
         int total = orderedCandidateIds.size();
         DisplayTier tier = resolveDisplayTier(total, edgeCount);
@@ -257,6 +293,9 @@ public class RuleCandidateArtifactPublisher {
                 .build();
     }
 
+    /**
+     * 후보 수/그래프 규모에 따라 SMALL~XLARGE 표시 티어를 결정한다.
+     */
     private DisplayTier resolveDisplayTier(int totalCandidates, long edgeCount) {
         DisplayTier baseTier;
         if (totalCandidates <= 40) {
@@ -273,6 +312,9 @@ public class RuleCandidateArtifactPublisher {
         return DisplayTier.byIndex(baseTier.ordinal() + boost);
     }
 
+    /**
+     * evidence 엔티티 리스트를 JSON DTO 리스트로 변환한다.
+     */
     private List<RuleCandidateEvidenceJson> toEvidenceJsonList(List<RuleCandidateEvidence> evidences) {
         if (evidences == null || evidences.isEmpty()) {
             return List.of();
@@ -283,6 +325,9 @@ public class RuleCandidateArtifactPublisher {
                 .toList();
     }
 
+    /**
+     * 단일 evidence 엔티티를 JSON DTO로 변환한다.
+     */
     private RuleCandidateEvidenceJson toEvidenceJson(RuleCandidateEvidence evidence) {
         return RuleCandidateEvidenceJson.builder()
                 .candidateEvidenceId(evidence.getCandidateEvidenceId())
@@ -297,6 +342,363 @@ public class RuleCandidateArtifactPublisher {
                 .snippet(evidence.getSnippet())
                 .note(evidence.getNote())
                 .build();
+    }
+
+    /**
+     * 우선순위 3: rule_candidates를 "패턴 후보 목록"에서 "메서드 기능 카드 입력원"까지 확장한다.
+     *
+     * - RuleMiningSignal 전체에서 METHOD/CONSTRUCTOR 단위로 그룹핑
+     * - method_fqn, source_file, line_range, summary_hint를 카드로 생성
+     * - LLM이 특정 메서드를 설명할 때 규칙 후보 유무와 관계없이 최소 설명 단서를 확보하도록 한다.
+     */
+    private List<RuleMethodCardJson> buildMethodCards(String runId, List<RuleCandidate> candidates) {
+        List<RuleMiningSignal> signals = ruleMiningSignalRepository.findAllWithSymbolAndSourceByRunId(runId);
+        if (signals == null || signals.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, List<RuleCandidate>> candidatesByMethodSymbolId = new HashMap<>();
+        for (RuleCandidate candidate : candidates) {
+            SymbolEntity subject = candidate.getSubjectSymbol();
+            if (!isMethodSymbol(subject)) {
+                continue;
+            }
+            candidatesByMethodSymbolId
+                    .computeIfAbsent(subject.getSymbolId(), ignored -> new ArrayList<>())
+                    .add(candidate);
+        }
+
+        Map<String, MethodSignalAggregate> aggregateByMethod = new HashMap<>();
+        for (RuleMiningSignal signal : signals) {
+            SymbolEntity symbol = signal.getSymbol();
+            if (!isMethodSymbol(symbol)) {
+                continue;
+            }
+            if (symbol.getSymbolId() == null || symbol.getSymbolId().isBlank()) {
+                continue;
+            }
+            aggregateByMethod
+                    .computeIfAbsent(symbol.getSymbolId(), ignored -> new MethodSignalAggregate(symbol))
+                    .add(signal);
+        }
+
+        if (aggregateByMethod.isEmpty()) {
+            return List.of();
+        }
+
+        List<RuleMethodCardJson> cards = new ArrayList<>();
+        for (MethodSignalAggregate aggregate : aggregateByMethod.values()) {
+            SymbolEntity symbol = aggregate.symbol();
+            String methodFqn = symbol.getQualifiedName();
+            if (methodFqn == null || methodFqn.isBlank()) {
+                continue;
+            }
+
+            List<RuleCandidate> methodCandidates =
+                    candidatesByMethodSymbolId.getOrDefault(symbol.getSymbolId(), List.of());
+
+            String classFqn = extractOwnerFqn(methodFqn);
+            String methodName = extractMethodName(methodFqn);
+
+            String sourceFile = symbol.getSourceFile() == null ? null : symbol.getSourceFile().getPath();
+            Integer startLine = symbol.getSourceStartLine() == null
+                    ? aggregate.minStartLine()
+                    : symbol.getSourceStartLine();
+            Integer endLine = symbol.getSourceEndLine() == null
+                    ? aggregate.maxEndLine()
+                    : symbol.getSourceEndLine();
+
+            String summaryHint = buildSummaryHint(methodName, aggregate, methodCandidates);
+            String scenarioHint = inferScenarioHint(methodName, aggregate);
+            int importance = calculateImportance(aggregate, methodCandidates);
+
+            cards.add(RuleMethodCardJson.builder()
+                    .methodFqn(methodFqn)
+                    .methodSymbolId(symbol.getSymbolId())
+                    .classFqn(classFqn)
+                    .methodName(methodName)
+                    .sourceFile(sourceFile)
+                    .startLine(startLine)
+                    .endLine(endLine)
+                    .summaryHint(summaryHint)
+                    .scenarioHint(scenarioHint)
+                    .importance(importance)
+                    .signalCount(aggregate.signalCount())
+                    .signalTypes(aggregate.sortedSignalTypes())
+                    .avgConfidenceHint(aggregate.avgConfidenceHint())
+                    .build());
+        }
+
+        cards.sort(
+                Comparator.comparing(RuleMethodCardJson::importance, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(RuleMethodCardJson::signalCount, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(RuleMethodCardJson::methodFqn, Comparator.nullsLast(String::compareTo))
+        );
+
+        if (cards.size() > MAX_METHOD_CARDS) {
+            return List.copyOf(cards.subList(0, MAX_METHOD_CARDS));
+        }
+        return List.copyOf(cards);
+    }
+
+    /**
+     * 메서드 카드의 summary_hint를 생성한다.
+     * - 1순위: 해당 메서드의 최고 점수 RuleCandidate 설명
+     * - 2순위: signal 패턴 기반 기본 설명 문장
+     */
+    private String buildSummaryHint(
+            String methodName,
+            MethodSignalAggregate aggregate,
+            List<RuleCandidate> methodCandidates
+    ) {
+        RuleCandidate bestCandidate = methodCandidates.stream()
+                .sorted(Comparator
+                        .comparing(RuleCandidate::getScore, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(RuleCandidate::getCandidateId, Comparator.nullsLast(Comparator.naturalOrder())))
+                .findFirst()
+                .orElse(null);
+
+        if (bestCandidate != null) {
+            String fromCandidate = firstNonBlank(bestCandidate.getDescription(), bestCandidate.getTitle());
+            if (fromCandidate != null && !fromCandidate.isBlank()) {
+                return truncate(fromCandidate, 170);
+            }
+        }
+
+        return switch (inferPrimaryBehavior(aggregate)) {
+            case "GUARD_THROW" -> "입력/상태 검증 후 예외를 던지는 방어 로직이 중심인 메서드입니다.";
+            case "GUARD_RETURN" -> "조건 검사 후 조기 반환으로 흐름을 제어하는 메서드입니다.";
+            case "PERSISTENCE" -> "저장소 save/update/delete 호출을 포함한 영속화 변경 메서드입니다.";
+            case "ASSERTION" -> "require/assert 계열의 사전조건 검증을 수행하는 메서드입니다.";
+            default -> {
+                String safeName = methodName == null || methodName.isBlank() ? "핵심 메서드" : methodName;
+                yield safeName + " 동작과 관련된 핵심 신호가 수집된 메서드입니다.";
+            }
+        };
+    }
+
+    /**
+     * 메서드 카드에서 시나리오 라벨로 쓸 짧은 힌트를 만든다.
+     */
+    private String inferScenarioHint(String methodName, MethodSignalAggregate aggregate) {
+        return switch (inferPrimaryBehavior(aggregate)) {
+            case "GUARD_THROW" -> "잘못된 입력 처리 시나리오";
+            case "GUARD_RETURN" -> "검증 실패 조기 종료 시나리오";
+            case "PERSISTENCE" -> "데이터 변경/저장 시나리오";
+            case "ASSERTION" -> "사전조건 검증 시나리오";
+            default -> {
+                String safeName = methodName == null || methodName.isBlank() ? "핵심 로직" : methodName;
+                yield safeName + " 호출 시나리오";
+            }
+        };
+    }
+
+    /**
+     * 메서드 카드 중요도를 계산한다.
+     * - signal 밀도 + 연결된 후보 점수 + 행위 유형 보너스를 합산한다.
+     */
+    private int calculateImportance(MethodSignalAggregate aggregate, List<RuleCandidate> methodCandidates) {
+        int signalScore = Math.min(12, aggregate.signalCount());
+        int candidateScore = methodCandidates.stream()
+                .map(RuleCandidate::getScore)
+                .filter(score -> score != null)
+                .map(score -> (int) Math.round(score.doubleValue() * 10.0d))
+                .max(Integer::compareTo)
+                .orElse(0);
+
+        int behaviorBonus = switch (inferPrimaryBehavior(aggregate)) {
+            case "GUARD_THROW", "GUARD_RETURN" -> 4;
+            case "PERSISTENCE" -> 3;
+            case "ASSERTION" -> 2;
+            default -> 1;
+        };
+
+        return Math.min(30, 6 + signalScore + candidateScore + behaviorBonus);
+    }
+
+    /**
+     * 수집된 signal 패턴을 기반으로 메서드의 대표 행위를 분류한다.
+     */
+    private String inferPrimaryBehavior(MethodSignalAggregate aggregate) {
+        boolean hasGuardThrow = hasSignalType(aggregate, "IF_CONDITION") && hasSignalType(aggregate, "THROW_STATEMENT");
+        if (hasGuardThrow) {
+            return "GUARD_THROW";
+        }
+
+        boolean hasGuardReturn = hasSignalType(aggregate, "IF_CONDITION")
+                && (hasSignalType(aggregate, "RETURN_STATEMENT") || hasSignalType(aggregate, "ERROR_RESPONSE"));
+        if (hasGuardReturn) {
+            return "GUARD_RETURN";
+        }
+
+        boolean hasPersistence = hasSignalType(aggregate, "REPOSITORY_SAVE")
+                || hasSignalType(aggregate, "REPOSITORY_UPDATE")
+                || hasSignalType(aggregate, "REPOSITORY_DELETE");
+        if (hasPersistence) {
+            return "PERSISTENCE";
+        }
+
+        boolean hasAssertion = hasSignalType(aggregate, "ASSERTION_CALL")
+                || hasSignalType(aggregate, "REQUIRE_CALL");
+        if (hasAssertion) {
+            return "ASSERTION";
+        }
+        return "GENERAL";
+    }
+
+    /**
+     * 특정 signal type이 한 번이라도 등장했는지 확인한다.
+     */
+    private boolean hasSignalType(MethodSignalAggregate aggregate, String signalType) {
+        if (aggregate == null || signalType == null) {
+            return false;
+        }
+        return aggregate.signalTypeCount(signalType) > 0;
+    }
+
+    /**
+     * symbol이 METHOD/CONSTRUCTOR인지 판별한다.
+     */
+    private boolean isMethodSymbol(SymbolEntity symbol) {
+        if (symbol == null || symbol.getSymbolKind() == null) {
+            return false;
+        }
+        return symbol.getSymbolKind() == SymbolKind.METHOD
+                || symbol.getSymbolKind() == SymbolKind.CONSTRUCTOR;
+    }
+
+    /**
+     * method FQN에서 owner class FQN을 추출한다.
+     * 예) a.b.C.m -> a.b.C
+     */
+    private String extractOwnerFqn(String methodFqn) {
+        if (methodFqn == null || methodFqn.isBlank()) {
+            return "";
+        }
+        int idx = methodFqn.lastIndexOf('.');
+        if (idx <= 0) {
+            return "";
+        }
+        return methodFqn.substring(0, idx);
+    }
+
+    /**
+     * method FQN에서 method 이름을 추출한다.
+     * 예) a.b.C.m -> m
+     */
+    private String extractMethodName(String methodFqn) {
+        if (methodFqn == null || methodFqn.isBlank()) {
+            return "";
+        }
+        int idx = methodFqn.lastIndexOf('.');
+        if (idx < 0 || idx + 1 >= methodFqn.length()) {
+            return "";
+        }
+        return methodFqn.substring(idx + 1);
+    }
+
+    /**
+     * 여러 문자열 중 비어있지 않은 첫 값을 반환한다.
+     */
+    private String firstNonBlank(String... values) {
+        if (values == null || values.length == 0) {
+            return "";
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * 최대 길이를 넘는 문자열을 말줄임 처리한다.
+     */
+    private String truncate(String text, int maxLength) {
+        if (text == null) {
+            return "";
+        }
+        if (text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, Math.max(0, maxLength - 3)) + "...";
+    }
+
+    private static class MethodSignalAggregate {
+        private final SymbolEntity symbol;
+        private final Map<String, Integer> signalTypeCounts = new HashMap<>();
+        private int signalCount = 0;
+        private BigDecimal confidenceSum = BigDecimal.ZERO;
+        private int confidenceCount = 0;
+        private Integer minStartLine;
+        private Integer maxEndLine;
+
+        private MethodSignalAggregate(SymbolEntity symbol) {
+            this.symbol = symbol;
+        }
+
+        /**
+         * 같은 메서드로 수집된 signal을 누적한다.
+         * - 타입 빈도, 라인 범위, confidence 평균 계산용 합계를 함께 업데이트한다.
+         */
+        private void add(RuleMiningSignal signal) {
+            signalCount++;
+            String typeName = signal.getSignalType() == null ? "UNKNOWN" : signal.getSignalType().name();
+            signalTypeCounts.merge(typeName, 1, Integer::sum);
+
+            if (signal.getConfidenceHint() != null) {
+                confidenceSum = confidenceSum.add(signal.getConfidenceHint());
+                confidenceCount++;
+            }
+            if (signal.getStartLine() != null) {
+                minStartLine = minStartLine == null ? signal.getStartLine() : Math.min(minStartLine, signal.getStartLine());
+            }
+            if (signal.getEndLine() != null) {
+                maxEndLine = maxEndLine == null ? signal.getEndLine() : Math.max(maxEndLine, signal.getEndLine());
+            }
+        }
+
+        private SymbolEntity symbol() {
+            return symbol;
+        }
+
+        private int signalCount() {
+            return signalCount;
+        }
+
+        private int signalTypeCount(String signalType) {
+            return signalTypeCounts.getOrDefault(signalType, 0);
+        }
+
+        /**
+         * signal type 빈도 내림차순으로 정렬된 목록을 반환한다.
+         */
+        private List<String> sortedSignalTypes() {
+            return signalTypeCounts.entrySet().stream()
+                    .sorted(Map.Entry.<String, Integer>comparingByValue().reversed()
+                            .thenComparing(Map.Entry.comparingByKey()))
+                    .map(Map.Entry::getKey)
+                    .toList();
+        }
+
+        private Integer minStartLine() {
+            return minStartLine;
+        }
+
+        private Integer maxEndLine() {
+            return maxEndLine;
+        }
+
+        /**
+         * 누적된 confidence 힌트의 평균을 계산한다.
+         */
+        private BigDecimal avgConfidenceHint() {
+            if (confidenceCount == 0) {
+                return null;
+            }
+            return confidenceSum.divide(BigDecimal.valueOf(confidenceCount), 4, RoundingMode.HALF_UP);
+        }
     }
 
     private enum DisplayTier {

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RunArtifactIdsResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RunArtifactIdsResponse.java
@@ -20,6 +20,7 @@ public class RunArtifactIdsResponse {
      * Rule 단계 산출물
      */
     private Long ruleCandidatesArtifactId;
+    private Long symbolSourceIndexArtifactId;
 
     /*
      * LLM 단계 산출물

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
@@ -68,6 +68,9 @@ public class RunProgressQueryService {
                 .ruleCandidatesArtifactId(
                         latestArtifactId(runId, ArtifactKind.RULE_CANDIDATES_JSON)
                 )
+                .symbolSourceIndexArtifactId(
+                        latestArtifactId(runId, ArtifactKind.SYMBOL_SOURCE_INDEX_JSON)
+                )
 
                 .llmRefinedRulesArtifactId(
                         latestArtifactId(runId, ArtifactKind.LLM_REFINED_RULES)

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
@@ -30,13 +30,15 @@ import java.util.Set;
 /**
  * LLM 입력 조립 서비스.
  *
- * <p>팀 합의에 맞춰 LLM 입력 원천을 4개 JSON으로 제한한다.
+ *  팀 합의에 맞춰 LLM 입력 원천을 4개 JSON으로 제한
  * - api_map.json (ArtifactKind.API_MAP_JSON)
  * - rule_candidates.json (ArtifactKind.RULE_CANDIDATES_JSON)
  * - rankings.json (ArtifactKind.RANKINGS_JSON)
  * - subsystems.json (ArtifactKind.SUBSYSTEMS_JSON)
  *
- * <p>입력이 부족하면 LLM에 더 많은 파일을 넣지 않고, 앞단 산출물 보강으로 해결하도록 설계한다.
+ *  symbol_source_index.json은 없어도 파이프라인은 동작하고, 있으면 품질이 올라가는 형태
+ *
+ *  입력이 부족하면 LLM에 더 많은 파일을 넣지 않고, 앞단 산출물 보강으로 해결하도록 설계
  */
 @Service
 @RequiredArgsConstructor
@@ -168,7 +170,10 @@ public class LlmInputAssemblerService {
                 continue;
             }
             String fqn = sanitizeQualifiedName(item.path("fqn").asText(""));
-            String sourceFile = safeText(item.path("source_file").asText(""));
+            String sourceFile = toUserFacingSourcePath(firstNonBlank(
+                    item.path("source_file").asText(""),
+                    item.path("sourceFile").asText("")
+            ));
             Integer startLine = asNullableInt(item.path("start_line"));
             Integer endLine = asNullableInt(item.path("end_line"));
             double confidence = item.path("confidence").isNumber() ? item.path("confidence").asDouble(0.0d) : 0.0d;
@@ -194,7 +199,10 @@ public class LlmInputAssemblerService {
                 continue;
             }
             String symbolId = safeText(item.path("symbol_id").asText(""));
-            String sourceFile = safeText(item.path("source_file").asText(""));
+            String sourceFile = toUserFacingSourcePath(firstNonBlank(
+                    item.path("source_file").asText(""),
+                    item.path("sourceFile").asText("")
+            ));
             Integer startLine = asNullableInt(item.path("start_line"));
             Integer endLine = asNullableInt(item.path("end_line"));
             double confidence = item.path("confidence").isNumber() ? item.path("confidence").asDouble(0.0d) : 0.0d;
@@ -450,6 +458,12 @@ public class LlmInputAssemblerService {
             int confidenceBoost = confidenceToImportanceBoost(item.path("confidence").asText(""));
             int importance = Math.max(baseImportance, item.path("importance").asInt(baseImportance));
             importance = Math.max(importance, baseImportance + confidenceBoost + Math.min(4, Math.max(0, score / 2)));
+            String resolvedFilePath = toUserFacingSourcePath(firstNonBlank(
+                    item.path("filePath").asText(""),
+                    item.path("file_path").asText(""),
+                    item.path("sourceFile").asText(""),
+                    item.path("source_file").asText("")
+            ));
 
             CoreTypeSeed prev = byFqn.get(fqn);
             CoreTypeSeed next = new CoreTypeSeed(
@@ -458,10 +472,7 @@ public class LlmInputAssemblerService {
                     packageName,
                     className,
                     firstNonBlank(
-                            item.path("filePath").asText(""),
-                            item.path("file_path").asText(""),
-                            item.path("sourceFile").asText(""),
-                            item.path("source_file").asText(""),
+                            resolvedFilePath,
                             prev == null ? "" : prev.filePath()
                     ),
                     role,
@@ -668,8 +679,12 @@ public class LlmInputAssemblerService {
                     methodName,
                     methodFqn,
                     firstNonBlank(
-                            item.path("filePath").asText(""),
-                            item.path("file_path").asText(""),
+                            toUserFacingSourcePath(firstNonBlank(
+                                    item.path("filePath").asText(""),
+                                    item.path("file_path").asText(""),
+                                    item.path("sourceFile").asText(""),
+                                    item.path("source_file").asText("")
+                            )),
                             prev == null ? "" : prev.filePath()
                     ),
                     importance,
@@ -744,8 +759,11 @@ public class LlmInputAssemblerService {
 
             String filePath = firstNonBlank(
                     firstEvidence.path("filePath").asText(""),
-                    firstEvidence.path("file_path").asText("")
+                    firstEvidence.path("file_path").asText(""),
+                    firstEvidence.path("sourceFile").asText(""),
+                    firstEvidence.path("source_file").asText("")
             );
+            filePath = toUserFacingSourcePath(filePath);
             Integer startLine = firstNonNullInt(
                     asNullableInt(firstEvidence.path("startLine")),
                     asNullableInt(firstEvidence.path("start_line"))
@@ -1122,12 +1140,15 @@ public class LlmInputAssemblerService {
         }
 
         Map<String, List<CoreTypeSeed>> typesByDir = new LinkedHashMap<>();
+        Map<String, String> typeFilePathByFqn = new HashMap<>();
         for (CoreTypeSeed type : coreTypes) {
-            if (!isUserFacingSourcePath(type.filePath())) {
+            String userFacingFilePath = toUserFacingSourcePath(type.filePath());
+            if (!isUserFacingSourcePath(userFacingFilePath)) {
                 continue;
             }
-            String dir = extractDirectoryPath(type.filePath());
+            String dir = extractDirectoryPath(userFacingFilePath);
             typesByDir.computeIfAbsent(dir, k -> new ArrayList<>()).add(type);
+            typeFilePathByFqn.put(type.fqn(), userFacingFilePath);
         }
 
         Map<String, List<CoreMethodSeed>> methodsByClass = new HashMap<>();
@@ -1136,6 +1157,11 @@ public class LlmInputAssemblerService {
         }
         for (List<CoreMethodSeed> methods : methodsByClass.values()) {
             methods.sort(Comparator.comparingInt(CoreMethodSeed::importance).reversed());
+        }
+
+        // core type에서 파일 경로를 찾지 못한 경우에도 core method 기준 최소 파일 트리를 만든다.
+        if (typesByDir.isEmpty()) {
+            return buildDirectoriesFromMethods(coreMethods);
         }
 
         ArrayNode directories = objectMapper.createArrayNode();
@@ -1150,7 +1176,10 @@ public class LlmInputAssemblerService {
 
             for (CoreTypeSeed type : entry.getValue()) {
                 ObjectNode fileNode = files.addObject();
-                fileNode.put("path", type.filePath());
+                fileNode.put("path", firstNonBlank(
+                        typeFilePathByFqn.get(type.fqn()),
+                        toUserFacingSourcePath(type.filePath())
+                ));
                 ArrayNode classes = fileNode.putArray("classes");
                 ObjectNode classNode = classes.addObject();
                 classNode.put("symbolId", type.symbolId());
@@ -1175,6 +1204,76 @@ public class LlmInputAssemblerService {
     }
 
     /**
+     * core type seed가 비어도 core method seed를 이용해 최소 파일 트리를 구성한다.
+     */
+    private JsonNode buildDirectoriesFromMethods(List<CoreMethodSeed> coreMethods) {
+        Map<String, Map<String, List<CoreMethodSeed>>> methodsByDirAndClass = new LinkedHashMap<>();
+        Map<String, String> classFileByFqn = new HashMap<>();
+        Map<String, String> classNameByFqn = new HashMap<>();
+        Map<String, String> classSymbolIdByFqn = new HashMap<>();
+
+        for (CoreMethodSeed method : coreMethods) {
+            String filePath = toUserFacingSourcePath(method.filePath());
+            if (!isUserFacingSourcePath(filePath)) {
+                continue;
+            }
+            String classFqn = sanitizeQualifiedName(firstNonBlank(
+                    method.classFqn(),
+                    extractOwnerFqn(method.fqn())
+            ));
+            if (classFqn.isBlank()) {
+                continue;
+            }
+            String directory = extractDirectoryPath(filePath);
+            methodsByDirAndClass
+                    .computeIfAbsent(directory, k -> new LinkedHashMap<>())
+                    .computeIfAbsent(classFqn, k -> new ArrayList<>())
+                    .add(method);
+            classFileByFqn.putIfAbsent(classFqn, filePath);
+            classNameByFqn.putIfAbsent(classFqn, firstNonBlank(method.className(), extractSimpleName(classFqn)));
+            classSymbolIdByFqn.putIfAbsent(classFqn, method.classSymbolId());
+        }
+
+        ArrayNode directories = objectMapper.createArrayNode();
+        int dirCount = 0;
+        for (Map.Entry<String, Map<String, List<CoreMethodSeed>>> dirEntry : methodsByDirAndClass.entrySet()) {
+            if (dirCount++ >= MAX_DIRECTORIES) {
+                break;
+            }
+
+            ObjectNode dirNode = directories.addObject();
+            dirNode.put("path", dirEntry.getKey());
+            ArrayNode files = dirNode.putArray("files");
+
+            for (Map.Entry<String, List<CoreMethodSeed>> classEntry : dirEntry.getValue().entrySet()) {
+                String classFqn = classEntry.getKey();
+                List<CoreMethodSeed> classMethods = classEntry.getValue();
+                classMethods.sort(Comparator.comparingInt(CoreMethodSeed::importance).reversed());
+
+                ObjectNode fileNode = files.addObject();
+                fileNode.put("path", classFileByFqn.getOrDefault(classFqn, ""));
+                ArrayNode classes = fileNode.putArray("classes");
+                ObjectNode classNode = classes.addObject();
+                putIfText(classNode, "symbolId", classSymbolIdByFqn.getOrDefault(classFqn, ""));
+                classNode.put("name", classNameByFqn.getOrDefault(classFqn, extractSimpleName(classFqn)));
+                classNode.put("summary", "핵심 메서드 기반으로 추정한 클래스");
+                classNode.put("estimated", true);
+
+                ArrayNode methods = classNode.putArray("methods");
+                for (int i = 0; i < classMethods.size() && i < MAX_METHODS_PER_CLASS; i++) {
+                    CoreMethodSeed method = classMethods.get(i);
+                    ObjectNode methodNode = methods.addObject();
+                    methodNode.put("symbolId", method.symbolId());
+                    methodNode.put("name", method.methodName());
+                    methodNode.put("summary", method.summarySeed());
+                    methodNode.put("estimated", true);
+                }
+            }
+        }
+        return directories;
+    }
+
+    /**
      * 근거 인덱스.
      */
     private JsonNode buildEvidenceIndex(
@@ -1186,10 +1285,11 @@ public class LlmInputAssemblerService {
         Set<String> dedupe = new LinkedHashSet<>();
 
         for (CoreTypeSeed type : coreTypes) {
-            if (!isUserFacingSourcePath(type.filePath())) {
+            String filePath = toUserFacingSourcePath(type.filePath());
+            if (!isUserFacingSourcePath(filePath)) {
                 continue;
             }
-            String key = "TYPE|" + type.fqn() + "|" + type.filePath() + "|" + type.startLine() + "|" + type.endLine();
+            String key = "TYPE|" + type.fqn() + "|" + filePath + "|" + type.startLine() + "|" + type.endLine();
             if (!dedupe.add(key)) {
                 continue;
             }
@@ -1197,7 +1297,7 @@ public class LlmInputAssemblerService {
             node.put("kind", "TYPE");
             putIfText(node, "symbolId", type.symbolId());
             putIfText(node, "fqn", type.fqn());
-            putIfText(node, "filePath", type.filePath());
+            putIfText(node, "filePath", filePath);
             if (type.startLine() != null) {
                 node.put("startLine", type.startLine());
             }
@@ -1207,10 +1307,11 @@ public class LlmInputAssemblerService {
         }
 
         for (CoreMethodSeed method : coreMethods) {
-            if (!isUserFacingSourcePath(method.filePath())) {
+            String filePath = toUserFacingSourcePath(method.filePath());
+            if (!isUserFacingSourcePath(filePath)) {
                 continue;
             }
-            String key = "METHOD|" + method.fqn() + "|" + method.filePath() + "|" + method.startLine() + "|" + method.endLine();
+            String key = "METHOD|" + method.fqn() + "|" + filePath + "|" + method.startLine() + "|" + method.endLine();
             if (!dedupe.add(key)) {
                 continue;
             }
@@ -1218,7 +1319,7 @@ public class LlmInputAssemblerService {
             node.put("kind", "METHOD");
             putIfText(node, "symbolId", method.symbolId());
             putIfText(node, "fqn", method.fqn());
-            putIfText(node, "filePath", method.filePath());
+            putIfText(node, "filePath", filePath);
             if (method.startLine() != null) {
                 node.put("startLine", method.startLine());
             }
@@ -1236,7 +1337,12 @@ public class LlmInputAssemblerService {
                 }
                 for (JsonNode evidence : evidences) {
                     Long evidenceId = evidence.path("evidenceId").canConvertToLong() ? evidence.path("evidenceId").asLong() : null;
-                    String filePath = safeText(evidence.path("filePath").asText(""));
+                    String filePath = toUserFacingSourcePath(firstNonBlank(
+                            evidence.path("filePath").asText(""),
+                            evidence.path("file_path").asText(""),
+                            evidence.path("sourceFile").asText(""),
+                            evidence.path("source_file").asText("")
+                    ));
                     if (!isUserFacingSourcePath(filePath)) {
                         continue;
                     }
@@ -1585,7 +1691,7 @@ public class LlmInputAssemblerService {
     }
 
     private boolean isUserFacingSourcePath(String filePath) {
-        String normalized = normalizePath(filePath);
+        String normalized = normalizePath(toUserFacingSourcePath(filePath));
         if (normalized == null) {
             return false;
         }
@@ -1593,6 +1699,77 @@ public class LlmInputAssemblerService {
             return false;
         }
         return normalized.contains(MAIN_JAVA_MARKER) || normalized.contains(MAIN_KOTLIN_MARKER);
+    }
+
+    /**
+     * 바이트코드 경로를 사용자 소스 경로로 정규화한다.
+     */
+    private String toUserFacingSourcePath(String rawPath) {
+        String normalized = safeText(rawPath).replace('\\', '/');
+        if (normalized.isBlank()) {
+            return "";
+        }
+
+        String lower = normalized.toLowerCase(Locale.ROOT);
+        String fromMavenTarget = rewriteCompiledPath(
+                normalized,
+                lower,
+                "/target/classes/",
+                "/src/main/java/",
+                ".java"
+        );
+        if (!fromMavenTarget.isBlank()) {
+            return fromMavenTarget;
+        }
+
+        String fromGradleJava = rewriteCompiledPath(
+                normalized,
+                lower,
+                "/build/classes/java/main/",
+                "/src/main/java/",
+                ".java"
+        );
+        if (!fromGradleJava.isBlank()) {
+            return fromGradleJava;
+        }
+
+        String fromGradleKotlin = rewriteCompiledPath(
+                normalized,
+                lower,
+                "/build/classes/kotlin/main/",
+                "/src/main/kotlin/",
+                ".kt"
+        );
+        if (!fromGradleKotlin.isBlank()) {
+            return fromGradleKotlin;
+        }
+
+        return normalized;
+    }
+
+    private String rewriteCompiledPath(
+            String originalPath,
+            String lowerPath,
+            String marker,
+            String sourceRoot,
+            String sourceExtension
+    ) {
+        int markerIndex = lowerPath.indexOf(marker);
+        if (markerIndex < 0) {
+            return "";
+        }
+
+        String prefix = originalPath.substring(0, markerIndex);
+        String suffix = originalPath.substring(markerIndex + marker.length());
+        if (suffix.endsWith(".class")) {
+            String classPath = suffix.substring(0, suffix.length() - ".class".length());
+            int nestedTypeIndex = classPath.indexOf('$');
+            if (nestedTypeIndex >= 0) {
+                classPath = classPath.substring(0, nestedTypeIndex);
+            }
+            suffix = classPath + sourceExtension;
+        }
+        return prefix + sourceRoot + suffix;
     }
 
     private String normalizePath(String rawPath) {

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
@@ -305,6 +305,8 @@ public class LlmInputAssemblerService {
                     firstNonBlank(
                             item.path("filePath").asText(""),
                             item.path("file_path").asText(""),
+                            item.path("sourceFile").asText(""),
+                            item.path("source_file").asText(""),
                             prev == null ? "" : prev.filePath()
                     ),
                     role,
@@ -404,8 +406,14 @@ public class LlmInputAssemblerService {
         }
 
         if (byFqn.isEmpty()) {
+            // rule_candidates의 method_cards를 먼저 반영해 "규칙 후보가 없는 메서드"도 코어 메서드 씨앗으로 포함한다.
+            appendMethodsFromApiMap(byFqn, ruleCandidates.path("methodCards"), coreTypeFqns, 9);
+            appendMethodsFromApiMap(byFqn, ruleCandidates.path("method_cards"), coreTypeFqns, 9);
             appendMethodsFromRuleCandidates(byFqn, ruleCandidates, coreTypeFqns, 8, publicApiTypeBySymbolId);
         } else {
+            // 이미 seed가 있더라도 method_cards를 낮은 가중치로 합쳐 coverage를 넓힌다.
+            appendMethodsFromApiMap(byFqn, ruleCandidates.path("methodCards"), coreTypeFqns, 7);
+            appendMethodsFromApiMap(byFqn, ruleCandidates.path("method_cards"), coreTypeFqns, 7);
             appendMethodsFromRuleCandidates(byFqn, ruleCandidates, coreTypeFqns, 6, publicApiTypeBySymbolId);
         }
 
@@ -480,6 +488,8 @@ public class LlmInputAssemblerService {
             String signatureHint = firstNonBlank(item.path("signatureHint").asText(""), item.path("signature").asText(""));
             String summarySeed = firstNonBlank(
                     item.path("summary").asText(""),
+                    item.path("summaryHint").asText(""),
+                    item.path("summary_hint").asText(""),
                     inferMethodUsage(methodName, className, signatureHint)
             );
             int importance = Math.max(baseImportance, item.path("importance").asInt(baseImportance) + methodHeuristicBonus(methodName));
@@ -489,6 +499,8 @@ public class LlmInputAssemblerService {
                     firstNonBlank(
                             item.path("symbolId").asText(""),
                             item.path("symbol_id").asText(""),
+                            item.path("methodSymbolId").asText(""),
+                            item.path("method_symbol_id").asText(""),
                             prev == null ? "" : prev.symbolId()
                     ),
                     firstNonBlank(
@@ -508,7 +520,11 @@ public class LlmInputAssemblerService {
                     importance,
                     signatureHint,
                     shortenText(summarySeed, 140),
-                    firstNonBlank(item.path("scenarioHint").asText(""), inferScenarioHint(methodName)),
+                    firstNonBlank(
+                            item.path("scenarioHint").asText(""),
+                            item.path("scenario_hint").asText(""),
+                            inferScenarioHint(methodName)
+                    ),
                     firstNonNullInt(asNullableInt(item.path("startLine")), asNullableInt(item.path("start_line"))),
                     firstNonNullInt(asNullableInt(item.path("endLine")), asNullableInt(item.path("end_line")))
             );

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
@@ -560,7 +560,7 @@ public class LlmInputAssemblerService {
                         prev == null ? "" : prev.filePath(),
                         Math.max(importance, methodHeuristicBonus(methodName)),
                         prev == null ? "" : prev.signatureHint(),
-                        inferMethodUsage(methodName, className, prev == null ? "" : prev.signatureHint()),
+                        normalizeSummarySeed(inferMethodUsage(methodName, className, prev == null ? "" : prev.signatureHint())),
                         inferScenarioHint(methodName),
                         prev == null ? null : prev.startLine(),
                         prev == null ? null : prev.endLine()
@@ -689,7 +689,7 @@ public class LlmInputAssemblerService {
                     ),
                     importance,
                     signatureHint,
-                    shortenText(summarySeed, 140),
+                    normalizeSummarySeed(summarySeed),
                     firstNonBlank(
                             item.path("scenarioHint").asText(""),
                             item.path("scenario_hint").asText(""),
@@ -793,7 +793,7 @@ public class LlmInputAssemblerService {
                     firstNonBlank(filePath, prev == null ? "" : prev.filePath()),
                     Math.max(importance, methodHeuristicBonus(methodName)),
                     prev == null ? "" : prev.signatureHint(),
-                    shortenText(summarySeed, 140),
+                    normalizeSummarySeed(summarySeed),
                     inferScenarioHint(methodName),
                     firstNonNullInt(startLine, prev == null ? null : prev.startLine()),
                     firstNonNullInt(endLine, prev == null ? null : prev.endLine())
@@ -1992,6 +1992,14 @@ public class LlmInputAssemblerService {
             return value;
         }
         return value.substring(0, maxLength);
+    }
+
+    private String normalizeSummarySeed(String text) {
+        String normalized = safeText(text).replaceAll("\\s+", " ").trim();
+        if (normalized.isBlank()) {
+            return "핵심 동작을 수행한다.";
+        }
+        return normalized;
     }
 
     private double round3(double value) {

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmInputAssemblerService.java
@@ -106,13 +106,17 @@ public class LlmInputAssemblerService {
     private ObjectNode buildAutoStructure(String runId, boolean forceKorean) {
         JsonNode apiMap = loadOptionalArtifactMeta(runId, ArtifactKind.API_MAP_JSON);
         JsonNode apiSurface = loadOptionalArtifactMeta(runId, ArtifactKind.API_SURFACE_JSON);
+        JsonNode symbolSourceIndex = loadOptionalArtifactMeta(runId, ArtifactKind.SYMBOL_SOURCE_INDEX_JSON);
         JsonNode ruleCandidates = requireArtifactMeta(runId, ArtifactKind.RULE_CANDIDATES_JSON);
         JsonNode rankings = requireArtifactMeta(runId, ArtifactKind.RANKINGS_JSON);
         JsonNode subsystems = requireArtifactMeta(runId, ArtifactKind.SUBSYSTEMS_JSON);
 
         Map<String, String> publicApiTypeBySymbolId = indexPublicApiTypeBySymbolId(apiMap, apiSurface);
+        Map<String, SourceAnchor> sourceAnchorBySymbolId = indexSourceAnchorBySymbolId(symbolSourceIndex);
+        Map<String, SourceAnchor> sourceAnchorByFqn = indexSourceAnchorByFqn(symbolSourceIndex);
 
         List<CoreTypeSeed> coreTypes = extractCoreTypes(apiMap, rankings, subsystems, publicApiTypeBySymbolId);
+        coreTypes = applyTypeSourceAnchors(coreTypes, sourceAnchorBySymbolId, sourceAnchorByFqn);
         List<CoreMethodSeed> coreMethods = extractCoreMethods(
                 apiMap,
                 rankings,
@@ -120,6 +124,7 @@ public class LlmInputAssemblerService {
                 ruleCandidates,
                 publicApiTypeBySymbolId
         );
+        coreMethods = applyMethodSourceAnchors(coreMethods, sourceAnchorBySymbolId, sourceAnchorByFqn);
 
         ObjectNode root = objectMapper.createObjectNode();
         root.put("runId", runId);
@@ -134,7 +139,7 @@ public class LlmInputAssemblerService {
         root.set("extensionSeed", buildExtensionSeed(apiMap, coreTypes, subsystems));
         root.set("directories", buildDirectories(apiMap, coreTypes, coreMethods));
         root.set("evidenceIndex", buildEvidenceIndex(coreTypes, coreMethods, ruleCandidates));
-        root.set("qualityGate", buildQualityGate(apiMap, ruleCandidates, rankings, subsystems));
+        root.set("qualityGate", buildQualityGate(apiMap, ruleCandidates, rankings, subsystems, symbolSourceIndex));
 
         // 하위 호환을 위한 집계 필드
         ObjectNode publicSurface = root.putObject("publicSurface");
@@ -145,6 +150,156 @@ public class LlmInputAssemblerService {
         publicSurface.set("apiEntries", buildApiEntries(coreMethods));
 
         return root;
+    }
+
+    /**
+     * symbol_source_index.json을 symbol_id 기준으로 인덱싱한다.
+     * - 기존 산출물에 누락된 source_file/start_line/end_line을 보강하기 위해 사용한다.
+     */
+    private Map<String, SourceAnchor> indexSourceAnchorBySymbolId(JsonNode symbolSourceIndex) {
+        Map<String, SourceAnchor> out = new HashMap<>();
+        JsonNode symbols = symbolSourceIndex.path("symbols");
+        if (!symbols.isArray()) {
+            return out;
+        }
+        for (JsonNode item : symbols) {
+            String symbolId = safeText(item.path("symbol_id").asText(""));
+            if (symbolId.isBlank()) {
+                continue;
+            }
+            String fqn = sanitizeQualifiedName(item.path("fqn").asText(""));
+            String sourceFile = safeText(item.path("source_file").asText(""));
+            Integer startLine = asNullableInt(item.path("start_line"));
+            Integer endLine = asNullableInt(item.path("end_line"));
+            double confidence = item.path("confidence").isNumber() ? item.path("confidence").asDouble(0.0d) : 0.0d;
+
+            out.put(symbolId, new SourceAnchor(symbolId, fqn, sourceFile, startLine, endLine, confidence));
+        }
+        return out;
+    }
+
+    /**
+     * symbol_source_index.json을 fqn 기준으로 인덱싱한다.
+     * - 동일 fqn 충돌 시 confidence가 더 높은 항목을 채택한다.
+     */
+    private Map<String, SourceAnchor> indexSourceAnchorByFqn(JsonNode symbolSourceIndex) {
+        Map<String, SourceAnchor> out = new HashMap<>();
+        JsonNode symbols = symbolSourceIndex.path("symbols");
+        if (!symbols.isArray()) {
+            return out;
+        }
+        for (JsonNode item : symbols) {
+            String fqn = sanitizeQualifiedName(item.path("fqn").asText(""));
+            if (fqn.isBlank()) {
+                continue;
+            }
+            String symbolId = safeText(item.path("symbol_id").asText(""));
+            String sourceFile = safeText(item.path("source_file").asText(""));
+            Integer startLine = asNullableInt(item.path("start_line"));
+            Integer endLine = asNullableInt(item.path("end_line"));
+            double confidence = item.path("confidence").isNumber() ? item.path("confidence").asDouble(0.0d) : 0.0d;
+
+            SourceAnchor next = new SourceAnchor(symbolId, fqn, sourceFile, startLine, endLine, confidence);
+            SourceAnchor prev = out.get(fqn);
+            if (prev == null || next.confidence() > prev.confidence()) {
+                out.put(fqn, next);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * core class seed에 소스 앵커를 보강한다.
+     */
+    private List<CoreTypeSeed> applyTypeSourceAnchors(
+            List<CoreTypeSeed> coreTypes,
+            Map<String, SourceAnchor> sourceAnchorBySymbolId,
+            Map<String, SourceAnchor> sourceAnchorByFqn
+    ) {
+        if (coreTypes == null || coreTypes.isEmpty()) {
+            return List.of();
+        }
+        List<CoreTypeSeed> out = new ArrayList<>(coreTypes.size());
+        for (CoreTypeSeed seed : coreTypes) {
+            SourceAnchor anchor = resolveBestAnchor(
+                    seed.symbolId(),
+                    seed.fqn(),
+                    sourceAnchorBySymbolId,
+                    sourceAnchorByFqn
+            );
+            if (anchor == null) {
+                out.add(seed);
+                continue;
+            }
+            out.add(new CoreTypeSeed(
+                    seed.symbolId(),
+                    seed.fqn(),
+                    seed.packageName(),
+                    seed.className(),
+                    firstNonBlank(seed.filePath(), anchor.sourceFile()),
+                    seed.role(),
+                    seed.usage(),
+                    seed.importance(),
+                    firstNonNullInt(seed.startLine(), anchor.startLine()),
+                    firstNonNullInt(seed.endLine(), anchor.endLine())
+            ));
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * core method seed에 소스 앵커를 보강한다.
+     */
+    private List<CoreMethodSeed> applyMethodSourceAnchors(
+            List<CoreMethodSeed> coreMethods,
+            Map<String, SourceAnchor> sourceAnchorBySymbolId,
+            Map<String, SourceAnchor> sourceAnchorByFqn
+    ) {
+        if (coreMethods == null || coreMethods.isEmpty()) {
+            return List.of();
+        }
+        List<CoreMethodSeed> out = new ArrayList<>(coreMethods.size());
+        for (CoreMethodSeed seed : coreMethods) {
+            SourceAnchor anchor = resolveBestAnchor(
+                    seed.symbolId(),
+                    seed.fqn(),
+                    sourceAnchorBySymbolId,
+                    sourceAnchorByFqn
+            );
+            if (anchor == null) {
+                out.add(seed);
+                continue;
+            }
+            out.add(new CoreMethodSeed(
+                    seed.symbolId(),
+                    seed.classSymbolId(),
+                    seed.classFqn(),
+                    seed.className(),
+                    seed.methodName(),
+                    seed.fqn(),
+                    firstNonBlank(seed.filePath(), anchor.sourceFile()),
+                    seed.importance(),
+                    seed.signatureHint(),
+                    seed.summarySeed(),
+                    seed.scenarioHint(),
+                    firstNonNullInt(seed.startLine(), anchor.startLine()),
+                    firstNonNullInt(seed.endLine(), anchor.endLine())
+            ));
+        }
+        return List.copyOf(out);
+    }
+
+    private SourceAnchor resolveBestAnchor(
+            String symbolId,
+            String fqn,
+            Map<String, SourceAnchor> sourceAnchorBySymbolId,
+            Map<String, SourceAnchor> sourceAnchorByFqn
+    ) {
+        SourceAnchor byId = sourceAnchorBySymbolId.get(safeText(symbolId));
+        if (byId != null) {
+            return byId;
+        }
+        return sourceAnchorByFqn.get(sanitizeQualifiedName(fqn));
     }
 
     /**
@@ -1113,13 +1268,20 @@ public class LlmInputAssemblerService {
     /**
      * 품질 게이트 요약.
      */
-    private JsonNode buildQualityGate(JsonNode apiMap, JsonNode ruleCandidates, JsonNode rankings, JsonNode subsystems) {
+    private JsonNode buildQualityGate(
+            JsonNode apiMap,
+            JsonNode ruleCandidates,
+            JsonNode rankings,
+            JsonNode subsystems,
+            JsonNode symbolSourceIndex
+    ) {
         ObjectNode out = objectMapper.createObjectNode();
         out.put("apiMapPresent", !apiMap.isMissingNode() && !apiMap.isNull() && !apiMap.isEmpty());
         out.put("ruleCandidateCount", countArray(ruleCandidates.path("candidates")));
         out.put("rankingCount", countArray(rankings.path("symbolRankings")));
         out.put("subsystemCount", countArray(subsystems.path("subsystems")));
-        out.put("inputSourcePolicy", "api_map + rule_candidates + rankings + subsystems");
+        out.put("symbolSourceAnchorCount", countArray(symbolSourceIndex.path("symbols")));
+        out.put("inputSourcePolicy", "api_map + rule_candidates + rankings + subsystems + optional(symbol_source_index)");
         return out;
     }
 
@@ -1662,6 +1824,16 @@ public class LlmInputAssemblerService {
     public record LlmContextBundle(
             Map<String, Object> structureEngineOutput,
             List<LlmRequest.EvidenceSnippet> evidenceBundle
+    ) {
+    }
+
+    private record SourceAnchor(
+            String symbolId,
+            String fqn,
+            String sourceFile,
+            Integer startLine,
+            Integer endLine,
+            double confidence
     ) {
     }
 

--- a/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
+++ b/src/main/java/com/example/ossdoc/global/llm/service/LlmService.java
@@ -73,6 +73,7 @@ public class LlmService {
     private static final int MAX_METHOD_FLOW = 8;
     private static final int MAX_EVIDENCE_LINKS = 3;
     private static final int MAX_API_ENTRY_OUTPUT = 14;
+    private static final int MAX_METHOD_DESCRIPTION_PREVIEW = 140;
 
     private static final int TOKENS_CAUTIONS = 4000;
     private static final int TOKENS_SCENARIOS = 10000;
@@ -786,11 +787,17 @@ public class LlmService {
 
             String fqn = seed.path("fqn").asText("");
             String methodName = seed.path("methodName").asText("");
+            String whatItDoesFull = normalizeSentence(seed.path("summarySeed").asText("핵심 동작을 수행한다."));
+            String whatItDoesPreview = shortenForPreview(whatItDoesFull, MAX_METHOD_DESCRIPTION_PREVIEW);
+            boolean whatItDoesTruncated = !whatItDoesPreview.equals(whatItDoesFull);
 
             card.put("methodName", methodName);
             card.put("classFqn", seed.path("classFqn").asText(""));
             card.put("fqn", fqn);
-            card.put("whatItDoes", seed.path("summarySeed").asText("핵심 동작을 수행한다."));
+            card.put("whatItDoes", whatItDoesPreview);
+            card.put("whatItDoesPreview", whatItDoesPreview);
+            card.put("whatItDoesFull", whatItDoesFull);
+            card.put("whatItDoesTruncated", whatItDoesTruncated);
             card.put("whenToUse", inferWhenToUse(methodName));
             card.put("inputs", extractInputs(seed.path("signatureHint").asText("")));
             card.put("returns", extractReturns(seed.path("signatureHint").asText("")));
@@ -975,7 +982,16 @@ public class LlmService {
             JsonNode method = coreMethods.get(i);
             ObjectNode entry = out.addObject();
             entry.put("fqn", method.path("fqn").asText(""));
-            entry.put("summary", shortenText(method.path("whatItDoes").asText("핵심 동작 수행"), 140));
+            String summaryFull = normalizeSentence(firstNonBlank(
+                    method.path("whatItDoesFull").asText(""),
+                    method.path("whatItDoes").asText("핵심 동작 수행")
+            ));
+            String summaryPreview = shortenForPreview(summaryFull, MAX_METHOD_DESCRIPTION_PREVIEW);
+            boolean summaryTruncated = !summaryPreview.equals(summaryFull);
+            entry.put("summary", summaryPreview);
+            entry.put("summaryPreview", summaryPreview);
+            entry.put("summaryFull", summaryFull);
+            entry.put("summaryTruncated", summaryTruncated);
             entry.put("subsystem", shortenText(method.path("classFqn").asText("core"), 80));
             ArrayNode relatedScenarios = entry.putArray("relatedScenarios");
             relatedScenarios.add("SCN-001");
@@ -1540,6 +1556,44 @@ public class LlmService {
             return value;
         }
         return value.substring(0, maxLength);
+    }
+
+    private String normalizeSentence(String text) {
+        String normalized = safeText(text).replaceAll("\\s+", " ").trim();
+        if (normalized.isBlank()) {
+            return "핵심 동작 수행";
+        }
+        return normalized;
+    }
+
+    private String shortenForPreview(String text, int maxLength) {
+        String value = normalizeSentence(text);
+        if (value.length() <= maxLength) {
+            return value;
+        }
+
+        int sentenceBoundary = findSentenceBoundary(value, maxLength);
+        if (sentenceBoundary >= Math.max(1, maxLength / 2)) {
+            return value.substring(0, sentenceBoundary).trim() + "...";
+        }
+
+        int wordBoundary = value.lastIndexOf(' ', maxLength);
+        if (wordBoundary >= Math.max(1, maxLength / 2)) {
+            return value.substring(0, wordBoundary).trim() + "...";
+        }
+
+        return value.substring(0, maxLength).trim() + "...";
+    }
+
+    private int findSentenceBoundary(String text, int limit) {
+        int scanLimit = Math.min(limit, text.length() - 1);
+        for (int i = scanLimit; i >= 0; i--) {
+            char current = text.charAt(i);
+            if (current == '.' || current == '!' || current == '?') {
+                return i + 1;
+            }
+        }
+        return -1;
     }
 
     private String toJson(Object obj) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/example/ossdoc/domain/cluster/service/SymbolScoringServiceTest.java
+++ b/src/test/java/com/example/ossdoc/domain/cluster/service/SymbolScoringServiceTest.java
@@ -32,6 +32,11 @@ class SymbolScoringServiceTest {
                                 .packageName("com.example.auth")
                                 .moduleId("m1")
                                 .publicApi(true)
+                                .symbolKind("TYPE")
+                                .ownerSymbol(null)
+                                .sourceFile("src/main/java/com/example/auth/AuthController.java")
+                                .sourceStartLine(10)
+                                .sourceEndLine(120)
                                 .build(),
                         ProjectedNode.builder()
                                 .symbolId("sym_service")
@@ -40,6 +45,11 @@ class SymbolScoringServiceTest {
                                 .packageName("com.example.auth")
                                 .moduleId("m1")
                                 .publicApi(false)
+                                .symbolKind("TYPE")
+                                .ownerSymbol(null)
+                                .sourceFile("src/main/java/com/example/auth/AuthService.java")
+                                .sourceStartLine(15)
+                                .sourceEndLine(180)
                                 .build()
                 ))
                 .edges(List.of(
@@ -67,6 +77,11 @@ class SymbolScoringServiceTest {
         assertThat(ranked).hasSize(2);
         assertThat(ranked.get(0).getSymbolId()).isEqualTo("sym_controller");
         assertThat(ranked.get(0).getApiScore()).isEqualTo(1.0);
+        assertThat(ranked.get(0).getSymbolKind()).isEqualTo("TYPE");
+        assertThat(ranked.get(0).getSourceFile()).isEqualTo("src/main/java/com/example/auth/AuthController.java");
+        assertThat(ranked.get(0).getLineRange()).isNotNull();
+        assertThat(ranked.get(0).getLineRange().getStartLine()).isEqualTo(10);
+        assertThat(ranked.get(0).getLineRange().getEndLine()).isEqualTo(120);
         assertThat(ranked.get(1).getSymbolId()).isEqualTo("sym_service");
         assertThat(ranked.get(1).getApiScore()).isEqualTo(0.0);
     }


### PR DESCRIPTION
### 커밋별 의미 정리
1. refactor: api_map.json / api_surface.json 보강
API/심볼에 소스 파일·라인·소유 타입 앵커를 보강해 LLM이 코드 위치 기반 설명을 만들 수 있게 함.
2. refactor: rankings.json 보강
랭킹 심볼에 kind/owner/source/line_range 정보를 추가해 핵심 메서드 선정 근거를 강화함.
3. refactor: rule_candidates.json 역할 확장
규칙 후보 중심 구조를 메서드 기능 카드 생성까지 확장해 설명 커버리지를 넓힘.
4. refactor: symbol_source_index.json 브릿지 산출물 생성
symbol_id ↔ fqn/source/evidence를 단일 인덱스로 연결해 LLM 입력 조립 경로를 단순화함.
5. refactor: LLM 산출물(fileTree/coreMethods) 매핑 보강 및 결과 생성 안정화
fileTree와 coreMethods 간 매핑 정합성을 높여 산출물 누락/불일치를 줄임.
6. refactor: LLM 메서드 설명 full/preview 분리 및 중간 절단 방지
설명문을 full + preview + truncated 구조로 분리하고 단어/문장 경계 기반 preview 생성으로 품질 저하를 방지함.

### 작업 내용
이번 작업은 LLM 설명 품질 개선을 위해 입력 산출물 스키마를 단계적으로 보강하고, 최종 출력 계약을 안정화하는 데 목적이 있습니다. api_map/api_surface/rankings/rule_candidates를 확장해 메서드·클래스 설명의 근거 앵커를 강화했으며, symbol_source_index 브릿지 산출물을 추가해 symbol 기준 소스 매핑을 일관되게 연결했습니다. 이후 fileTree/coreMethods 매핑 로직을 보강해 결과 누락을 줄였고, 마지막으로 설명문 출력을 full/preview/truncated 형태로 분리해 중간 글자 절단 없이 안정적인 미리보기와 전체 보기 호환을 확보했습니다