### PR TITLE
feat: GitHub 사용 통계량 기능(#60)

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/githubstats/client/GithubStatsApiClient.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/client/GithubStatsApiClient.java
@@ -1,0 +1,363 @@
+package com.example.ossdoc.domain.githubstats.client;
+
+import com.example.ossdoc.domain.githubstats.exception.GithubStatsException;
+import com.example.ossdoc.domain.githubstats.exception.code.GithubStatsErrorCode;
+import com.example.ossdoc.global.properties.GithubStatsProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class GithubStatsApiClient {
+
+    private static final String GITHUB_API_BASE_URL = "https://api.github.com";
+    private static final String GITHUB_API_VERSION = "2022-11-28";
+    private static final int ERROR_BODY_PREVIEW_LEN = 300;
+    private static final Pattern LAST_PAGE_PATTERN =
+            Pattern.compile("[?&]page=(\\d+)>; rel=\\\"last\\\"");
+
+    private final ObjectMapper objectMapper;
+    private final GithubStatsProperties properties;
+    private final WebClient webClient;
+
+    public GithubStatsApiClient(ObjectMapper objectMapper, GithubStatsProperties properties) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.webClient = WebClient.builder()
+                .baseUrl(GITHUB_API_BASE_URL)
+                .defaultHeader(HttpHeaders.USER_AGENT, "ossdoc")
+                .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                .defaultHeader("X-GitHub-Api-Version", GITHUB_API_VERSION)
+                .defaultHeaders(headers -> {
+                    if (properties.getToken() != null && !properties.getToken().isBlank()) {
+                        headers.setBearerAuth(properties.getToken());
+                    }
+                })
+                .build();
+    }
+
+    public JsonNode getRepository(String owner, String repo) {
+        return getRequiredJson("/repos/{owner}/{repo}", owner, repo);
+    }
+
+    public JsonNode getLanguages(String owner, String repo) {
+        return getRequiredJson("/repos/{owner}/{repo}/languages", owner, repo);
+    }
+
+    /*
+     * GitHub statistics API는 처음 호출 시 202 Accepted를 반환할 수 있습니다.
+     * 이 경우 null을 반환하고, 서비스 계층에서 commitStatsProcessing=true로 응답합니다.
+     */
+    public JsonNode getCommitActivityOrNull(String owner, String repo) {
+        try {
+            ResponseEntity<String> entity = webClient.get()
+                    .uri("/repos/{owner}/{repo}/stats/commit_activity", owner, repo)
+                    .exchangeToMono(response -> response.toEntity(String.class))
+                    .block(timeout());
+
+            if (entity == null) {
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+            }
+
+            int status = entity.getStatusCode().value();
+
+            if (status == 202) {
+                log.info("GitHub commit activity is processing owner={}, repo={}", owner, repo);
+                return null;
+            }
+
+            if (status == 404) {
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND);
+            }
+
+            if (status < 200 || status >= 300) {
+                log.warn(
+                        "GitHub commit activity API failed owner={}, repo={}, status={}, body={}",
+                        owner,
+                        repo,
+                        status,
+                        previewBody(entity.getBody())
+                );
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+            }
+
+            return readJson(entity.getBody());
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub commit activity API failed owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    public Long countContributors(String owner, String repo) {
+        try {
+            ResponseEntity<String> entity = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/repos/{owner}/{repo}/contributors")
+                            .queryParam("anon", "true")
+                            .queryParam("per_page", "1")
+                            .build(owner, repo))
+                    .exchangeToMono(response -> response.toEntity(String.class))
+                    .block(timeout());
+
+            if (entity == null) {
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+            }
+
+            int status = entity.getStatusCode().value();
+
+            if (status == 404) {
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND);
+            }
+
+            if (status < 200 || status >= 300) {
+                log.warn(
+                        "GitHub contributors API failed owner={}, repo={}, status={}, body={}",
+                        owner,
+                        repo,
+                        status,
+                        previewBody(entity.getBody())
+                );
+                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+            }
+
+            Long countFromLink = parseLastPageNumber(entity.getHeaders().get(HttpHeaders.LINK));
+            if (countFromLink != null) {
+                return countFromLink;
+            }
+
+            JsonNode body = readJson(entity.getBody());
+            if (body == null || !body.isArray()) {
+                return 0L;
+            }
+
+            return (long) body.size();
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub contributors API failed owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    public Long countRecentIssues(String owner, String repo, LocalDate sinceDate) {
+        try {
+            String query = "repo:" + owner + "/" + repo + " type:issue created:>=" + sinceDate;
+
+            JsonNode node = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/search/issues")
+                            .queryParam("q", query)
+                            .queryParam("per_page", "1")
+                            .build())
+                    .exchangeToMono(response -> {
+                        int status = response.statusCode().value();
+
+                        if (status == 404) {
+                            return Mono.<JsonNode>error(
+                                    new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND)
+                            );
+                        }
+
+                        if (status < 200 || status >= 300) {
+                            return response.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .flatMap(body -> {
+                                        log.warn(
+                                                "GitHub issue search API failed owner={}, repo={}, status={}, body={}",
+                                                owner,
+                                                repo,
+                                                status,
+                                                previewBody(body)
+                                        );
+                                        return Mono.<JsonNode>error(
+                                                new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED)
+                                        );
+                                    });
+                        }
+
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .map(this::readJson);
+                    })
+                    .block(timeout());
+
+            if (node == null || node.get("total_count") == null || node.get("total_count").isNull()) {
+                return 0L;
+            }
+
+            return node.get("total_count").asLong();
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub issue search API failed owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    public JsonNode getLatestReleaseOrNull(String owner, String repo) {
+        try {
+            ResponseEntity<String> entity = webClient.get()
+                    .uri("/repos/{owner}/{repo}/releases/latest", owner, repo)
+                    .exchangeToMono(response -> response.toEntity(String.class))
+                    .block(timeout());
+
+            if (entity == null) {
+                return null;
+            }
+
+            int status = entity.getStatusCode().value();
+
+            if (status == 404) {
+                return null;
+            }
+
+            if (status < 200 || status >= 300) {
+                log.warn(
+                        "GitHub latest release API failed owner={}, repo={}, status={}, body={}",
+                        owner,
+                        repo,
+                        status,
+                        previewBody(entity.getBody())
+                );
+                return null;
+            }
+
+            return readJson(entity.getBody());
+        } catch (Exception e) {
+            log.warn(
+                    "GitHub latest release API skipped owner={}, repo={}, cause={}",
+                    owner,
+                    repo,
+                    e.toString()
+            );
+            return null;
+        }
+    }
+
+    private JsonNode getRequiredJson(String path, String owner, String repo) {
+        try {
+            return webClient.get()
+                    .uri(path, owner, repo)
+                    .exchangeToMono(response -> {
+                        int status = response.statusCode().value();
+
+                        if (status == 404) {
+                            return Mono.<JsonNode>error(
+                                    new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND)
+                            );
+                        }
+
+                        if (status < 200 || status >= 300) {
+                            return response.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .flatMap(body -> {
+                                        log.warn(
+                                                "GitHub API failed path={}, owner={}, repo={}, status={}, body={}",
+                                                path,
+                                                owner,
+                                                repo,
+                                                status,
+                                                previewBody(body)
+                                        );
+                                        return Mono.<JsonNode>error(
+                                                new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED)
+                                        );
+                                    });
+                        }
+
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .map(this::readJson);
+                    })
+                    .block(timeout());
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub API failed path={}, owner={}, repo={}, cause={}",
+                    path,
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    private JsonNode readJson(String body) {
+        try {
+            if (body == null || body.isBlank()) {
+                return null;
+            }
+            return objectMapper.readTree(body);
+        } catch (Exception e) {
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_RESPONSE_PARSE_FAILED);
+        }
+    }
+
+    private Long parseLastPageNumber(List<String> linkHeaders) {
+        if (linkHeaders == null || linkHeaders.isEmpty()) {
+            return null;
+        }
+
+        for (String linkHeader : linkHeaders) {
+            Matcher matcher = LAST_PAGE_PATTERN.matcher(linkHeader);
+            if (matcher.find()) {
+                return Long.parseLong(matcher.group(1));
+            }
+        }
+
+        return null;
+    }
+
+    private Duration timeout() {
+        long seconds = properties.getApiTimeoutSeconds() <= 0
+                ? 30
+                : properties.getApiTimeoutSeconds();
+
+        return Duration.ofSeconds(seconds);
+    }
+
+    private String previewBody(String body) {
+        if (body == null || body.isBlank()) {
+            return "<empty>";
+        }
+
+        return body.length() > ERROR_BODY_PREVIEW_LEN
+                ? body.substring(0, ERROR_BODY_PREVIEW_LEN) + "..."
+                : body;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/client/GithubStatsApiClient.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/client/GithubStatsApiClient.java
@@ -12,9 +12,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.util.List;
+import java.time.*;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,58 +53,6 @@ public class GithubStatsApiClient {
 
     public JsonNode getLanguages(String owner, String repo) {
         return getRequiredJson("/repos/{owner}/{repo}/languages", owner, repo);
-    }
-
-    /*
-     * GitHub statistics API는 처음 호출 시 202 Accepted를 반환할 수 있습니다.
-     * 이 경우 null을 반환하고, 서비스 계층에서 commitStatsProcessing=true로 응답합니다.
-     */
-    public JsonNode getCommitActivityOrNull(String owner, String repo) {
-        try {
-            ResponseEntity<String> entity = webClient.get()
-                    .uri("/repos/{owner}/{repo}/stats/commit_activity", owner, repo)
-                    .exchangeToMono(response -> response.toEntity(String.class))
-                    .block(timeout());
-
-            if (entity == null) {
-                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
-            }
-
-            int status = entity.getStatusCode().value();
-
-            if (status == 202) {
-                log.info("GitHub commit activity is processing owner={}, repo={}", owner, repo);
-                return null;
-            }
-
-            if (status == 404) {
-                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND);
-            }
-
-            if (status < 200 || status >= 300) {
-                log.warn(
-                        "GitHub commit activity API failed owner={}, repo={}, status={}, body={}",
-                        owner,
-                        repo,
-                        status,
-                        previewBody(entity.getBody())
-                );
-                throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
-            }
-
-            return readJson(entity.getBody());
-        } catch (GithubStatsException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error(
-                    "GitHub commit activity API failed owner={}, repo={}, cause={}",
-                    owner,
-                    repo,
-                    e.toString(),
-                    e
-            );
-            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
-        }
     }
 
     public Long countContributors(String owner, String repo) {
@@ -166,64 +113,31 @@ public class GithubStatsApiClient {
     }
 
     public Long countRecentIssues(String owner, String repo, LocalDate sinceDate) {
-        try {
-            String query = "repo:" + owner + "/" + repo + " type:issue created:>=" + sinceDate;
+        String query = "repo:" + owner + "/" + repo + " is:issue created:>=" + sinceDate;
+        return countIssuesBySearchQuery(owner, repo, query, "created issues");
+    }
 
-            JsonNode node = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/search/issues")
-                            .queryParam("q", query)
-                            .queryParam("per_page", "1")
-                            .build())
-                    .exchangeToMono(response -> {
-                        int status = response.statusCode().value();
+    public Long countRecentClosedIssues(String owner, String repo, LocalDate sinceDate) {
+        String query = "repo:" + owner + "/" + repo + " is:issue closed:>=" + sinceDate;
+        return countIssuesBySearchQuery(owner, repo, query, "closed issues");
+    }
 
-                        if (status == 404) {
-                            return Mono.<JsonNode>error(
-                                    new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND)
-                            );
-                        }
+    /**
+     * 최근 28일 이슈 생성 수를 날짜별로 계산합니다.
+     * 하루마다 28번 호출하지 않고 Search API를 페이지 단위로 조회합니다.
+     */
+    public Map<LocalDate, Integer> countRecentIssuesByDate(String owner, String repo, LocalDate sinceDate) {
+        String query = "repo:" + owner + "/" + repo + " is:issue created:>=" + sinceDate;
+        return countIssuesByDate(owner, repo, sinceDate, query, "created_at", "created issues by date");
+    }
 
-                        if (status < 200 || status >= 300) {
-                            return response.bodyToMono(String.class)
-                                    .defaultIfEmpty("")
-                                    .flatMap(body -> {
-                                        log.warn(
-                                                "GitHub issue search API failed owner={}, repo={}, status={}, body={}",
-                                                owner,
-                                                repo,
-                                                status,
-                                                previewBody(body)
-                                        );
-                                        return Mono.<JsonNode>error(
-                                                new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED)
-                                        );
-                                    });
-                        }
-
-                        return response.bodyToMono(String.class)
-                                .defaultIfEmpty("")
-                                .map(this::readJson);
-                    })
-                    .block(timeout());
-
-            if (node == null || node.get("total_count") == null || node.get("total_count").isNull()) {
-                return 0L;
-            }
-
-            return node.get("total_count").asLong();
-        } catch (GithubStatsException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error(
-                    "GitHub issue search API failed owner={}, repo={}, cause={}",
-                    owner,
-                    repo,
-                    e.toString(),
-                    e
-            );
-            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
-        }
+    /**
+     * 최근 28일 해결된 이슈 수를 날짜별로 계산합니다.
+     * GitHub Search API의 closed qualifier와 closed_at 값을 사용합니다.
+     */
+    public Map<LocalDate, Integer> countRecentClosedIssuesByDate(String owner, String repo, LocalDate sinceDate) {
+        String query = "repo:" + owner + "/" + repo + " is:issue closed:>=" + sinceDate;
+        return countIssuesByDate(owner, repo, sinceDate, query, "closed_at", "closed issues by date");
     }
 
     public JsonNode getLatestReleaseOrNull(String owner, String repo) {
@@ -263,6 +177,161 @@ public class GithubStatsApiClient {
                     e.toString()
             );
             return null;
+        }
+    }
+
+    private Long countIssuesBySearchQuery(String owner, String repo, String query, String apiName) {
+        try {
+            JsonNode node = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/search/issues")
+                            .queryParam("q", query)
+                            .queryParam("per_page", "1")
+                            .build())
+                    .exchangeToMono(response -> {
+                        int status = response.statusCode().value();
+
+                        if (status == 404) {
+                            return Mono.<JsonNode>error(
+                                    new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND)
+                            );
+                        }
+
+                        if (status < 200 || status >= 300) {
+                            return response.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .flatMap(body -> {
+                                        log.warn(
+                                                "GitHub issue search API failed apiName={}, owner={}, repo={}, status={}, body={}",
+                                                apiName,
+                                                owner,
+                                                repo,
+                                                status,
+                                                previewBody(body)
+                                        );
+                                        return Mono.<JsonNode>error(
+                                                new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED)
+                                        );
+                                    });
+                        }
+
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .map(this::readJson);
+                    })
+                    .block(timeout());
+
+            if (node == null || node.get("total_count") == null || node.get("total_count").isNull()) {
+                return 0L;
+            }
+
+            return node.get("total_count").asLong();
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub issue search API failed apiName={}, owner={}, repo={}, cause={}",
+                    apiName,
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    private Map<LocalDate, Integer> countIssuesByDate(
+            String owner,
+            String repo,
+            LocalDate sinceDate,
+            String query,
+            String dateFieldName,
+            String apiName
+    ) {
+        try {
+            Map<LocalDate, Integer> result = initializeDailyCountMap(sinceDate);
+            LocalDate today = LocalDate.now(ZoneOffset.UTC);
+
+            for (int page = 1; page <= 10; page++) {
+                int currentPage = page;
+
+                JsonNode node = webClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path("/search/issues")
+                                .queryParam("q", query)
+                                .queryParam("sort", "created_at".equals(dateFieldName) ? "created" : "updated")
+                                .queryParam("order", "desc")
+                                .queryParam("per_page", "100")
+                                .queryParam("page", currentPage)
+                                .build())
+                        .exchangeToMono(response -> {
+                            int status = response.statusCode().value();
+
+                            if (status == 404) {
+                                return Mono.<JsonNode>error(
+                                        new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_REPOSITORY_NOT_FOUND)
+                                );
+                            }
+
+                            if (status < 200 || status >= 300) {
+                                return response.bodyToMono(String.class)
+                                        .defaultIfEmpty("")
+                                        .flatMap(body -> {
+                                            log.warn(
+                                                    "GitHub issue search API failed apiName={}, owner={}, repo={}, status={}, body={}",
+                                                    apiName,
+                                                    owner,
+                                                    repo,
+                                                    status,
+                                                    previewBody(body)
+                                            );
+                                            return Mono.<JsonNode>error(
+                                                    new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED)
+                                            );
+                                        });
+                            }
+
+                            return response.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .map(this::readJson);
+                        })
+                        .block(timeout());
+
+                JsonNode items = node == null ? null : node.get("items");
+
+                if (items == null || !items.isArray() || items.size() == 0) {
+                    break;
+                }
+
+                for (JsonNode item : items) {
+                    LocalDate date = parseGithubDate(item.path(dateFieldName).asText(null));
+
+                    if (date == null || date.isBefore(sinceDate) || date.isAfter(today)) {
+                        continue;
+                    }
+
+                    result.merge(date, 1, Integer::sum);
+                }
+
+                if (items.size() < 100) {
+                    break;
+                }
+            }
+
+            return result;
+        } catch (GithubStatsException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "GitHub issue search API failed apiName={}, owner={}, repo={}, cause={}",
+                    apiName,
+                    owner,
+                    repo,
+                    e.toString(),
+                    e
+            );
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
         }
     }
 
