### PR TITLE
Feat  run 응답에 분석 시각(createdAt/updatedAt) 제공 및 전역 캐시 hit 시 원본 분석 시각 매핑

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/cluster/dto/request/ClusterBuildRequest.java
@@ -2,6 +2,7 @@ package com.example.ossdoc.domain.cluster.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunCreateResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunCreateResponse.java
@@ -4,6 +4,8 @@ import com.example.ossdoc.domain.run.enums.RunStatus;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class RepoRunCreateResponse {
@@ -49,4 +51,10 @@ public class RepoRunCreateResponse {
      * - 전역 캐시 공유 hit면 원본 runId를 담고, 반환 runId는 복제된 공유 run이 됩니다.
      */
     private String sourceRunId;
+
+    /**
+     * FE에서 "최근 분석 n시간 전" 표시를 계산할 때 사용하는 시각 정보입니다.
+     */
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunProgressResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunProgressResponse.java
@@ -5,6 +5,7 @@ import com.example.ossdoc.domain.run.entity.RunPipelineJob;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -20,6 +21,8 @@ public class RepoRunProgressResponse {
     private String failureMessage;
     private String repoUrl;
     private String commitSha;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     private RunArtifactIdsResponse artifacts;
     private List<RunStepProgressResponse> steps;
@@ -42,6 +45,8 @@ public class RepoRunProgressResponse {
                 .failureMessage(job.getFailureMessage())
                 .repoUrl(run.getRepoUrl())
                 .commitSha(run.getCommitSha())
+                .createdAt(run.getCreatedAt())
+                .updatedAt(run.getUpdatedAt())
                 .artifacts(artifacts)
                 .steps(steps)
                 .failedSteps(failedSteps)

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -175,7 +175,8 @@ public class RepoRunService {
                             sharedCachedRun,
                             true,
                             cacheLookupResult.cacheKey(),
-                            sourceRun.getRunId()
+                            sourceRun.getRunId(),
+                            sourceRun
                     );
                 }
 
@@ -585,6 +586,18 @@ public class RepoRunService {
             String cacheKey,
             String sourceRunId
     ) {
+        return toCreateResponse(run, cacheHit, cacheKey, sourceRunId, null);
+    }
+
+    private RepoRunCreateResponse toCreateResponse(
+            RepoRun run,
+            boolean cacheHit,
+            String cacheKey,
+            String sourceRunId,
+            RepoRun analyzedSourceRun
+    ) {
+        RepoRun analyzedAtBaseRun = analyzedSourceRun != null ? analyzedSourceRun : run;
+
         return RepoRunCreateResponse.builder()
                 .runId(run.getRunId())
                 .status(run.getStatus())
@@ -593,6 +606,8 @@ public class RepoRunService {
                 .cacheHit(cacheHit)
                 .cacheKey(cacheKey)
                 .sourceRunId(sourceRunId)
+                .createdAt(analyzedAtBaseRun.getCreatedAt())
+                .updatedAt(analyzedAtBaseRun.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 제목
feat(be): run 응답에 분석 시각(createdAt/updatedAt) 제공 및 전역 캐시 hit 시 원본 분석 시각 매핑

## 요약
프론트에서 `기존 분석 결과 · 최근 분석 n시간 전`을 정확히 표시할 수 있도록,
run 생성/진행 응답에 분석 시각 필드를 추가했습니다.  
또한 전역 캐시 hit(공유 run 생성) 경로에서 시각이 왜곡되지 않도록
응답 시각 기준을 공유 run이 아닌 원본 분석 run으로 매핑했습니다.

## 주요 변경 사항
1. `RepoRunCreateResponse` 확장
- `createdAt`, `updatedAt` 필드 추가
- FE가 create 응답만으로도 상대시간 계산 가능

2. `RepoRunProgressResponse` 확장
- `createdAt`, `updatedAt` 필드 추가
- progress polling 응답에서도 동일한 시각 기준 제공

3. 전역 캐시 hit 시 시각 매핑 보정
- 기존: 전역 hit 시 공유 run(방금 생성됨) 기준 시각이 내려갈 수 있음
- 변경: 원본 분석 run(`sourceRun`)의 `createdAt/updatedAt`을 응답에 반영
- 결과: 캐시 재사용 시 “최근 분석 n시간 전”이 실제 분석 시점 기준으로 정확

4. `RepoRunService#toCreateResponse` 오버로드 추가
- 기본 경로는 기존 동작 유지
- 필요 시 `analyzedSourceRun`을 주입해 시각 기준 run을 명시적으로 선택

## 변경 파일
- `src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunCreateResponse.java`
- `src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunProgressResponse.java`
- `src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java`
