### PR TITLE
feat: Google OAuth 전용 인증 및 회원 관리 구조 개편

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/controller/AuthController.java
@@ -1,11 +1,14 @@
 package com.example.ossdoc.domain.auth.controller;
 
+import com.example.ossdoc.domain.auth.dto.request.NicknameUpdateRequest;
 import com.example.ossdoc.domain.auth.dto.response.CurrentUserResponse;
+import com.example.ossdoc.domain.auth.dto.response.NicknameCheckResponse;
 import com.example.ossdoc.domain.auth.service.AuthService;
 import com.example.ossdoc.global.apiPayload.ApiResponse;
 import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -24,17 +27,52 @@ public class AuthController {
         return ApiResponse.onSuccess(authService.getCurrentUser(authenticatedUser));
     }
 
+    @GetMapping("/nicknames/{nickname}/availability")
+    public ApiResponse<NicknameCheckResponse> checkNickname(
+            @PathVariable String nickname,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        return ApiResponse.onSuccess(
+                authService.checkNickname(nickname, authenticatedUser)
+        );
+    }
+
+    @PatchMapping("/me/nickname")
+    public ApiResponse<CurrentUserResponse> updateNickname(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody NicknameUpdateRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                authService.updateNickname(authenticatedUser, request)
+        );
+    }
+
     @PostMapping("/refresh")
-    public ApiResponse<String> refresh(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<String> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
         authService.refresh(request, response);
         return ApiResponse.onSuccess("토큰 재발급 완료");
     }
 
     @PostMapping("/logout")