@@ -314,6 +383,30 @@ public class GithubStatsApiClient {
                     e
             );
             throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_API_FAILED);
+        }
+    }
+
+    private Map<LocalDate, Integer> initializeDailyCountMap(LocalDate sinceDate) {
+        Map<LocalDate, Integer> result = new LinkedHashMap<>();
+
+        for (int i = 0; i < 28; i++) {
+            result.put(sinceDate.plusDays(i), 0);
+        }
+
+        return result;
+    }
+
+    private LocalDate parseGithubDate(String dateText) {
+        if (dateText == null || dateText.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Instant.parse(dateText)
+                    .atZone(ZoneOffset.UTC)
+                    .toLocalDate();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/example/ossdoc/domain/githubstats/controller/GithubStatsController.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/controller/GithubStatsController.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.githubstats.controller;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.githubstats.dto.response.GithubStatsResponse;
+import com.example.ossdoc.domain.githubstats.service.GithubStatsService;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/runs")
+public class GithubStatsController {
+
+    private final GithubStatsService githubStatsService;
+
+    /*
+     * 분석 완료 run 기준 GitHub 사용 통계량 조회 API입니다.
+     *
+     * GET /api/v1/runs/{runId}/github-stats
+     * GET /api/v1/runs/{runId}/github-stats?forceRefresh=true
+     */
+    @GetMapping("/{runId}/github-stats")
+    public ApiResponse<GithubStatsResponse> getGithubStats(
+            @PathVariable String runId,
+            @RequestParam(defaultValue = "false") boolean forceRefresh,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
+
+        GithubStatsResponse response = githubStatsService.getStats(
+                runId,
+                authenticatedUser.getUserId(),
+                forceRefresh
+        );
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/dto/response/GithubStatsResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/dto/response/GithubStatsResponse.java
@@ -29,6 +29,7 @@ public class GithubStatsResponse {
         private final String name;
         private final String description;
         private final String htmlUrl;
+        private final String avatarUrl;
         private final String language;
         private final Double languagePercent;
         private final String defaultBranch;
@@ -47,14 +48,13 @@ public class GithubStatsResponse {
         private final Long stars;
         private final Long forks;
         private final Long openIssues;
-        private final Integer recent28dCommits;
         private final Long recent28dIssues;
+        private final Long recent28dClosedIssues;
         private final Long contributors;
 
         /*
-         * GitHub API만으로 과거 대비 증가량을 안정적으로 계산하기 어렵기 때문에,
-         * 초기 버전에서는 null로 내려주고 FE에서 숨김 처리합니다.
-         * 추후 우리 DB에 일별 snapshot을 쌓으면 값 채우면 됩니다.
+         * 현재 버전에서는 snapshot이 충분히 쌓였을 때만 계산합니다.
+         * 값이 null이면 FE에서 증가량 문구를 숨기거나 "-"로 표시합니다.
          */
         private final Long starDelta28d;
         private final Long forkDelta28d;
@@ -66,26 +66,16 @@ public class GithubStatsResponse {
     @Builder
     @Jacksonized
     public static class Activity {
-        private final Boolean commitStatsProcessing;
-        private final List<DailyActivity> recent28dDailyActivities;
-        private final List<WeeklyCommitActivity> lastYearWeeklyCommits;
+        private final List<DailyIssueActivity> recent28dDailyIssueActivities;
     }
 
     @Getter
     @Builder
     @Jacksonized
-    public static class DailyActivity {
+    public static class DailyIssueActivity {
         private final String date;
-        private final Integer commits;
         private final Integer issuesCreated;
-    }
-
-    @Getter
-    @Builder
-    @Jacksonized
-    public static class WeeklyCommitActivity {
-        private final String weekStart;
-        private final Integer commits;
+        private final Integer issuesClosed;
     }
 
     @Getter

--- a/src/main/java/com/example/ossdoc/domain/githubstats/dto/response/GithubStatsResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/dto/response/GithubStatsResponse.java
@@ -1,0 +1,99 @@
+package com.example.ossdoc.domain.githubstats.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder(toBuilder = true)
+@Jacksonized
+public class GithubStatsResponse {
+
+    private final String runId;
+    private final RepositoryInfo repository;
+    private final Summary summary;
+    private final Activity activity;
+    private final List<Insight> insights;
+    private final LocalDateTime collectedAt;
+    private final Boolean fromCache;
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class RepositoryInfo {
+        private final String fullName;
+        private final String owner;
+        private final String name;
+        private final String description;
+        private final String htmlUrl;
+        private final String language;
+        private final Double languagePercent;
+        private final String defaultBranch;
+        private final String license;
+        private final String createdAt;
+        private final String updatedAt;
+        private final String pushedAt;
+        private final String latestRelease;
+        private final String latestReleasePublishedAt;
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class Summary {
+        private final Long stars;
+        private final Long forks;
+        private final Long openIssues;
+        private final Integer recent28dCommits;
+        private final Long recent28dIssues;
+        private final Long contributors;
+
+        /*
+         * GitHub API만으로 과거 대비 증가량을 안정적으로 계산하기 어렵기 때문에,
+         * 초기 버전에서는 null로 내려주고 FE에서 숨김 처리합니다.
+         * 추후 우리 DB에 일별 snapshot을 쌓으면 값 채우면 됩니다.
+         */
+        private final Long starDelta28d;
+        private final Long forkDelta28d;
+        private final Long openIssueDelta28d;
+        private final Long contributorDelta28d;
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class Activity {
+        private final Boolean commitStatsProcessing;
+        private final List<DailyActivity> recent28dDailyActivities;
+        private final List<WeeklyCommitActivity> lastYearWeeklyCommits;
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class DailyActivity {
+        private final String date;
+        private final Integer commits;
+        private final Integer issuesCreated;
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class WeeklyCommitActivity {
+        private final String weekStart;
+        private final Integer commits;
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class Insight {
+        private final String type;
+        private final String title;
+        private final String message;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/entity/GithubStatsSnapshot.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/entity/GithubStatsSnapshot.java
@@ -50,11 +50,11 @@ public class GithubStatsSnapshot extends BaseCreatedEntity {
     @Column(name = "contributors")
     private Long contributors;
 
-    @Column(name = "recent_28d_commits")
-    private Integer recent28dCommits;
-
     @Column(name = "recent_28d_issues")
     private Long recent28dIssues;
+
+    @Column(name = "recent_28d_closed_issues")
+    private Long recent28dClosedIssues;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
@@ -70,8 +70,8 @@ public class GithubStatsSnapshot extends BaseCreatedEntity {
             Long forks,
             Long openIssues,
             Long contributors,
-            Integer recent28dCommits,
             Long recent28dIssues,
+            Long recent28dClosedIssues,
             JsonNode payload,
             LocalDateTime collectedAt
     ) {
@@ -82,8 +82,8 @@ public class GithubStatsSnapshot extends BaseCreatedEntity {
         snapshot.forks = forks;
         snapshot.openIssues = openIssues;
         snapshot.contributors = contributors;
-        snapshot.recent28dCommits = recent28dCommits;
         snapshot.recent28dIssues = recent28dIssues;
+        snapshot.recent28dClosedIssues = recent28dClosedIssues;
         snapshot.payload = payload;
         snapshot.collectedAt = collectedAt;
         return snapshot;

--- a/src/main/java/com/example/ossdoc/domain/githubstats/entity/GithubStatsSnapshot.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/entity/GithubStatsSnapshot.java
@@ -1,0 +1,91 @@
+package com.example.ossdoc.domain.githubstats.entity;
+
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.global.apiPayload.code.BaseCreatedEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "github_stats_snapshot",
+        indexes = {
+                @Index(name = "idx_github_stats_run_collected", columnList = "run_id, collected_at"),
+                @Index(name = "idx_github_stats_repo_collected", columnList = "repo_full_name, collected_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GithubStatsSnapshot extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "github_stats_snapshot_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "run_id", nullable = false)
+    private RepoRun run;
+
+    @Column(name = "repo_full_name", nullable = false)
+    private String repoFullName;
+
+    @Column(name = "stars")
+    private Long stars;
+
+    @Column(name = "forks")
+    private Long forks;
+
+    @Column(name = "open_issues")
+    private Long openIssues;
+
+    @Column(name = "contributors")
+    private Long contributors;
+
+    @Column(name = "recent_28d_commits")
+    private Integer recent28dCommits;
+
+    @Column(name = "recent_28d_issues")
+    private Long recent28dIssues;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
+    private JsonNode payload;
+
+    @Column(name = "collected_at", nullable = false)
+    private LocalDateTime collectedAt;
+
+    public static GithubStatsSnapshot create(
+            RepoRun run,
+            String repoFullName,
+            Long stars,
+            Long forks,
+            Long openIssues,
+            Long contributors,
+            Integer recent28dCommits,
+            Long recent28dIssues,
+            JsonNode payload,
+            LocalDateTime collectedAt
+    ) {
+        GithubStatsSnapshot snapshot = new GithubStatsSnapshot();
+        snapshot.run = run;
+        snapshot.repoFullName = repoFullName;
+        snapshot.stars = stars;
+        snapshot.forks = forks;
+        snapshot.openIssues = openIssues;
+        snapshot.contributors = contributors;
+        snapshot.recent28dCommits = recent28dCommits;
+        snapshot.recent28dIssues = recent28dIssues;
+        snapshot.payload = payload;
+        snapshot.collectedAt = collectedAt;
+        return snapshot;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/exception/GithubStatsException.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/exception/GithubStatsException.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.githubstats.exception;
+
+import com.example.ossdoc.domain.githubstats.exception.code.GithubStatsErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class GithubStatsException extends GeneralException {
+
+    public GithubStatsException(GithubStatsErrorCode code) {
+        super(code);
+    }
+
+    public GithubStatsException(GithubStatsErrorCode code, String detailMessage) {
+        super(code, detailMessage);
+    }
+
+    public GithubStatsException(BaseCode code) {
+        super(code);
+    }
+
+    public GithubStatsException(BaseCode code, String detailMessage) {
+        super(code, detailMessage);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/exception/code/GithubStatsErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/exception/code/GithubStatsErrorCode.java
@@ -1,0 +1,77 @@
+package com.example.ossdoc.domain.githubstats.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GithubStatsErrorCode implements BaseCode {
+
+    GITHUB_STATS_RUN_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "GITHUBSTATS404_1",
+            "존재하지 않는 run 입니다."
+    ),
+
+    GITHUB_STATS_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "GITHUBSTATS403_1",
+            "해당 run 접근 권한이 없습니다."
+    ),
+
+    GITHUB_STATS_INVALID_REPOSITORY(
+            HttpStatus.BAD_REQUEST,
+            "GITHUBSTATS400_1",
+            "GitHub 저장소 정보가 올바르지 않습니다."
+    ),
+
+    GITHUB_STATS_REPOSITORY_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "GITHUBSTATS404_2",
+            "GitHub 저장소를 찾을 수 없습니다."
+    ),
+
+    GITHUB_STATS_API_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "GITHUBSTATS502_1",
+            "GitHub 통계 API 호출에 실패했습니다."
+    ),
+
+    GITHUB_STATS_RESPONSE_PARSE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "GITHUBSTATS500_1",
+            "GitHub 통계 응답 처리에 실패했습니다."
+    ),
+
+    GITHUB_STATS_CACHE_READ_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "GITHUBSTATS500_2",
+            "GitHub 통계 캐시 조회에 실패했습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/repository/GithubStatsSnapshotRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/repository/GithubStatsSnapshotRepository.java
@@ -1,0 +1,23 @@
+package com.example.ossdoc.domain.githubstats.repository;
+
+import com.example.ossdoc.domain.githubstats.entity.GithubStatsSnapshot;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface GithubStatsSnapshotRepository extends JpaRepository<GithubStatsSnapshot, Long> {
+
+    @Query("""
+            select s
+            from GithubStatsSnapshot s
+            where s.run.runId = :runId
+            order by s.collectedAt desc
+            """)
+    List<GithubStatsSnapshot> findLatestByRunId(
+            @Param("runId") String runId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsInsightBuilder.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsInsightBuilder.java
@@ -11,13 +11,13 @@ public class GithubStatsInsightBuilder {
 
     public List<GithubStatsResponse.Insight> build(
             Long stars,
-            Integer recent28dCommits,
+            Long recent28dClosedIssues,
             Long contributors
     ) {
         List<GithubStatsResponse.Insight> insights = new ArrayList<>();
 
         insights.add(popularityInsight(stars));
-        insights.add(maintenanceInsight(recent28dCommits));
+        insights.add(maintenanceInsight(recent28dClosedIssues));
         insights.add(communityInsight(contributors));
 
         return insights;
@@ -49,35 +49,35 @@ public class GithubStatsInsightBuilder {
         );
     }
 
-    private GithubStatsResponse.Insight maintenanceInsight(Integer recent28dCommits) {
-        if (recent28dCommits == null) {
+    private GithubStatsResponse.Insight maintenanceInsight(Long recent28dClosedIssues) {
+        if (recent28dClosedIssues == null) {
             return insight(
                     "MAINTENANCE",
-                    "활동 수집 중",
-                    "GitHub 커밋 통계가 아직 생성 중입니다. 잠시 후 다시 조회해주세요."
+                    "이슈 해결 수집 실패",
+                    "최근 28일 해결 이슈를 수집하지 못했습니다. GitHub API 상태를 확인해주세요."
             );
         }
 
-        if (recent28dCommits >= 100) {
+        if (recent28dClosedIssues >= 100) {
             return insight(
                     "MAINTENANCE",
-                    "활발한 유지보수",
-                    "최근 28일 동안 커밋이 꾸준히 발생하여 개발 활동이 활발합니다."
+                    "활발한 이슈 대응",
+                    "최근 28일 동안 해결된 이슈가 많아 유지보수 대응이 활발합니다."
             );
         }
 
-        if (recent28dCommits >= 20) {
+        if (recent28dClosedIssues >= 20) {
             return insight(
                     "MAINTENANCE",
-                    "유지보수 진행 중",
-                    "최근 28일 동안 일정 수준의 커밋 활동이 확인됩니다."
+                    "이슈 대응 진행 중",
+                    "최근 28일 동안 일정 수준의 이슈 해결 활동이 확인됩니다."
             );
         }
 
         return insight(
                 "MAINTENANCE",
-                "낮은 최근 활동",
-                "최근 28일 커밋 수가 적어 유지보수 상태를 추가로 확인하는 것이 좋습니다."
+                "낮은 최근 이슈 해결",
+                "최근 28일 해결 이슈 수가 적어 유지보수 상태를 추가로 확인하는 것이 좋습니다."
         );
     }
 

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsInsightBuilder.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsInsightBuilder.java
@@ -1,0 +1,117 @@
+package com.example.ossdoc.domain.githubstats.service;
+
+import com.example.ossdoc.domain.githubstats.dto.response.GithubStatsResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class GithubStatsInsightBuilder {
+
+    public List<GithubStatsResponse.Insight> build(
+            Long stars,
+            Integer recent28dCommits,
+            Long contributors
+    ) {
+        List<GithubStatsResponse.Insight> insights = new ArrayList<>();
+
+        insights.add(popularityInsight(stars));
+        insights.add(maintenanceInsight(recent28dCommits));
+        insights.add(communityInsight(contributors));
+
+        return insights;
+    }
+
+    private GithubStatsResponse.Insight popularityInsight(Long stars) {
+        long value = stars == null ? 0 : stars;
+
+        if (value >= 10_000) {
+            return insight(
+                    "POPULARITY",
+                    "높은 인기",
+                    "스타 수가 높아 많은 사용자가 관심을 가지고 있는 저장소입니다."
+            );
+        }
+
+        if (value >= 1_000) {
+            return insight(
+                    "POPULARITY",
+                    "일정 수준의 인기",
+                    "스타 수를 기준으로 일정 규모 이상의 관심을 받고 있는 저장소입니다."
+            );
+        }
+
+        return insight(
+                "POPULARITY",
+                "낮은 인지도",
+                "스타 수가 아직 많지 않아 도입 전 추가 검토가 필요합니다."
+        );
+    }
+
+    private GithubStatsResponse.Insight maintenanceInsight(Integer recent28dCommits) {
+        if (recent28dCommits == null) {
+            return insight(
+                    "MAINTENANCE",
+                    "활동 수집 중",
+                    "GitHub 커밋 통계가 아직 생성 중입니다. 잠시 후 다시 조회해주세요."
+            );
+        }
+
+        if (recent28dCommits >= 100) {
+            return insight(
+                    "MAINTENANCE",
+                    "활발한 유지보수",
+                    "최근 28일 동안 커밋이 꾸준히 발생하여 개발 활동이 활발합니다."
+            );
+        }
+
+        if (recent28dCommits >= 20) {
+            return insight(
+                    "MAINTENANCE",
+                    "유지보수 진행 중",
+                    "최근 28일 동안 일정 수준의 커밋 활동이 확인됩니다."
+            );
+        }
+
+        return insight(
+                "MAINTENANCE",
+                "낮은 최근 활동",
+                "최근 28일 커밋 수가 적어 유지보수 상태를 추가로 확인하는 것이 좋습니다."
+        );
+    }
+
+    private GithubStatsResponse.Insight communityInsight(Long contributors) {
+        long value = contributors == null ? 0 : contributors;
+
+        if (value >= 100) {
+            return insight(
+                    "COMMUNITY",
+                    "넓은 커뮤니티",
+                    "많은 기여자가 참여하고 있어 커뮤니티 규모가 큰 저장소입니다."
+            );
+        }
+
+        if (value >= 20) {
+            return insight(
+                    "COMMUNITY",
+                    "일정 규모의 커뮤니티",
+                    "여러 기여자가 참여하고 있어 협업 이력이 확인됩니다."
+            );
+        }
+
+        return insight(
+                "COMMUNITY",
+                "작은 커뮤니티",
+                "기여자 수가 많지 않아 장기 유지보수 가능성을 함께 확인해야 합니다."
+        );
+    }
+
+    private GithubStatsResponse.Insight insight(String type, String title, String message) {
+        return GithubStatsResponse.Insight.builder()
+                .type(type)
+                .title(title)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsQueryService.java
@@ -8,6 +8,7 @@ import com.example.ossdoc.domain.githubstats.repository.GithubStatsSnapshotRepos
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.global.properties.GithubStatsProperties;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,7 @@ public class GithubStatsQueryService {
 
         GithubStatsSnapshot snapshot = snapshots.get(0);
 
-        if (!isCacheAlive(snapshot)) {
+        if (!isCacheAlive(snapshot) || !isIssueActivityCache(snapshot.getPayload())) {
             return Optional.empty();
         }
 
@@ -79,6 +80,18 @@ public class GithubStatsQueryService {
 
             throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_CACHE_READ_FAILED);
         }
+    }
+
+    private boolean isIssueActivityCache(JsonNode payload) {
+        if (payload == null || payload.isNull()) {
+            return false;
+        }
+
+        JsonNode summary = payload.path("summary");
+        JsonNode activity = payload.path("activity");
+
+        return summary.has("recent28dClosedIssues")
+                && activity.has("recent28dDailyIssueActivities");
     }
 
     private boolean isCacheAlive(GithubStatsSnapshot snapshot) {

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsQueryService.java
@@ -1,0 +1,93 @@
+package com.example.ossdoc.domain.githubstats.service;
+
+import com.example.ossdoc.domain.githubstats.dto.response.GithubStatsResponse;
+import com.example.ossdoc.domain.githubstats.entity.GithubStatsSnapshot;
+import com.example.ossdoc.domain.githubstats.exception.GithubStatsException;
+import com.example.ossdoc.domain.githubstats.exception.code.GithubStatsErrorCode;
+import com.example.ossdoc.domain.githubstats.repository.GithubStatsSnapshotRepository;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.example.ossdoc.global.properties.GithubStatsProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GithubStatsQueryService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final GithubStatsSnapshotRepository snapshotRepository;
+    private final GithubStatsProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public RepoRun findRunAndCheckOwner(String runId, Long userId) {
+        RepoRun run = repoRunRepository.findById(runId)
+                .orElseThrow(() -> new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_RUN_NOT_FOUND));
+
+        if (run.getOwner() == null || !Objects.equals(run.getOwner().getId(), userId)) {
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_FORBIDDEN);
+        }
+
+        return run;
+    }
+
+    public Optional<GithubStatsResponse> findValidCache(String runId) {
+        List<GithubStatsSnapshot> snapshots =
+                snapshotRepository.findLatestByRunId(runId, PageRequest.of(0, 1));
+
+        if (snapshots.isEmpty()) {
+            return Optional.empty();
+        }
+
+        GithubStatsSnapshot snapshot = snapshots.get(0);
+
+        if (!isCacheAlive(snapshot)) {
+            return Optional.empty();
+        }
+
+        try {
+            GithubStatsResponse response = objectMapper.treeToValue(
+                    snapshot.getPayload(),
+                    GithubStatsResponse.class
+            );
+
+            return Optional.of(
+                    response.toBuilder()
+                            .fromCache(true)
+                            .collectedAt(snapshot.getCollectedAt())
+                            .build()
+            );
+
+        } catch (Exception e) {
+            log.warn(
+                    "GitHub stats cache read failed runId={}, snapshotId={}",
+                    runId,
+                    snapshot.getId(),
+                    e
+            );
+
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_CACHE_READ_FAILED);
+        }
+    }
+
+    private boolean isCacheAlive(GithubStatsSnapshot snapshot) {
+        long ttlMinutes = properties.getCacheTtlMinutes() <= 0
+                ? 360
+                : properties.getCacheTtlMinutes();
+
+        return snapshot.getCollectedAt()
+                .plusMinutes(ttlMinutes)
+                .isAfter(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsService.java
@@ -1,0 +1,275 @@
+package com.example.ossdoc.domain.githubstats.service;
+
+import com.example.ossdoc.domain.githubstats.client.GithubStatsApiClient;
+import com.example.ossdoc.domain.githubstats.dto.response.GithubStatsResponse;
+import com.example.ossdoc.domain.githubstats.exception.GithubStatsException;
+import com.example.ossdoc.domain.githubstats.exception.code.GithubStatsErrorCode;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.support.GithubRepoRef;
+import com.example.ossdoc.domain.run.support.GithubUrlParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GithubStatsService {
+
+    private static final ZoneId UTC = ZoneOffset.UTC;
+    private static final int RECENT_DAYS = 28;
+
+    private final GithubStatsQueryService githubStatsQueryService;
+    private final GithubStatsSnapshotCommandService snapshotCommandService;
+    private final GithubStatsApiClient githubStatsApiClient;
+    private final GithubStatsInsightBuilder insightBuilder;
+
+    public GithubStatsResponse getStats(String runId, Long userId, boolean forceRefresh) {
+        RepoRun run = githubStatsQueryService.findRunAndCheckOwner(runId, userId);
+
+        if (!forceRefresh) {
+            Optional<GithubStatsResponse> cached = githubStatsQueryService.findValidCache(runId);
+
+            if (cached.isPresent()) {
+                return cached.get();
+            }
+        }
+
+        return collectAndSave(run);
+    }
+
+    private GithubStatsResponse collectAndSave(RepoRun run) {
+        GithubRepoRef repoRef = resolveRepoRef(run);
+
+        String owner = repoRef.getOwner();
+        String repo = repoRef.getRepo();
+
+        JsonNode repositoryNode = githubStatsApiClient.getRepository(owner, repo);
+        JsonNode languagesNode = githubStatsApiClient.getLanguages(owner, repo);
+        JsonNode commitActivityNode = githubStatsApiClient.getCommitActivityOrNull(owner, repo);
+        JsonNode latestReleaseNode = githubStatsApiClient.getLatestReleaseOrNull(owner, repo);
+
+        Long contributors = githubStatsApiClient.countContributors(owner, repo);
+
+        LocalDate recentStartDate = LocalDate.now(UTC).minusDays(RECENT_DAYS - 1L);
+        Long recentIssues = githubStatsApiClient.countRecentIssues(owner, repo, recentStartDate);
+
+        CommitActivityResult commitActivity = buildCommitActivity(commitActivityNode, recentStartDate);
+
+        String fullName = text(repositoryNode, "full_name", owner + "/" + repo);
+        String primaryLanguage = text(repositoryNode, "language", null);
+        Double languagePercent = calculateLanguagePercent(languagesNode, primaryLanguage);
+
+        Long stars = longValue(repositoryNode, "stargazers_count");
+        Long forks = longValue(repositoryNode, "forks_count");
+        Long openIssues = longValue(repositoryNode, "open_issues_count");
+
+        LocalDateTime collectedAt = LocalDateTime.now();
+
+        GithubStatsResponse response = GithubStatsResponse.builder()
+                .runId(run.getRunId())
+                .repository(GithubStatsResponse.RepositoryInfo.builder()
+                        .fullName(fullName)
+                        .owner(owner)
+                        .name(repo)
+                        .description(text(repositoryNode, "description", ""))
+                        .htmlUrl(text(repositoryNode, "html_url", ""))
+                        .language(primaryLanguage)
+                        .languagePercent(languagePercent)
+                        .defaultBranch(text(repositoryNode, "default_branch", ""))
+                        .license(resolveLicense(repositoryNode))
+                        .createdAt(text(repositoryNode, "created_at", null))
+                        .updatedAt(text(repositoryNode, "updated_at", null))
+                        .pushedAt(text(repositoryNode, "pushed_at", null))
+                        .latestRelease(text(latestReleaseNode, "tag_name", null))
+                        .latestReleasePublishedAt(text(latestReleaseNode, "published_at", null))
+                        .build())
+                .summary(GithubStatsResponse.Summary.builder()
+                        .stars(stars)
+                        .forks(forks)
+                        .openIssues(openIssues)
+                        .recent28dCommits(commitActivity.recent28dCommits())
+                        .recent28dIssues(recentIssues)
+                        .contributors(contributors)
+                        .starDelta28d(null)
+                        .forkDelta28d(null)
+                        .openIssueDelta28d(null)
+                        .contributorDelta28d(null)
+                        .build())
+                .activity(GithubStatsResponse.Activity.builder()
+                        .commitStatsProcessing(commitActivity.processing())
+                        .recent28dDailyActivities(commitActivity.dailyActivities())
+                        .lastYearWeeklyCommits(commitActivity.weeklyActivities())
+                        .build())
+                .insights(insightBuilder.build(stars, commitActivity.recent28dCommits(), contributors))
+                .collectedAt(collectedAt)
+                .fromCache(false)
+                .build();
+
+        snapshotCommandService.saveSnapshot(run.getRunId(), response);
+
+        return response;
+    }
+
+    private GithubRepoRef resolveRepoRef(RepoRun run) {
+        if (notBlank(run.getRepoOwner()) && notBlank(run.getRepoName())) {
+            return GithubRepoRef.builder()
+                    .owner(run.getRepoOwner())
+                    .repo(run.getRepoName())
+                    .build();
+        }
+
+        try {
+            return GithubUrlParser.parse(run.getRepoUrl(), null);
+        } catch (Exception e) {
+            throw new GithubStatsException(GithubStatsErrorCode.GITHUB_STATS_INVALID_REPOSITORY);
+        }
+    }
+
+    private CommitActivityResult buildCommitActivity(JsonNode commitActivityNode, LocalDate recentStartDate) {
+        LocalDate today = LocalDate.now(UTC);
+
+        Map<LocalDate, Integer> recentCommitCounts = new LinkedHashMap<>();
+
+        for (int i = 0; i < RECENT_DAYS; i++) {
+            recentCommitCounts.put(recentStartDate.plusDays(i), 0);
+        }
+
+        List<GithubStatsResponse.WeeklyCommitActivity> weeklyActivities = new ArrayList<>();
+
+        if (commitActivityNode == null || !commitActivityNode.isArray()) {
+            List<GithubStatsResponse.DailyActivity> daily = recentCommitCounts.entrySet()
+                    .stream()
+                    .map(entry -> dailyActivity(entry.getKey(), null, null))
+                    .toList();
+
+            return new CommitActivityResult(true, null, daily, weeklyActivities);
+        }
+
+        for (JsonNode weekNode : commitActivityNode) {
+            long weekEpochSeconds = weekNode.path("week").asLong(0L);
+
+            LocalDate weekStart = Instant.ofEpochSecond(weekEpochSeconds)
+                    .atZone(UTC)
+                    .toLocalDate();
+
+            int weekTotal = weekNode.path("total").asInt(0);
+
+            weeklyActivities.add(GithubStatsResponse.WeeklyCommitActivity.builder()
+                    .weekStart(weekStart.toString())
+                    .commits(weekTotal)
+                    .build());
+
+            JsonNode daysNode = weekNode.path("days");
+
+            if (!daysNode.isArray()) {
+                continue;
+            }
+
+            for (int i = 0; i < daysNode.size(); i++) {
+                LocalDate date = weekStart.plusDays(i);
+
+                if (date.isBefore(recentStartDate) || date.isAfter(today)) {
+                    continue;
+                }
+
+                recentCommitCounts.put(date, daysNode.get(i).asInt(0));
+            }
+        }
+
+        int recentTotal = recentCommitCounts.values()
+                .stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+
+        List<GithubStatsResponse.DailyActivity> daily = recentCommitCounts.entrySet()
+                .stream()
+                .map(entry -> dailyActivity(entry.getKey(), entry.getValue(), null))
+                .toList();
+
+        return new CommitActivityResult(false, recentTotal, daily, weeklyActivities);
+    }
+
+    private GithubStatsResponse.DailyActivity dailyActivity(
+            LocalDate date,
+            Integer commits,
+            Integer issuesCreated
+    ) {
+        return GithubStatsResponse.DailyActivity.builder()
+                .date(date.toString())
+                .commits(commits)
+                .issuesCreated(issuesCreated)
+                .build();
+    }
+
+    private Double calculateLanguagePercent(JsonNode languagesNode, String primaryLanguage) {
+        if (languagesNode == null || primaryLanguage == null || primaryLanguage.isBlank()) {
+            return null;
+        }
+
+        long totalBytes = 0;
+
+        Iterator<Map.Entry<String, JsonNode>> fields = languagesNode.fields();
+
+        while (fields.hasNext()) {
+            totalBytes += fields.next().getValue().asLong(0L);
+        }
+
+        if (totalBytes <= 0 || languagesNode.get(primaryLanguage) == null) {
+            return null;
+        }
+
+        long primaryBytes = languagesNode.get(primaryLanguage).asLong(0L);
+        double percent = (primaryBytes * 100.0) / totalBytes;
+
+        return Math.round(percent * 10.0) / 10.0;
+    }
+
+    private String resolveLicense(JsonNode repositoryNode) {
+        JsonNode licenseNode = repositoryNode == null ? null : repositoryNode.get("license");
+
+        if (licenseNode == null || licenseNode.isNull()) {
+            return null;
+        }
+
+        String spdxId = text(licenseNode, "spdx_id", null);
+
+        if (notBlank(spdxId) && !"NOASSERTION".equalsIgnoreCase(spdxId)) {
+            return spdxId;
+        }
+
+        return text(licenseNode, "name", null);
+    }
+
+    private String text(JsonNode node, String fieldName, String defaultValue) {
+        if (node == null || node.get(fieldName) == null || node.get(fieldName).isNull()) {
+            return defaultValue;
+        }
+
+        return node.get(fieldName).asText(defaultValue);
+    }
+
+    private Long longValue(JsonNode node, String fieldName) {
+        if (node == null || node.get(fieldName) == null || node.get(fieldName).isNull()) {
+            return null;
+        }
+
+        return node.get(fieldName).asLong();
+    }
+
+    private boolean notBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private record CommitActivityResult(
+            boolean processing,
+            Integer recent28dCommits,
+            List<GithubStatsResponse.DailyActivity> dailyActivities,
+            List<GithubStatsResponse.WeeklyCommitActivity> weeklyActivities
+    ) {
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.*;
 import java.util.*;
+import java.util.function.Supplier;
 
 @Slf4j
 @Service
@@ -48,17 +49,44 @@ public class GithubStatsService {
         String owner = repoRef.getOwner();
         String repo = repoRef.getRepo();
 
+        /*
+         * 저장소 기본 정보는 화면 구성에 필요한 필수 데이터입니다.
+         * contributors/search 계열 API는 rate limit이나 일시 실패가 발생할 수 있으므로
+         * 실패해도 전체 화면이 깨지지 않도록 null 또는 빈 데이터로 대체합니다.
+         */
         JsonNode repositoryNode = githubStatsApiClient.getRepository(owner, repo);
-        JsonNode languagesNode = githubStatsApiClient.getLanguages(owner, repo);
-        JsonNode commitActivityNode = githubStatsApiClient.getCommitActivityOrNull(owner, repo);
+        String defaultBranch = text(repositoryNode, "default_branch", null);
+
+        JsonNode languagesNode = getOptionalJson("languages", () -> githubStatsApiClient.getLanguages(owner, repo));
         JsonNode latestReleaseNode = githubStatsApiClient.getLatestReleaseOrNull(owner, repo);
 
-        Long contributors = githubStatsApiClient.countContributors(owner, repo);
+        Long contributors = getOptionalLong("contributors", () -> githubStatsApiClient.countContributors(owner, repo));
 
         LocalDate recentStartDate = LocalDate.now(UTC).minusDays(RECENT_DAYS - 1L);
-        Long recentIssues = githubStatsApiClient.countRecentIssues(owner, repo, recentStartDate);
 
-        CommitActivityResult commitActivity = buildCommitActivity(commitActivityNode, recentStartDate);
+        Map<LocalDate, Integer> recentIssueCounts = getOptionalDailyCountMap(
+                "recent_issues_created_by_date",
+                () -> githubStatsApiClient.countRecentIssuesByDate(owner, repo, recentStartDate)
+        );
+
+        Map<LocalDate, Integer> recentClosedIssueCounts = getOptionalDailyCountMap(
+                "recent_issues_closed_by_date",
+                () -> githubStatsApiClient.countRecentClosedIssuesByDate(owner, repo, recentStartDate)
+        );
+
+        Long recentIssues = recentIssueCounts == null
+                ? getOptionalLong("recent_issues_created", () -> githubStatsApiClient.countRecentIssues(owner, repo, recentStartDate))
+                : recentIssueCounts.values().stream().mapToLong(Integer::longValue).sum();
+
+        Long recentClosedIssues = recentClosedIssueCounts == null
+                ? getOptionalLong("recent_issues_closed", () -> githubStatsApiClient.countRecentClosedIssues(owner, repo, recentStartDate))
+                : recentClosedIssueCounts.values().stream().mapToLong(Integer::longValue).sum();
+
+        IssueActivityResult issueActivity = buildRecentIssueActivity(
+                recentStartDate,
+                recentIssueCounts,
+                recentClosedIssueCounts
+        );
 
         String fullName = text(repositoryNode, "full_name", owner + "/" + repo);
         String primaryLanguage = text(repositoryNode, "language", null);
@@ -78,9 +106,10 @@ public class GithubStatsService {
                         .name(repo)
                         .description(text(repositoryNode, "description", ""))
                         .htmlUrl(text(repositoryNode, "html_url", ""))
+                        .avatarUrl(text(repositoryNode.path("owner"), "avatar_url", null))
                         .language(primaryLanguage)
                         .languagePercent(languagePercent)
-                        .defaultBranch(text(repositoryNode, "default_branch", ""))
+                        .defaultBranch(defaultBranch == null ? "" : defaultBranch)
                         .license(resolveLicense(repositoryNode))
                         .createdAt(text(repositoryNode, "created_at", null))
                         .updatedAt(text(repositoryNode, "updated_at", null))
@@ -92,8 +121,8 @@ public class GithubStatsService {
                         .stars(stars)
                         .forks(forks)
                         .openIssues(openIssues)
-                        .recent28dCommits(commitActivity.recent28dCommits())
                         .recent28dIssues(recentIssues)
+                        .recent28dClosedIssues(recentClosedIssues)
                         .contributors(contributors)
                         .starDelta28d(null)
                         .forkDelta28d(null)
@@ -101,11 +130,9 @@ public class GithubStatsService {
                         .contributorDelta28d(null)
                         .build())
                 .activity(GithubStatsResponse.Activity.builder()
-                        .commitStatsProcessing(commitActivity.processing())
-                        .recent28dDailyActivities(commitActivity.dailyActivities())
-                        .lastYearWeeklyCommits(commitActivity.weeklyActivities())
+                        .recent28dDailyIssueActivities(issueActivity.dailyActivities())
                         .build())
-                .insights(insightBuilder.build(stars, commitActivity.recent28dCommits(), contributors))
+                .insights(insightBuilder.build(stars, recentClosedIssues, contributors))
                 .collectedAt(collectedAt)
                 .fromCache(false)
                 .build();
@@ -130,79 +157,80 @@ public class GithubStatsService {
         }
     }
 
-    private CommitActivityResult buildCommitActivity(JsonNode commitActivityNode, LocalDate recentStartDate) {
-        LocalDate today = LocalDate.now(UTC);
+    private IssueActivityResult buildRecentIssueActivity(
+            LocalDate recentStartDate,
+            Map<LocalDate, Integer> dailyIssueCounts,
+            Map<LocalDate, Integer> dailyClosedIssueCounts
+    ) {
+        boolean hasIssueCounts = dailyIssueCounts != null;
+        boolean hasClosedIssueCounts = dailyClosedIssueCounts != null;
 
-        Map<LocalDate, Integer> recentCommitCounts = new LinkedHashMap<>();
+        if (!hasIssueCounts && !hasClosedIssueCounts) {
+            return new IssueActivityResult(List.of());
+        }
+
+        List<GithubStatsResponse.DailyIssueActivity> daily = new ArrayList<>();
 
         for (int i = 0; i < RECENT_DAYS; i++) {
-            recentCommitCounts.put(recentStartDate.plusDays(i), 0);
+            LocalDate date = recentStartDate.plusDays(i);
+
+            Integer issuesCreated = hasIssueCounts ? dailyIssueCounts.getOrDefault(date, 0) : 0;
+            Integer issuesClosed = hasClosedIssueCounts ? dailyClosedIssueCounts.getOrDefault(date, 0) : 0;
+
+            daily.add(dailyIssueActivity(date, issuesCreated, issuesClosed));
         }
 
-        List<GithubStatsResponse.WeeklyCommitActivity> weeklyActivities = new ArrayList<>();
-
-        if (commitActivityNode == null || !commitActivityNode.isArray()) {
-            List<GithubStatsResponse.DailyActivity> daily = recentCommitCounts.entrySet()
-                    .stream()
-                    .map(entry -> dailyActivity(entry.getKey(), null, null))
-                    .toList();
-
-            return new CommitActivityResult(true, null, daily, weeklyActivities);
-        }
-
-        for (JsonNode weekNode : commitActivityNode) {
-            long weekEpochSeconds = weekNode.path("week").asLong(0L);
-
-            LocalDate weekStart = Instant.ofEpochSecond(weekEpochSeconds)
-                    .atZone(UTC)
-                    .toLocalDate();
-
-            int weekTotal = weekNode.path("total").asInt(0);
-
-            weeklyActivities.add(GithubStatsResponse.WeeklyCommitActivity.builder()
-                    .weekStart(weekStart.toString())
-                    .commits(weekTotal)
-                    .build());
-
-            JsonNode daysNode = weekNode.path("days");
-
-            if (!daysNode.isArray()) {
-                continue;
-            }
-
-            for (int i = 0; i < daysNode.size(); i++) {
-                LocalDate date = weekStart.plusDays(i);
-
-                if (date.isBefore(recentStartDate) || date.isAfter(today)) {
-                    continue;
-                }
-
-                recentCommitCounts.put(date, daysNode.get(i).asInt(0));
-            }
-        }
-
-        int recentTotal = recentCommitCounts.values()
-                .stream()
-                .mapToInt(Integer::intValue)
-                .sum();
-
-        List<GithubStatsResponse.DailyActivity> daily = recentCommitCounts.entrySet()
-                .stream()
-                .map(entry -> dailyActivity(entry.getKey(), entry.getValue(), null))
-                .toList();
-
-        return new CommitActivityResult(false, recentTotal, daily, weeklyActivities);
+        return new IssueActivityResult(daily);
     }
 
-    private GithubStatsResponse.DailyActivity dailyActivity(
-            LocalDate date,
-            Integer commits,
-            Integer issuesCreated
+    private JsonNode getOptionalJson(String apiName, Supplier<JsonNode> supplier) {
+        try {
+            return supplier.get();
+        } catch (GithubStatsException e) {
+            log.warn("GitHub optional API skipped apiName={}, code={}", apiName, e.getCode().getReason().getCode());
+            return null;
+        } catch (Exception e) {
+            log.warn("GitHub optional API skipped apiName={}, cause={}", apiName, e.toString());
+            return null;
+        }
+    }
+
+    private Long getOptionalLong(String apiName, Supplier<Long> supplier) {
+        try {
+            return supplier.get();
+        } catch (GithubStatsException e) {
+            log.warn("GitHub optional API skipped apiName={}, code={}", apiName, e.getCode().getReason().getCode());
+            return null;
+        } catch (Exception e) {
+            log.warn("GitHub optional API skipped apiName={}, cause={}", apiName, e.toString());
+            return null;
+        }
+    }
+
+    private Map<LocalDate, Integer> getOptionalDailyCountMap(
+            String apiName,
+            Supplier<Map<LocalDate, Integer>> supplier
     ) {
-        return GithubStatsResponse.DailyActivity.builder()
+        try {
+            return supplier.get();
+        } catch (GithubStatsException e) {
+            log.warn("GitHub optional API skipped apiName={}, code={}", apiName, e.getCode().getReason().getCode());
+            return null;
+        } catch (Exception e) {
+            log.warn("GitHub optional API skipped apiName={}, cause={}", apiName, e.toString());
+            return null;
+        }
+    }
+
+    private GithubStatsResponse.DailyIssueActivity dailyIssueActivity(
+            LocalDate date,
+            Integer issuesCreated,
+            Integer issuesClosed
+    ) {
+        return GithubStatsResponse.DailyIssueActivity.builder()
                 .date(date.toString())
-                .commits(commits)
                 .issuesCreated(issuesCreated)
+                .issuesClosed(issuesClosed)
                 .build();
     }
 
@@ -265,11 +293,8 @@ public class GithubStatsService {
         return value != null && !value.isBlank();
     }
 
-    private record CommitActivityResult(
-            boolean processing,
-            Integer recent28dCommits,
-            List<GithubStatsResponse.DailyActivity> dailyActivities,
-            List<GithubStatsResponse.WeeklyCommitActivity> weeklyActivities
+    private record IssueActivityResult(
+            List<GithubStatsResponse.DailyIssueActivity> dailyActivities
     ) {
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsSnapshotCommandService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsSnapshotCommandService.java
@@ -35,8 +35,8 @@ public class GithubStatsSnapshotCommandService {
                 summary.getForks(),
                 summary.getOpenIssues(),
                 summary.getContributors(),
-                summary.getRecent28dCommits(),
                 summary.getRecent28dIssues(),
+                summary.getRecent28dClosedIssues(),
                 payload,
                 response.getCollectedAt()
         ));

--- a/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsSnapshotCommandService.java
+++ b/src/main/java/com/example/ossdoc/domain/githubstats/service/GithubStatsSnapshotCommandService.java
@@ -1,0 +1,44 @@
+package com.example.ossdoc.domain.githubstats.service;
+
+import com.example.ossdoc.domain.githubstats.dto.response.GithubStatsResponse;
+import com.example.ossdoc.domain.githubstats.entity.GithubStatsSnapshot;
+import com.example.ossdoc.domain.githubstats.repository.GithubStatsSnapshotRepository;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.run.repository.RepoRunRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GithubStatsSnapshotCommandService {
+
+    private final RepoRunRepository repoRunRepository;
+    private final GithubStatsSnapshotRepository snapshotRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void saveSnapshot(String runId, GithubStatsResponse response) {
+        RepoRun runRef = repoRunRepository.getReferenceById(runId);
+
+        GithubStatsResponse.RepositoryInfo repository = response.getRepository();
+        GithubStatsResponse.Summary summary = response.getSummary();
+
+        JsonNode payload = objectMapper.valueToTree(response);
+
+        snapshotRepository.save(GithubStatsSnapshot.create(
+                runRef,
+                repository.getFullName(),
+                summary.getStars(),
+                summary.getForks(),
+                summary.getOpenIssues(),
+                summary.getContributors(),
+                summary.getRecent28dCommits(),
+                summary.getRecent28dIssues(),
+                payload,
+                response.getCollectedAt()
+        ));
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/properties/GithubStatsProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/GithubStatsProperties.java
@@ -1,0 +1,22 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "github.stats")
+public class GithubStatsProperties {
+    // GitHub REST API 토큰
+    // 비워두면 비인증 요청으로 동작하지만 rate limit낮음
+    private String token = "";
+
+    // 통계 스냅샷 캐시 유지 시간
+    private long cacheTtlMinutes = 360;
+
+    // GitHub API 요청 타임아웃
+    private long apiTimeoutSeconds = 30;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
 build:
-  maven-command: ${MAVEN_COMMAND:C:\\tools\\apache-maven-3.9.13\\bin\\mvn.cmd}
+  maven-command: ${MAVEN_COMMAND:D:\\Program Files\\apache-maven-3.9.13\\bin\\mvn.cmd}
   gradle-command: ${GRADLE_COMMAND:gradle}
   java-homes:
     - ${JAVA11_HOME}
@@ -94,6 +94,7 @@ claude:
   model: ${CLAUDE_MODEL:claude-sonnet-4-5}
   # Step2~5는 기본적으로 Haiku를 사용하고, 실패 시 서비스에서 Sonnet 폴백을 수행한다.
   haiku-model: ${CLAUDE_HAIKU_MODEL:claude-haiku-4-5}
+  # enabled: ${LLM_ENABLED:false}
   max-tokens: ${CLAUDE_MAX_TOKENS:20000}
 
 cloud:
@@ -105,6 +106,12 @@ cloud:
       static: ${AWS_REGION:ap-northeast-2}
     s3:
       bucket: ${S3_BUCKET:ossdoc-artifact-storage}
+
+github:
+  stats:
+    token: ${GITHUB_STATS_TOKEN:}
+    cache-ttl-minutes: ${GITHUB_STATS_CACHE_TTL_MINUTES:360}
+    api-timeout-seconds: ${GITHUB_STATS_API_TIMEOUT_SECONDS:30}
 
 logging:
   level:


### PR DESCRIPTION
## 작업 내용

GitHub 통계량 기능에서 기존 최근 28일 커밋 통계 수집 로직을 제거하고, 최근 28일 기준 이슈 생성/해결 통계를 수집하도록 변경했습니다.

## 변경 사항

- 최근 28일 커밋 통계 수집 로직 제거
- GitHub Issues API 기반 최근 28일 생성 이슈 수 수집
- 최근 28일 해결 이슈 수 수집
- 일자별 이슈 생성/해결 통계 응답 추가
- 기존 캐시 데이터에 신규 이슈 통계 필드가 없을 경우 재수집되도록 처리

## 변경 이유

기존 최근 28일 커밋 통계는 일부 저장소에서 데이터가 정상적으로 표시되지 않거나 사용자 관점에서 유지보수 상태를 판단하기 어려운 문제가 있었습니다.

이에 따라 사용자가 오픈소스의 활동성과 유지보수 상태를 더 직관적으로 확인할 수 있도록, 최근 28일 동안 생성된 이슈와 해결된 이슈 통계로 변경했습니다.

## 테스트

- GitHub 통계량 조회 API 정상 응답 확인
- 최근 28일 생성 이슈 수 확인
- 최근 28일 해결 이슈 수 확인
- 프론트 화면에서 이슈 생성/해결 막대 그래프 정상 표시 확인

## 참고 사항
같은 클래스 내부에서 collectAndSave()를 호출하면 Spring AOP 프록시를 거치지 않음. 그래서  @Transactional이 제대로 적용되지 않아서, 클래스 전체의 readOnly = true가 유지되고 INSERT가 막히는 문제 발생
해결 ->
GithubStatsService
- 트랜잭션 없음
- 전체 흐름 조율
- GitHub API 호출

GithubStatsQueryService
- readOnly = true
- run 조회
- 권한 검증
- 캐시 조회

GithubStatsSnapshotCommandService
- 일반 @Transactional
- github_stats_snapshot 저장