-    public ApiResponse<String> logout(HttpServletRequest request,
-                                      HttpServletResponse response,
-                                      @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+    public ApiResponse<String> logout(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
         authService.logout(request, response, authenticatedUser);
         return ApiResponse.onSuccess("로그아웃 완료");
+    }
+
+    @DeleteMapping("/me")
+    public ApiResponse<String> deleteAccount(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        authService.deleteAccount(request, response, authenticatedUser);
+        return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/auth/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.ossdoc.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9_]+$",
+                message = "닉네임은 한글, 영문, 숫자, 밑줄(_)만 사용할 수 있습니다."
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/dto/response/CurrentUserResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/dto/response/CurrentUserResponse.java
@@ -4,6 +4,8 @@ public record CurrentUserResponse(
         Long userId,
         String email,
         String name,
-        String role
+        String nickname,
+        String role,
+        String provider
 ) {
 }

--- a/src/main/java/com/example/ossdoc/domain/auth/dto/response/NicknameCheckResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/dto/response/NicknameCheckResponse.java
@@ -1,0 +1,7 @@
+package com.example.ossdoc.domain.auth.dto.response;
+
+public record NicknameCheckResponse(
+        String nickname,
+        boolean available
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/exception/AuthException.java
@@ -1,7 +1,6 @@
 package com.example.ossdoc.domain.auth.exception;
 
 import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
-import com.example.ossdoc.domain.build.exception.code.BuildErrorCode;
 import com.example.ossdoc.global.apiPayload.code.BaseCode;
 import com.example.ossdoc.global.apiPayload.exception.GeneralException;
 

--- a/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
@@ -1,6 +1,5 @@
 package com.example.ossdoc.domain.auth.exception.code;
 
-
 import com.example.ossdoc.global.apiPayload.code.BaseCode;
 import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
 import lombok.Getter;
@@ -10,17 +9,84 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements BaseCode {
-    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_002", "접근 권한이 없습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "만료된 토큰입니다."),
-    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH_005", "잘못된 토큰 타입입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_006", "리프레시 토큰이 없습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_007", "리프레시 토큰이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_008", "사용자를 찾을 수 없습니다."),
-    INACTIVE_USER(HttpStatus.FORBIDDEN, "AUTH_009", "비활성화된 사용자입니다."),
-    OAUTH2_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_010", "구글 로그인 처리에 실패했습니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "AUTH_0011", "인증 사용자 정보를 찾을 수 없습니다.");
+
+    AUTHENTICATION_REQUIRED(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_1",
+            "인증이 필요합니다."
+    ),
+
+    USER_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "AUTH404_1",
+            "사용자를 찾을 수 없습니다."
+    ),
+
+    OAUTH2_LOGIN_FAILED(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_2",
+            "Google 로그인에 실패했습니다."
+    ),
+
+    GOOGLE_EMAIL_NOT_VERIFIED(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_3",
+            "Google에서 인증되지 않은 이메일입니다."
+    ),
+
+    INACTIVE_USER(
+            HttpStatus.FORBIDDEN,
+            "AUTH403_1",
+            "탈퇴한 계정입니다."
+    ),
+
+    REJOIN_WAIT_PERIOD_NOT_PASSED(
+            HttpStatus.FORBIDDEN,
+            "AUTH403_2",
+            "회원 탈퇴 후 재가입 대기기간이 지나지 않았습니다."
+    ),
+
+    DUPLICATE_NICKNAME(
+            HttpStatus.CONFLICT,
+            "AUTH409_1",
+            "이미 사용 중인 닉네임입니다."
+    ),
+
+    INVALID_NICKNAME(
+            HttpStatus.BAD_REQUEST,
+            "AUTH400_1",
+            "사용할 수 없는 닉네임입니다."
+    ),
+
+    INVALID_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_4",
+            "유효하지 않은 토큰입니다."
+    ),
+
+    EXPIRED_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_5",
+            "만료된 토큰입니다."
+    ),
+
+    INVALID_TOKEN_TYPE(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_6",
+            "잘못된 토큰 타입입니다."
+    ),
+
+    REFRESH_TOKEN_NOT_FOUND(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_7",
+            "리프레시 토큰이 없습니다."
+    ),
+
+    REFRESH_TOKEN_MISMATCH(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_8",
+            "리프레시 토큰이 일치하지 않습니다."
+    );
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -29,18 +95,18 @@ public enum AuthErrorCode implements BaseCode {
     @Override
     public ReasonDTO getReason() {
         return ReasonDTO.builder()
-                .message(message)
-                .code(code)
                 .isSuccess(false)
+                .code(code)
+                .message(message)
                 .build();
     }
 
     @Override
     public ReasonDTO getReasonHttpStatus() {
         return ReasonDTO.builder()
-                .message(message)
-                .code(code)
                 .isSuccess(false)
+                .code(code)
+                .message(message)
                 .httpStatus(httpStatus)
                 .build();
     }

--- a/src/main/java/com/example/ossdoc/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/service/AuthService.java
@@ -1,15 +1,19 @@
 package com.example.ossdoc.domain.auth.service;
 
+import com.example.ossdoc.domain.auth.dto.request.NicknameUpdateRequest;
 import com.example.ossdoc.domain.auth.dto.response.CurrentUserResponse;
+import com.example.ossdoc.domain.auth.dto.response.NicknameCheckResponse;
 import com.example.ossdoc.domain.auth.entity.RefreshToken;
-import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.auth.repository.RefreshTokenRepository;
 import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.enums.AuthProvider;
 import com.example.ossdoc.domain.user.repository.UserRepository;
 import com.example.ossdoc.global.properties.AuthProperties;
 import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
 import com.example.ossdoc.global.security.jwt.JwtTokenProvider;
+import com.example.ossdoc.global.properties.AccountPolicyProperties;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,19 +26,74 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
 
+    private static final Pattern NICKNAME_PATTERN =
+            Pattern.compile("^[가-힣a-zA-Z0-9_]{2,10}$");
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthProperties authProperties;
+    private final AccountPolicyProperties accountPolicyProperties;
+
+    /**
+     * Google OAuth 성공 시 호출됩니다.
+     * 자체 회원가입은 없고, Google 계정 기준으로 사용자를 생성하거나 갱신합니다.
+     */
+    @Transactional
+    public User upsertGoogleUser(
+            String providerId,
+            String email,
+            String googleName
+    ) {
+        if (providerId == null || providerId.isBlank()
+                || email == null || email.isBlank()) {
+            throw new AuthException(AuthErrorCode.OAUTH2_LOGIN_FAILED);
+        }
+
+        String normalizedEmail = normalizeEmail(email);
+        LocalDateTime now = LocalDateTime.now();
+
+        return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, providerId)
+                .map(user -> {
+                    if (!user.isActive()) {
+                        if (!user.canReactivateAfter(
+                                now,
+                                accountPolicyProperties.getRejoinWaitDays()
+                        )) {
+                            throw new AuthException(AuthErrorCode.REJOIN_WAIT_PERIOD_NOT_PASSED);
+                        }
+
+                        user.reactivate(now);
+                    }
+
+                    user.updateGoogleEmail(normalizedEmail);
+                    return user;
+                })
+                .orElseGet(() -> {
+                    String baseNickname = resolveBaseNickname(normalizedEmail, googleName);
+                    String uniqueNickname = generateUniqueNickname(baseNickname);
+
+                    User newUser = User.createGoogleUser(
+                            providerId,
+                            normalizedEmail,
+                            uniqueNickname
+                    );
+
+                    return userRepository.save(newUser);
+                });
+    }
 
     @Transactional
     public void issueLoginTokens(User user, HttpServletResponse response) {
+        validateActiveUser(user);
+
         String accessToken = jwtTokenProvider.generateAccessToken(user);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user);
 
@@ -53,20 +112,35 @@ public class AuthService {
                         )
                 );
 
-        addCookie(response, authProperties.getAccessCookieName(), accessToken, jwtTokenProvider.getAccessTokenMaxAgeSeconds());
-        addCookie(response, authProperties.getRefreshCookieName(), refreshToken, jwtTokenProvider.getRefreshTokenMaxAgeSeconds());
+        addCookie(
+                response,
+                authProperties.getAccessCookieName(),
+                accessToken,
+                jwtTokenProvider.getAccessTokenMaxAgeSeconds()
+        );
+
+        addCookie(
+                response,
+                authProperties.getRefreshCookieName(),
+                refreshToken,
+                jwtTokenProvider.getRefreshTokenMaxAgeSeconds()
+        );
     }
 
     @Transactional
     public void refresh(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = getCookieValue(request, authProperties.getRefreshCookieName());
+
         if (refreshToken == null) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        validateActiveUser(user);
 
         RefreshToken savedRefreshToken = refreshTokenRepository.findByUser(user)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
@@ -87,15 +161,67 @@ public class AuthService {
                 LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenMaxAgeSeconds())
         );
 
-        addCookie(response, authProperties.getAccessCookieName(), newAccessToken, jwtTokenProvider.getAccessTokenMaxAgeSeconds());
-        addCookie(response, authProperties.getRefreshCookieName(), newRefreshToken, jwtTokenProvider.getRefreshTokenMaxAgeSeconds());
+        addCookie(
+                response,
+                authProperties.getAccessCookieName(),
+                newAccessToken,
+                jwtTokenProvider.getAccessTokenMaxAgeSeconds()
+        );
+
+        addCookie(
+                response,
+                authProperties.getRefreshCookieName(),
+                newRefreshToken,
+                jwtTokenProvider.getRefreshTokenMaxAgeSeconds()
+        );
+    }
+
+    public CurrentUserResponse getCurrentUser(AuthenticatedUser authenticatedUser) {
+        User user = getAuthenticatedActiveUser(authenticatedUser);
+        return toCurrentUserResponse(user);
+    }
+
+    public NicknameCheckResponse checkNickname(
+            String nickname,
+            AuthenticatedUser authenticatedUser
+    ) {
+        User user = getAuthenticatedActiveUser(authenticatedUser);
+        String normalized = normalizeNickname(nickname);
+
+        validateNicknameFormat(normalized);
+
+        boolean available = !userRepository.existsByNicknameAndIdNot(
+                normalized,
+                user.getId()
+        );
+
+        return new NicknameCheckResponse(normalized, available);
     }
 
     @Transactional
-    public void logout(HttpServletRequest request,
-                       HttpServletResponse response,
-                       AuthenticatedUser authenticatedUser) {
+    public CurrentUserResponse updateNickname(
+            AuthenticatedUser authenticatedUser,
+            NicknameUpdateRequest request
+    ) {
+        User user = getAuthenticatedActiveUser(authenticatedUser);
+        String nickname = normalizeNickname(request.nickname());
 
+        validateNicknameFormat(nickname);
+
+        if (userRepository.existsByNicknameAndIdNot(nickname, user.getId())) {
+            throw new AuthException(AuthErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.updateNickname(nickname);
+        return toCurrentUserResponse(user);
+    }
+
+    @Transactional
+    public void logout(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticatedUser authenticatedUser
+    ) {
         if (authenticatedUser != null) {
             userRepository.findById(authenticatedUser.getUserId())
                     .ifPresent(refreshTokenRepository::deleteByUser);
@@ -107,19 +233,24 @@ public class AuthService {
             refreshTokenRepository.deleteByToken(refreshToken);
         }
 
-        deleteCookie(response, authProperties.getAccessCookieName());
-        deleteCookie(response, authProperties.getRefreshCookieName());
-        deleteCookie(response, "JSESSIONID");
-
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.invalidate();
-        }
-
-        SecurityContextHolder.clearContext();
+        clearLoginState(request, response);
     }
 
-    public CurrentUserResponse getCurrentUser(AuthenticatedUser authenticatedUser) {
+    @Transactional
+    public void deleteAccount(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticatedUser authenticatedUser
+    ) {
+        User user = getAuthenticatedActiveUser(authenticatedUser);
+
+        refreshTokenRepository.deleteByUser(user);
+        user.deactivate(LocalDateTime.now());
+
+        clearLoginState(request, response);
+    }
+
+    private User getAuthenticatedActiveUser(AuthenticatedUser authenticatedUser) {
         if (authenticatedUser == null) {
             throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
@@ -127,15 +258,111 @@ public class AuthService {
         User user = userRepository.findById(authenticatedUser.getUserId())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
+        validateActiveUser(user);
+        return user;
+    }
+
+    private void validateActiveUser(User user) {
+        if (!user.isActive()) {
+            throw new AuthException(AuthErrorCode.INACTIVE_USER);
+        }
+    }
+
+    private CurrentUserResponse toCurrentUserResponse(User user) {
         return new CurrentUserResponse(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),
-                user.getRole().name()
+                user.getNickname(),
+                user.getRole().name(),
+                user.getProvider().name()
         );
     }
 
-    private void addCookie(HttpServletResponse response, String name, String value, long maxAgeSeconds) {
+    private String normalizeEmail(String email) {
+        return email == null ? null : email.trim().toLowerCase();
+    }
+
+    private String normalizeNickname(String nickname) {
+        return nickname == null ? null : nickname.trim();
+    }
+
+    private void validateNicknameFormat(String nickname) {
+        if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new AuthException(AuthErrorCode.INVALID_NICKNAME);
+        }
+    }
+
+    private String resolveBaseNickname(String email, String googleName) {
+        String source = googleName;
+
+        if (source == null || source.isBlank()) {
+            source = email.substring(0, email.indexOf("@"));
+        }
+
+        String normalized = source
+                .replaceAll("[^가-힣a-zA-Z0-9_]", "")
+                .trim();
+
+        if (normalized.length() < 2) {
+            normalized = email.substring(0, email.indexOf("@"))
+                    .replaceAll("[^a-zA-Z0-9_]", "");
+        }
+
+        if (normalized.length() < 2) {
+            normalized = "user";
+        }
+
+        if (normalized.length() > 10) {
+            normalized = normalized.substring(0, 10);
+        }
+
+        return normalized;
+    }
+
+    private String generateUniqueNickname(String baseNickname) {
+        if (!userRepository.existsByNickname(baseNickname)) {
+            return baseNickname;
+        }
+
+        for (int i = 1; i <= 9999; i++) {
+            String suffix = "_" + i;
+            int maxBaseLength = 10 - suffix.length();
+
+            String candidateBase = baseNickname.length() > maxBaseLength
+                    ? baseNickname.substring(0, maxBaseLength)
+                    : baseNickname;
+
+            String candidate = candidateBase + suffix;
+
+            if (!userRepository.existsByNickname(candidate)) {
+                return candidate;
+            }
+        }
+
+        return "user_" + System.currentTimeMillis();
+    }
+
+    private void clearLoginState(HttpServletRequest request, HttpServletResponse response) {
+        deleteCookie(response, authProperties.getAccessCookieName());
+        deleteCookie(response, authProperties.getRefreshCookieName());
+        deleteCookie(response, "JSESSIONID");
+
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.invalidate();
+        }
+
+        SecurityContextHolder.clearContext();
+    }
+
+    private void addCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            long maxAgeSeconds
+    ) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(authProperties.isSecureCookie())
@@ -169,6 +396,7 @@ public class AuthService {
                 return cookie.getValue();
             }
         }
+
         return null;
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/user/entity/User.java
+++ b/src/main/java/com/example/ossdoc/domain/user/entity/User.java
@@ -6,12 +6,24 @@ import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(
         name = "users",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_provider_provider_id", columnNames = {"provider", "provider_id"}),
-                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"})
+                @UniqueConstraint(
+                        name = "uk_user_provider_provider_id",
+                        columnNames = {"provider", "provider_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_user_email",
+                        columnNames = {"email"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_user_nickname",
+                        columnNames = {"nickname"}
+                )
         }
 )
 @Getter
@@ -38,6 +50,9 @@ public class User extends BaseAuditedEntity {
     @Column(nullable = false, length = 100)
     private String name;
 
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private UserRole role;
@@ -46,12 +61,67 @@ public class User extends BaseAuditedEntity {
     @Builder.Default
     private Boolean active = true;
 
-    public void updateProfile(String email, String name) {
-        this.email = email;
-        this.name = name;
+    /**
+     * 회원 탈퇴 시각입니다.
+     * 일정 기간 후 재가입 허용 여부 판단에 사용합니다.
+     */
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    /**
+     * 탈퇴 계정이 다시 활성화된 시각입니다.
+     */
+    @Column(name = "reactivated_at")
+    private LocalDateTime reactivatedAt;
+
+    public static User createGoogleUser(
+            String providerId,
+            String email,
+            String nickname
+    ) {
+        return User.builder()
+                .provider(AuthProvider.GOOGLE)
+                .providerId(providerId)
+                .email(email)
+                .name(nickname)
+                .nickname(nickname)
+                .role(UserRole.USER)
+                .active(true)
+                .build();
     }
 
-    public void deactivate() {
+    public void updateGoogleEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+        this.name = nickname;
+    }
+
+    public void deactivate(LocalDateTime now) {
         this.active = false;
+        this.deletedAt = now;
+    }
+
+    public void reactivate(LocalDateTime now) {
+        this.active = true;
+        this.reactivatedAt = now;
+    }
+
+    public boolean isActive() {
+        return Boolean.TRUE.equals(active);
+    }
+
+    public boolean canReactivateAfter(LocalDateTime now, long rejoinWaitDays) {
+        if (isActive()) {
+            return true;
+        }
+
+        if (deletedAt == null) {
+            return false;
+        }
+
+        return !deletedAt.plusDays(rejoinWaitDays).isAfter(now);
     }
 }

--- a/src/main/java/com/example/ossdoc/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/user/repository/UserRepository.java
@@ -9,6 +9,10 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
-
     Optional<User> findByEmail(String email);
+
+    boolean existsByProviderAndProviderId(AuthProvider provider, String providerId);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/example/ossdoc/global/properties/AccountPolicyProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/AccountPolicyProperties.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.account")
+public class AccountPolicyProperties {
+
+    /**
+     * 탈퇴 후 같은 Google 계정으로 재가입할 수 있기까지 기다려야 하는 기간입니다.
+     * 기본값은 30일입니다.
+     */
+    private long rejoinWaitDays = 30;
+}

--- a/src/main/java/com/example/ossdoc/global/security/jwt/AuthenticatedUser.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/AuthenticatedUser.java
@@ -1,5 +1,6 @@
 package com.example.ossdoc.global.security.jwt;
 
+import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.domain.user.enums.UserRole;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,28 @@ import lombok.Getter;
 @Builder
 public class AuthenticatedUser {
 
-    private Long userId;
-    private String email;
-    private UserRole role;
+    private final Long userId;
+    private final String email;
+    private final String nickname;
+
+    /**
+     * 현재 권한 기반 처리는 사용하지 않습니다.
+     * 다만 기존 User 구조와 JWT 확장 가능성을 위해 값만 보관합니다.
+     */
+    private final UserRole role;
+
+    /**
+     * 탈퇴 계정 차단용입니다.
+     */
+    private final boolean active;
+
+    public static AuthenticatedUser from(User user) {
+        return AuthenticatedUser.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .active(user.isActive())
+                .build();
+    }
 }

--- a/src/main/java/com/example/ossdoc/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.example.ossdoc.global.security.jwt;
 
 import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.repository.UserRepository;
 import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
 import com.example.ossdoc.global.properties.AuthProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -19,6 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -26,6 +29,7 @@ import java.util.Map;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
     private final AuthProperties authProperties;
     private final ObjectMapper objectMapper;
 
@@ -43,16 +47,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
 
         try {
             String token = resolveToken(request);
 
-            if (StringUtils.hasText(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                Long userId = jwtTokenProvider.getUserIdFromAccessToken(token);
+
+                userRepository.findById(userId)
+                        .filter(User::isActive)
+                        .ifPresent(user -> {
+                            AuthenticatedUser principal = AuthenticatedUser.from(user);
+
+                            UsernamePasswordAuthenticationToken authentication =
+                                    new UsernamePasswordAuthenticationToken(
+                                            principal,
+                                            null,
+                                            List.of()
+                                    );
+
+                            SecurityContextHolder.getContext().setAuthentication(authentication);
+                        });
             }
 
             filterChain.doFilter(request, response);
@@ -95,6 +115,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return cookie.getValue();
             }
         }
+
         return null;
     }
 }

--- a/src/main/java/com/example/ossdoc/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/ossdoc/global/security/jwt/JwtTokenProvider.java
@@ -1,9 +1,8 @@
 package com.example.ossdoc.global.security.jwt;
 
-import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.user.entity.User;
-import com.example.ossdoc.domain.user.enums.UserRole;
 import com.example.ossdoc.global.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -13,13 +12,10 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.util.List;
+import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
@@ -40,10 +36,9 @@ public class JwtTokenProvider {
                 .issuer(jwtProperties.getIssuer())
                 .subject(String.valueOf(user.getId()))
                 .claim("email", user.getEmail())
-                .claim("role", user.getRole().name())
                 .claim("tokenType", "access")
-                .issuedAt(new java.util.Date())
-                .expiration(new java.util.Date(System.currentTimeMillis() + jwtProperties.getAccessExpirationMs()))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessExpirationMs()))
                 .signWith(secretKey)
                 .compact();
     }
@@ -53,13 +48,18 @@ public class JwtTokenProvider {
                 .issuer(jwtProperties.getIssuer())
                 .subject(String.valueOf(user.getId()))
                 .claim("tokenType", "refresh")
-                .issuedAt(new java.util.Date())
-                .expiration(new java.util.Date(System.currentTimeMillis() + jwtProperties.getRefreshExpirationMs()))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.getRefreshExpirationMs()))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public Authentication getAuthentication(String accessToken) {
+    public boolean validateToken(String token) {
+        parseClaims(token);
+        return true;
+    }
+
+    public Long getUserIdFromAccessToken(String accessToken) {
         Claims claims = parseClaims(accessToken);
 
         String tokenType = claims.get("tokenType", String.class);
@@ -67,21 +67,7 @@ public class JwtTokenProvider {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN_TYPE);
         }
 
-        Long userId = Long.parseLong(claims.getSubject());
-        String email = claims.get("email", String.class);
-        UserRole role = UserRole.valueOf(claims.get("role", String.class));
-
-        AuthenticatedUser principal = AuthenticatedUser.builder()
-                .userId(userId)
-                .email(email)
-                .role(role)
-                .build();
-
-        return new UsernamePasswordAuthenticationToken(
-                principal,
-                accessToken,
-                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
-        );
+        return Long.parseLong(claims.getSubject());
     }
 
     public Long getUserIdFromRefreshToken(String refreshToken) {

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2User.java
@@ -2,51 +2,38 @@ package com.example.ossdoc.global.security.oauth;
 
 import com.example.ossdoc.domain.user.entity.User;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 @Getter
-@RequiredArgsConstructor
-public class CustomOAuth2User implements OidcUser {
+public class CustomOAuth2User implements OAuth2User {
 
     private final User user;
-    private final OidcUser oidcUser;
+    private final OAuth2User delegate;
 
-    @Override
-    public Map<String, Object> getClaims() {
-        return oidcUser.getClaims();
-    }
-
-    @Override
-    public OidcUserInfo getUserInfo() {
-        return oidcUser.getUserInfo();
-    }
-
-    @Override
-    public OidcIdToken getIdToken() {
-        return oidcUser.getIdToken();
+    public CustomOAuth2User(User user, OAuth2User delegate) {
+        this.user = user;
+        this.delegate = delegate;
     }
 
     @Override
     public Map<String, Object> getAttributes() {
-        return oidcUser.getAttributes();
+        return delegate.getAttributes();
     }
 
+    /**
+     * 현재 서비스는 권한 기반 처리를 사용하지 않습니다.
+     * Google OAuth 기본 authority를 그대로 반환하거나 빈 리스트를 반환해도 됩니다.
+     */
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    public Collection getAuthorities() {
+        return delegate.getAuthorities();
     }
 
     @Override
     public String getName() {
-        return String.valueOf(user.getId());
+        return user.getEmail();
     }
 }

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,61 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.service.AuthService;
+import com.example.ossdoc.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final AuthService authService;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        String providerId = getStringAttribute(oauth2User, "sub");
+        String email = getStringAttribute(oauth2User, "email");
+        String name = getStringAttribute(oauth2User, "name");
+        Boolean emailVerified = getBooleanAttribute(oauth2User, "email_verified");
+
+        if (providerId == null || providerId.isBlank()
+                || email == null || email.isBlank()) {
+            throw new AuthException(AuthErrorCode.OAUTH2_LOGIN_FAILED);
+        }
+
+        if (!Boolean.TRUE.equals(emailVerified)) {
+            throw new AuthException(AuthErrorCode.GOOGLE_EMAIL_NOT_VERIFIED);
+        }
+
+        User user = authService.upsertGoogleUser(providerId, email, name);
+        return new CustomOAuth2User(user, oauth2User);
+    }
+
+    private String getStringAttribute(OAuth2User user, String key) {
+        Object value = user.getAttributes().get(key);
+        return value == null ? null : value.toString();
+    }
+
+    private Boolean getBooleanAttribute(OAuth2User user, String key) {
+        Object value = user.getAttributes().get(key);
+
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+
+        if (value instanceof String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUser.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUser.java
@@ -1,0 +1,26 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+import java.util.Collection;
+
+@Getter
+public class CustomOidcUser extends DefaultOidcUser {
+
+    private final User user;
+
+    public CustomOidcUser(
+            User user,
+            Collection<? extends GrantedAuthority> authorities,
+            OidcIdToken idToken,
+            OidcUserInfo userInfo
+    ) {
+        super(authorities, idToken, userInfo, "sub");
+        this.user = user;
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/CustomOidcUserService.java
@@ -1,11 +1,9 @@
 package com.example.ossdoc.global.security.oauth;
 
-import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.auth.service.AuthService;
 import com.example.ossdoc.domain.user.entity.User;
-import com.example.ossdoc.domain.user.enums.AuthProvider;
-import com.example.ossdoc.domain.user.enums.UserRole;
-import com.example.ossdoc.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
@@ -17,39 +15,34 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomOidcUserService extends OidcUserService {
 
-    private final UserRepository userRepository;
+    private final AuthService authService;
 
     @Override
     @Transactional
     public OidcUser loadUser(OidcUserRequest userRequest) {
         OidcUser oidcUser = super.loadUser(userRequest);
 
-        String providerId = (String) oidcUser.getAttributes().get("sub");
-        String email = (String) oidcUser.getAttributes().get("email");
-        String name = (String) oidcUser.getAttributes().get("name");
+        String providerId = oidcUser.getSubject();
+        String email = oidcUser.getEmail();
+        String name = oidcUser.getFullName();
+        Boolean emailVerified = oidcUser.getEmailVerified();
 
-        if (providerId == null || email == null) {
+        if (providerId == null || providerId.isBlank()
+                || email == null || email.isBlank()) {
             throw new AuthException(AuthErrorCode.OAUTH2_LOGIN_FAILED);
         }
 
-        User user = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, providerId)
-                .orElseGet(() -> userRepository.save(
-                        User.builder()
-                                .provider(AuthProvider.GOOGLE)
-                                .providerId(providerId)
-                                .email(email)
-                                .name(name)
-                                .role(UserRole.USER)
-                                .active(true)
-                                .build()
-                ));
-
-        if (!Boolean.TRUE.equals(user.getActive())) {
-            throw new AuthException(AuthErrorCode.INACTIVE_USER);
+        if (!Boolean.TRUE.equals(emailVerified)) {
+            throw new AuthException(AuthErrorCode.GOOGLE_EMAIL_NOT_VERIFIED);
         }
 
-        user.updateProfile(email, name);
+        User user = authService.upsertGoogleUser(providerId, email, name);
 
-        return new CustomOAuth2User(user, oidcUser);
+        return new CustomOidcUser(
+                user,
+                oidcUser.getAuthorities(),
+                oidcUser.getIdToken(),
+                oidcUser.getUserInfo()
+        );
     }
 }

--- a/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginFailureHandler.java
@@ -1,0 +1,35 @@
+package com.example.ossdoc.global.security.oauth;
+
+import com.example.ossdoc.global.properties.AuthProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final AuthProperties authProperties;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException, ServletException {
+        String redirectUri = UriComponentsBuilder
+                .fromUriString(authProperties.getFrontendFailureRedirectUri())
+                .queryParam("message", "Google 로그인에 실패했습니다.")
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/ossdoc/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -1,15 +1,15 @@
 package com.example.ossdoc.global.security.oauth;
 
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.auth.service.AuthService;
 import com.example.ossdoc.domain.user.entity.User;
 import com.example.ossdoc.global.properties.AuthProperties;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -23,26 +23,37 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final AuthProperties authProperties;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request,
-                                        HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+        User user = extractUser(authentication);
 
-        CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
-        User user = principal.getUser();
-
-        authService.issueLoginTokens(user, response);
-        clearAuthenticationAttributes(request);
-
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.invalidate();
+        if (!user.isActive()) {
+            throw new AuthException(AuthErrorCode.INACTIVE_USER);
         }
 
-        SecurityContextHolder.clearContext();
+        authService.issueLoginTokens(user, response);
 
         getRedirectStrategy().sendRedirect(
                 request,
                 response,
-                authProperties.getFrontendSuccessRedirectUri());
+                authProperties.getFrontendSuccessRedirectUri()
+        );
+    }
+
+    private User extractUser(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomOidcUser customOidcUser) {
+            return customOidcUser.getUser();
+        }
+
+        if (principal instanceof CustomOAuth2User customOAuth2User) {
+            return customOAuth2User.getUser();
+        }
+
+        throw new AuthException(AuthErrorCode.OAUTH2_LOGIN_FAILED);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,11 @@ app:
     refresh-cookie-name: ${REFRESH_COOKIE_NAME:ossdoc_refresh_token}
     secure-cookie: ${AUTH_SECURE_COOKIE:false}
     same-site: ${AUTH_COOKIE_SAME_SITE:Lax}
+  account:
+    rejoin-wait-days: ${ACCOUNT_REJOIN_WAIT_DAYS:30}
+
+  membership:
+    payment-provider: ${MEMBERSHIP_PAYMENT_PROVIDER:PORTONE_V2}
 
 jwt:
   issuer: ${JWT_ISSUER:ossdoc}


### PR DESCRIPTION
## 작업 개요

Google OAuth만을 사용하는 인증/회원 관리 구조로 개편했습니다.

기존 자체 회원가입/비밀번호 로그인 방식은 사용하지 않고, Google 계정 기반으로만 회원가입 및 로그인이 가능하도록 정리했습니다.  
서비스 ID는 Google 이메일을 사용하며, 사용자 식별은 Google OIDC `sub` 값을 기준으로 처리합니다.

또한 마이페이지에서 사용할 닉네임 변경, 닉네임 중복 확인, 회원 탈퇴 기능의 기반 API를 추가했습니다.

---

## 주요 변경 사항

### 1. Google OAuth 전용 회원 구조 적용

- 자체 회원가입/비밀번호 로그인 제거 방향으로 인증 구조 정리
- Google OAuth 로그인 성공 시 사용자 자동 생성 또는 기존 사용자 갱신
- Google `providerId(sub)` 기준으로 사용자 식별
- Google 이메일은 서비스 ID로 사용
- Google 이메일 인증 여부(`email_verified`) 검증 추가

### 2. 사용자 엔티티 개선

- `provider`, `providerId`, `email`, `nickname`, `active` 기반 회원 구조 적용
- 닉네임 컬럼 추가
- 회원 탈퇴 시 row 삭제 대신 `active=false` 처리
- 탈퇴 시각 저장을 위한 `deletedAt` 추가
- 재가입 시각 저장을 위한 `reactivatedAt` 추가

### 3. 탈퇴 후 재가입 정책 추가

- 탈퇴 후 일정 기간 동안 같은 Google 계정 재가입 차단
- 기본 대기 기간은 30일
- 대기 기간 이후에는 기존 계정을 재활성화
- 기존 `user_id`를 유지하므로 이후 무료 분석권/분석 이력/결제 이력 초기화 방지 가능

### 4. 닉네임 관리 API 추가

- 현재 로그인 사용자 조회
- 닉네임 중복 확인
- 닉네임 변경
- 닉네임 형식 검증 추가
  - 2~20자
  - 한글, 영문, 숫자, 밑줄(_) 허용

### 5. 인증 Principal 구조 정리

- `AuthenticatedUser`를 로그인 사용자 정보 보관용 객체로 정리
- 권한 기반 처리는 사용하지 않도록 단순화
- `getAuthorities()` 제거
- `SecurityConfig`에서는 `hasRole()` 대신 `authenticated()` 중심으로 접근 제어

### 6. JWT 인증 필터 정리

- JWT에서 `userId` 추출
- DB에서 사용자 조회
- `active=false` 사용자는 인증 처리하지 않음
- 권한 목록은 빈 리스트로 처리하여 로그인 여부만 판단

---

## 추가/수정 API

### 인증/회원

| Method | URL | 설명 |
|---|---|---|
| GET | `/api/v1/auth/me` | 현재 로그인 사용자 조회 |
| GET | `/api/v1/auth/nicknames/{nickname}/availability` | 닉네임 중복 확인 |
| PATCH | `/api/v1/auth/me/nickname` | 닉네임 변경 |
| POST | `/api/v1/auth/refresh` | Access Token 재발급 |
| POST | `/api/v1/auth/logout` | 로그아웃 |
| DELETE | `/api/v1/auth/me` | 회원 탈퇴 |

---

## 보안 정책

- 자체 비밀번호는 저장하지 않음
- Google OAuth 인증만 허용
- Google `email_verified=true`인 계정만 허용
- Google 이메일이 변경되어도 `providerId(sub)` 기준으로 동일 사용자 식별
- 탈퇴 계정은 즉시 로그인 차단
- 탈퇴 후 30일이 지나면 기존 계정 재활성화
- 재활성화 시 기존 `user_id` 유지

---

## 설정 추가

```yaml
app:
  account:
    rejoin-wait-days: ${ACCOUNT_REJOIN_WAIT_DAYS:30}