### PR TITLE
feat: Google 인증 기반 멤버십 및 PortOne 테스트 결제 연동

### DIFF
--- a/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/artifact/service/ArtifactQueryService.java
@@ -6,6 +6,10 @@ import com.example.ossdoc.domain.artifact.exception.ArtifactException;
 import com.example.ossdoc.domain.artifact.exception.code.ArtifactErrorCode;
 import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.membership.exception.MembershipException;
+import com.example.ossdoc.domain.membership.exception.code.MembershipErrorCode;
+import com.example.ossdoc.domain.membership.service.MembershipAccessService;
+import com.example.ossdoc.domain.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,12 +24,13 @@ public class ArtifactQueryService {
 
     private final ArtifactRepository artifactRepository;
     private final ObjectMapper objectMapper;
+    private final MembershipAccessService membershipAccessService;
 
     public ArtifactJsonResponse getJsonArtifact(Long artifactId, Long userId) {
         Artifact artifact = artifactRepository.findById(artifactId)
                 .orElseThrow(() -> new ArtifactException(ArtifactErrorCode.ARTIFACT_NOT_FOUND));
 
-        validateOwner(artifact, userId);
+        validateOwnerAndMembership(artifact, userId);
         validateJsonArtifact(artifact);
 
         /*
@@ -41,11 +46,16 @@ public class ArtifactQueryService {
         return ArtifactJsonResponse.from(artifact, plainJsonContent);
     }
 
-    private void validateOwner(Artifact artifact, Long userId) {
+    private void validateOwnerAndMembership(Artifact artifact, Long userId) {
         RepoRun run = artifact.getRun();
+        User owner = run.getOwner();
 
-        if (run.getOwner() == null || !Objects.equals(run.getOwner().getId(), userId)) {
+        if (owner == null || !Objects.equals(owner.getId(), userId)) {
             throw new ArtifactException(ArtifactErrorCode.ARTIFACT_FORBIDDEN);
+        }
+
+        if (!membershipAccessService.canViewRun(run, owner)) {
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP_REQUIRED);
         }
     }
 

--- a/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/auth/exception/code/AuthErrorCode.java
@@ -16,6 +16,17 @@ public enum AuthErrorCode implements BaseCode {
             "인증이 필요합니다."
     ),
 
+    /*
+     * 최신 develop의 여러 Controller에서 아직 사용하는 이름입니다.
+     * 의미는 AUTHENTICATION_REQUIRED와 동일합니다.
+     * 기존 컨트롤러 코드를 대량 수정하지 않기 위해 호환용으로 유지합니다.
+     */
+    UNAUTHORIZED_USER(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_1",
+            "인증이 필요합니다."
+    ),
+
     USER_NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "AUTH404_1",

--- a/src/main/java/com/example/ossdoc/domain/membership/controller/MembershipController.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/controller/MembershipController.java
@@ -1,0 +1,32 @@
+package com.example.ossdoc.domain.membership.controller;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.membership.dto.response.MembershipStatusResponse;
+import com.example.ossdoc.domain.membership.service.MembershipService;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/membership")
+public class MembershipController {
+
+    private final MembershipService membershipService;
+
+    @GetMapping("/me")
+    public ApiResponse<MembershipStatusResponse> me(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        return ApiResponse.onSuccess(
+                membershipService.getMyMembership(authenticatedUser.getUserId())
+        );
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/dto/response/MembershipStatusResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/dto/response/MembershipStatusResponse.java
@@ -1,0 +1,24 @@
+package com.example.ossdoc.domain.membership.dto.response;
+
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+import com.example.ossdoc.domain.membership.enums.SubscriptionStatus;
+
+import java.time.LocalDateTime;
+
+public record MembershipStatusResponse(
+        boolean membershipActive,
+        boolean canAnalyze,
+        int freeAnalysisLimit,
+        int freeAnalysisUsed,
+        int freeAnalysisRemaining,
+        MembershipPlan plan,
+        String planName,
+        int amount,
+        String currency,
+        SubscriptionStatus subscriptionStatus,
+        PaymentProvider paymentProvider,
+        LocalDateTime currentPeriodEnd,
+        String message
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/entity/UserSubscription.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/entity/UserSubscription.java
@@ -1,0 +1,132 @@
+package com.example.ossdoc.domain.membership.entity;
+
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+import com.example.ossdoc.domain.membership.enums.SubscriptionStatus;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_subscription",
+        indexes = {
+                @Index(
+                        name = "idx_user_subscription_user_status",
+                        columnList = "user_id,status"
+                ),
+                @Index(
+                        name = "idx_user_subscription_period",
+                        columnList = "current_period_end"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserSubscription extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private MembershipPlan plan;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SubscriptionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_provider", nullable = false, length = 30)
+    private PaymentProvider paymentProvider;
+
+    @Column(name = "provider_subscription_id", length = 120)
+    private String providerSubscriptionId;
+
+    @Column(name = "provider_customer_id", length = 120)
+    private String providerCustomerId;
+
+    @Column(name = "last_payment_id", length = 120)
+    private String lastPaymentId;
+
+    @Column(name = "billing_key_ref", length = 200)
+    private String billingKeyRef;
+
+    @Column(name = "price_amount", nullable = false)
+    private int priceAmount;
+
+    @Column(nullable = false, length = 10)
+    private String currency;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "current_period_start")
+    private LocalDateTime currentPeriodStart;
+
+    @Column(name = "current_period_end")
+    private LocalDateTime currentPeriodEnd;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    public static UserSubscription pending(
+            User user,
+            MembershipPlan plan,
+            PaymentProvider paymentProvider
+    ) {
+        return UserSubscription.builder()
+                .user(user)
+                .plan(plan)
+                .status(SubscriptionStatus.PENDING)
+                .paymentProvider(paymentProvider)
+                .priceAmount(plan.getAmount())
+                .currency(plan.getCurrency())
+                .build();
+    }
+
+    public boolean isActiveAt(LocalDateTime now) {
+        if (status != SubscriptionStatus.ACTIVE) {
+            return false;
+        }
+
+        return currentPeriodEnd == null || currentPeriodEnd.isAfter(now);
+    }
+
+    public void activateByPayment(
+            String paymentId,
+            LocalDateTime now,
+            LocalDateTime periodEnd
+    ) {
+        this.status = SubscriptionStatus.ACTIVE;
+        this.startedAt = this.startedAt == null ? now : this.startedAt;
+        this.currentPeriodStart = now;
+        this.currentPeriodEnd = periodEnd;
+        this.lastPaymentId = paymentId;
+        this.canceledAt = null;
+    }
+
+    public void cancelAtPeriodEnd(LocalDateTime now) {
+        this.status = SubscriptionStatus.CANCELED;
+        this.canceledAt = now;
+    }
+
+    public void markPastDue() {
+        this.status = SubscriptionStatus.PAST_DUE;
+    }
+
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/entity/UserUsageQuota.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/entity/UserUsageQuota.java
@@ -1,0 +1,56 @@
+package com.example.ossdoc.domain.membership.entity;
+
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "user_usage_quota",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_usage_quota_user",
+                        columnNames = "user_id"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserUsageQuota extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "usage_quota_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "free_analysis_limit", nullable = false)
+    @Builder.Default
+    private int freeAnalysisLimit = 1;
+
+    @Column(name = "free_analysis_used", nullable = false)
+    @Builder.Default
+    private int freeAnalysisUsed = 0;
+
+    public int remainingFreeAnalyses() {
+        return Math.max(0, freeAnalysisLimit - freeAnalysisUsed);
+    }
+
+    public boolean hasFreeAnalysis() {
+        return remainingFreeAnalyses() > 0;
+    }
+
+    public void consumeFreeAnalysis() {
+        if (!hasFreeAnalysis()) {
+            throw new IllegalStateException("무료 분석 기회가 남아 있지 않습니다.");
+        }
+
+        this.freeAnalysisUsed += 1;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/enums/AnalysisAccessType.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/enums/AnalysisAccessType.java
@@ -1,0 +1,6 @@
+package com.example.ossdoc.domain.membership.enums;
+
+public enum AnalysisAccessType {
+    FREE_TRIAL,
+    MEMBERSHIP
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/enums/MembershipPlan.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/enums/MembershipPlan.java
@@ -1,0 +1,31 @@
+package com.example.ossdoc.domain.membership.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MembershipPlan {
+
+    BASIC_MONTHLY(
+            "Basic Monthly",
+            9_900,
+            "KRW",
+            1
+    );
+
+    private final String displayName;
+    private final int amount;
+    private final String currency;
+    private final int billingCycleMonths;
+
+    MembershipPlan(
+            String displayName,
+            int amount,
+            String currency,
+            int billingCycleMonths
+    ) {
+        this.displayName = displayName;
+        this.amount = amount;
+        this.currency = currency;
+        this.billingCycleMonths = billingCycleMonths;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/enums/PaymentProvider.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/enums/PaymentProvider.java
@@ -1,0 +1,5 @@
+package com.example.ossdoc.domain.membership.enums;
+
+public enum PaymentProvider {
+    PORTONE_V2
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/enums/SubscriptionStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/enums/SubscriptionStatus.java
@@ -1,0 +1,9 @@
+package com.example.ossdoc.domain.membership.enums;
+
+public enum SubscriptionStatus {
+    PENDING,
+    ACTIVE,
+    CANCELED,
+    PAST_DUE,
+    EXPIRED
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/exception/MembershipException.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/exception/MembershipException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.membership.exception;
+
+import com.example.ossdoc.domain.membership.exception.code.MembershipErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class MembershipException extends GeneralException {
+
+    public MembershipException(MembershipErrorCode code) {
+        super(code);
+    }
+
+    public MembershipException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/exception/code/MembershipErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/exception/code/MembershipErrorCode.java
@@ -1,0 +1,53 @@
+package com.example.ossdoc.domain.membership.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MembershipErrorCode implements BaseCode {
+
+    MEMBERSHIP_REQUIRED(
+            HttpStatus.PAYMENT_REQUIRED,
+            "MEMBERSHIP402_1",
+            "무료 분석 기회를 모두 사용했습니다. 멤버십 가입 후 사용할 수 있습니다."
+    ),
+
+    SUBSCRIPTION_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "MEMBERSHIP404_1",
+            "구독 정보를 찾을 수 없습니다."
+    ),
+
+    SUBSCRIPTION_ALREADY_ACTIVE(
+            HttpStatus.CONFLICT,
+            "MEMBERSHIP409_1",
+            "이미 활성화된 멤버십이 있습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/repository/UserSubscriptionRepository.java
@@ -1,0 +1,21 @@
+package com.example.ossdoc.domain.membership.repository;
+
+import com.example.ossdoc.domain.membership.entity.UserSubscription;
+import com.example.ossdoc.domain.membership.enums.SubscriptionStatus;
+import com.example.ossdoc.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface UserSubscriptionRepository extends JpaRepository<UserSubscription, Long> {
+
+    Optional<UserSubscription> findFirstByUserAndStatusInOrderByCreatedAtDesc(
+            User user,
+            Collection<SubscriptionStatus> statuses
+    );
+
+    Optional<UserSubscription> findFirstByUserOrderByCreatedAtDesc(User user);
+
+    Optional<UserSubscription> findFirstByLastPaymentId(String lastPaymentId);
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/repository/UserUsageQuotaRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/repository/UserUsageQuotaRepository.java
@@ -1,0 +1,12 @@
+package com.example.ossdoc.domain.membership.repository;
+
+import com.example.ossdoc.domain.membership.entity.UserUsageQuota;
+import com.example.ossdoc.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserUsageQuotaRepository extends JpaRepository<UserUsageQuota, Long> {
+
+    Optional<UserUsageQuota> findByUser(User user);
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/service/MembershipAccessService.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/service/MembershipAccessService.java
@@ -1,0 +1,100 @@
+package com.example.ossdoc.domain.membership.service;
+
+import com.example.ossdoc.domain.membership.entity.UserSubscription;
+import com.example.ossdoc.domain.membership.entity.UserUsageQuota;
+import com.example.ossdoc.domain.membership.enums.AnalysisAccessType;
+import com.example.ossdoc.domain.membership.enums.SubscriptionStatus;
+import com.example.ossdoc.domain.membership.exception.MembershipException;
+import com.example.ossdoc.domain.membership.exception.code.MembershipErrorCode;
+import com.example.ossdoc.domain.membership.repository.UserSubscriptionRepository;
+import com.example.ossdoc.domain.membership.repository.UserUsageQuotaRepository;
+import com.example.ossdoc.domain.run.entity.RepoRun;
+import com.example.ossdoc.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MembershipAccessService {
+
+    private final UserUsageQuotaRepository userUsageQuotaRepository;
+    private final UserSubscriptionRepository userSubscriptionRepository;
+
+    @Transactional
+    public UserUsageQuota getOrCreateQuota(User user) {
+        return userUsageQuotaRepository.findByUser(user)
+                .orElseGet(() -> userUsageQuotaRepository.save(
+                        UserUsageQuota.builder()
+                                .user(user)
+                                .freeAnalysisLimit(1)
+                                .freeAnalysisUsed(0)
+                                .build()
+                ));
+    }
+
+    public boolean hasActiveMembership(User user) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return userSubscriptionRepository
+                .findFirstByUserAndStatusInOrderByCreatedAtDesc(
+                        user,
+                        List.of(SubscriptionStatus.ACTIVE)
+                )
+                .filter(subscription -> subscription.isActiveAt(now))
+                .isPresent();
+    }
+
+    public UserSubscription findLatestSubscription(User user) {
+        return userSubscriptionRepository
+                .findFirstByUserOrderByCreatedAtDesc(user)
+                .orElse(null);
+    }
+
+    /**
+     * 분석 시작 권한을 부여합니다.
+     *
+     * 정책:
+     * 1. ACTIVE 멤버십이 있으면 MEMBERSHIP 분석으로 생성
+     * 2. 멤버십이 없고 무료 분석권이 남아 있으면 FREE_TRIAL 분석으로 생성
+     * 3. 둘 다 없으면 MEMBERSHIP_REQUIRED 예외
+     */
+    @Transactional
+    public AnalysisAccessType grantAnalysisStart(User user) {
+        if (hasActiveMembership(user)) {
+            return AnalysisAccessType.MEMBERSHIP;
+        }
+
+        UserUsageQuota quota = getOrCreateQuota(user);
+
+        if (quota.hasFreeAnalysis()) {
+            quota.consumeFreeAnalysis();
+            return AnalysisAccessType.FREE_TRIAL;
+        }
+
+        throw new MembershipException(MembershipErrorCode.MEMBERSHIP_REQUIRED);
+    }
+
+    /**
+     * 분석 결과 조회 권한을 판단합니다.
+     *
+     * FREE_TRIAL로 생성된 run:
+     * - 미결제여도 계속 조회 가능
+     *
+     * MEMBERSHIP으로 생성된 run:
+     * - 현재 ACTIVE 멤버십이 있어야 조회 가능
+     */
+    public boolean canViewRun(RepoRun run, User user) {
+        AnalysisAccessType accessType = run.getAnalysisAccessType();
+
+        if (accessType == AnalysisAccessType.FREE_TRIAL) {
+            return true;
+        }
+
+        return hasActiveMembership(user);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/membership/service/MembershipService.java
+++ b/src/main/java/com/example/ossdoc/domain/membership/service/MembershipService.java
@@ -1,0 +1,76 @@
+package com.example.ossdoc.domain.membership.service;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.membership.dto.response.MembershipStatusResponse;
+import com.example.ossdoc.domain.membership.entity.UserSubscription;
+import com.example.ossdoc.domain.membership.entity.UserUsageQuota;
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MembershipService {
+
+    private static final MembershipPlan DEFAULT_PLAN = MembershipPlan.BASIC_MONTHLY;
+    private static final PaymentProvider DEFAULT_PAYMENT_PROVIDER = PaymentProvider.PORTONE_V2;
+
+    private final UserRepository userRepository;
+    private final MembershipAccessService membershipAccessService;
+
+    @Transactional
+    public MembershipStatusResponse getMyMembership(Long userId) {
+        User user = getActiveUser(userId);
+
+        UserUsageQuota quota = membershipAccessService.getOrCreateQuota(user);
+        UserSubscription latestSubscription = membershipAccessService.findLatestSubscription(user);
+
+        boolean membershipActive = membershipAccessService.hasActiveMembership(user);
+        int freeRemaining = quota.remainingFreeAnalyses();
+        boolean canAnalyze = membershipActive || freeRemaining > 0;
+
+        String message = resolveMessage(membershipActive, freeRemaining);
+
+        return new MembershipStatusResponse(
+                membershipActive,
+                canAnalyze,
+                quota.getFreeAnalysisLimit(),
+                quota.getFreeAnalysisUsed(),
+                freeRemaining,
+                DEFAULT_PLAN,
+                DEFAULT_PLAN.getDisplayName(),
+                DEFAULT_PLAN.getAmount(),
+                DEFAULT_PLAN.getCurrency(),
+                latestSubscription == null ? null : latestSubscription.getStatus(),
+                latestSubscription == null
+                        ? DEFAULT_PAYMENT_PROVIDER
+                        : latestSubscription.getPaymentProvider(),
+                latestSubscription == null ? null : latestSubscription.getCurrentPeriodEnd(),
+                message
+        );
+    }
+
+    private User getActiveUser(Long userId) {
+        return userRepository.findById(userId)
+                .filter(User::isActive)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+
+    private String resolveMessage(boolean membershipActive, int freeRemaining) {
+        if (membershipActive) {
+            return "멤버십이 활성화되어 분석을 계속 사용할 수 있습니다.";
+        }
+
+        if (freeRemaining > 0) {
+            return "무료 분석 기회 1회가 남아 있습니다.";
+        }
+
+        return "무료 분석 기회를 모두 사용했습니다. 멤버십 가입 후 분석할 수 있습니다.";
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/client/PortOnePaymentClient.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/client/PortOnePaymentClient.java
@@ -6,14 +6,18 @@ import com.example.ossdoc.domain.payment.exception.PaymentException;
 import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
 import com.example.ossdoc.global.properties.PortOneProperties;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PortOnePaymentClient {
@@ -21,25 +25,53 @@ public class PortOnePaymentClient {
     private final PortOneProperties portOneProperties;
     private final WebClient.Builder webClientBuilder;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     public PortOnePaymentSnapshot getPayment(String paymentId) {
         portOneProperties.validateApiConfig();
 
         try {
-            JsonNode root = webClient()
+            String body = webClient()
                     .get()
                     .uri("/payments/{paymentId}", paymentId)
-                    .retrieve()
-                    .bodyToMono(JsonNode.class)
+                    .exchangeToMono(response -> response.bodyToMono(String.class)
+                            .defaultIfEmpty("")
+                            .map(responseBody -> {
+                                if (response.statusCode().is2xxSuccessful()) {
+                                    return responseBody;
+                                }
+
+                                log.error(
+                                        "PortOne payment lookup failed. status={}, paymentId={}, body={}",
+                                        response.statusCode(),
+                                        paymentId,
+                                        responseBody
+                                );
+
+                                throw new PaymentException(PaymentErrorCode.PAYMENT_PROVIDER_ERROR);
+                            }))
                     .block();
 
-            if (root == null) {
+            if (body == null || body.isBlank()) {
+                log.error("PortOne payment lookup returned empty body. paymentId={}", paymentId);
                 throw new PaymentException(PaymentErrorCode.PAYMENT_PROVIDER_ERROR);
             }
+
+            JsonNode root = objectMapper.readTree(body);
+
+            log.info(
+                    "PortOne payment lookup success. paymentId={}, status={}, amount={}, currency={}",
+                    paymentId,
+                    text(root, "status", null),
+                    integer(root.path("amount"), "total"),
+                    text(root, "currency", null)
+            );
 
             return toSnapshot(root, paymentId);
         } catch (PaymentException e) {
             throw e;
         } catch (Exception e) {
+            log.error("PortOne payment lookup unexpected error. paymentId={}", paymentId, e);
             throw new PaymentException(PaymentErrorCode.PAYMENT_PROVIDER_ERROR);
         }
     }
@@ -48,22 +80,41 @@ public class PortOnePaymentClient {
         portOneProperties.validateApiConfig();
 
         try {
-            JsonNode root = webClient()
+            String body = webClient()
                     .post()
                     .uri("/payments/{paymentId}/cancel", paymentId)
+                    .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(new PortOneCancelRequest(reason))
-                    .retrieve()
-                    .bodyToMono(JsonNode.class)
+                    .exchangeToMono(response -> response.bodyToMono(String.class)
+                            .defaultIfEmpty("")
+                            .map(responseBody -> {
+                                if (response.statusCode().is2xxSuccessful()) {
+                                    return responseBody;
+                                }
+
+                                log.error(
+                                        "PortOne payment cancel failed. status={}, paymentId={}, body={}",
+                                        response.statusCode(),
+                                        paymentId,
+                                        responseBody
+                                );
+
+                                throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
+                            }))
                     .block();
 
-            if (root == null) {
+            if (body == null || body.isBlank()) {
+                log.error("PortOne payment cancel returned empty body. paymentId={}", paymentId);
                 throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
             }
+
+            JsonNode root = objectMapper.readTree(body);
 
             return toSnapshot(root, paymentId);
         } catch (PaymentException e) {
             throw e;
         } catch (Exception e) {
+            log.error("PortOne payment cancel unexpected error. paymentId={}", paymentId, e);
             throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
         }
     }
@@ -75,6 +126,7 @@ public class PortOnePaymentClient {
                         HttpHeaders.AUTHORIZATION,
                         "PortOne " + portOneProperties.getApiSecret()
                 )
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
 
@@ -101,9 +153,11 @@ public class PortOnePaymentClient {
 
     private String text(JsonNode node, String field, String fallback) {
         JsonNode value = node.get(field);
+
         if (value == null || value.isNull()) {
             return fallback;
         }
+
         return value.asText();
     }
 
@@ -113,6 +167,7 @@ public class PortOnePaymentClient {
         }
 
         JsonNode value = node.get(field);
+
         if (value == null || value.isNull()) {
             return null;
         }

--- a/src/main/java/com/example/ossdoc/domain/payment/client/PortOnePaymentClient.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/client/PortOnePaymentClient.java
@@ -1,0 +1,132 @@
+package com.example.ossdoc.domain.payment.client;
+
+import com.example.ossdoc.domain.payment.dto.portone.PortOneCancelRequest;
+import com.example.ossdoc.domain.payment.dto.portone.PortOnePaymentSnapshot;
+import com.example.ossdoc.domain.payment.exception.PaymentException;
+import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
+import com.example.ossdoc.global.properties.PortOneProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PortOnePaymentClient {
+
+    private final PortOneProperties portOneProperties;
+    private final WebClient.Builder webClientBuilder;
+
+    public PortOnePaymentSnapshot getPayment(String paymentId) {
+        portOneProperties.validateApiConfig();
+
+        try {
+            JsonNode root = webClient()
+                    .get()
+                    .uri("/payments/{paymentId}", paymentId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (root == null) {
+                throw new PaymentException(PaymentErrorCode.PAYMENT_PROVIDER_ERROR);
+            }
+
+            return toSnapshot(root, paymentId);
+        } catch (PaymentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_PROVIDER_ERROR);
+        }
+    }
+
+    public PortOnePaymentSnapshot cancelPayment(String paymentId, String reason) {
+        portOneProperties.validateApiConfig();
+
+        try {
+            JsonNode root = webClient()
+                    .post()
+                    .uri("/payments/{paymentId}/cancel", paymentId)
+                    .bodyValue(new PortOneCancelRequest(reason))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (root == null) {
+                throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
+            }
+
+            return toSnapshot(root, paymentId);
+        } catch (PaymentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
+        }
+    }
+
+    private WebClient webClient() {
+        return webClientBuilder
+                .baseUrl(portOneProperties.getApiBaseUrl())
+                .defaultHeader(
+                        HttpHeaders.AUTHORIZATION,
+                        "PortOne " + portOneProperties.getApiSecret()
+                )
+                .build();
+    }
+
+    private PortOnePaymentSnapshot toSnapshot(JsonNode root, String fallbackPaymentId) {
+        String paymentId = text(root, "id", fallbackPaymentId);
+        String status = text(root, "status", null);
+        Integer amount = integer(root.path("amount"), "total");
+        String currency = text(root, "currency", null);
+        String transactionId = text(root, "transactionId", null);
+
+        LocalDateTime paidAt = dateTime(root, "paidAt");
+        LocalDateTime canceledAt = dateTime(root, "cancelledAt");
+
+        return new PortOnePaymentSnapshot(
+                paymentId,
+                status,
+                amount,
+                currency,
+                transactionId,
+                paidAt,
+                canceledAt
+        );
+    }
+
+    private String text(JsonNode node, String field, String fallback) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return fallback;
+        }
+        return value.asText();
+    }
+
+    private Integer integer(JsonNode node, String field) {
+        if (node == null || node.isMissingNode()) {
+            return null;
+        }
+
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+
+        return value.asInt();
+    }
+
+    private LocalDateTime dateTime(JsonNode node, String field) {
+        String value = text(node, field, null);
+
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return OffsetDateTime.parse(value).toLocalDateTime();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/controller/PaymentController.java
@@ -1,0 +1,83 @@
+package com.example.ossdoc.domain.payment.controller;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.payment.dto.request.PaymentCancelRequest;
+import com.example.ossdoc.domain.payment.dto.request.PaymentVerifyRequest;
+import com.example.ossdoc.domain.payment.dto.response.PaymentCancelResponse;
+import com.example.ossdoc.domain.payment.dto.response.PaymentVerifyResponse;
+import com.example.ossdoc.domain.payment.dto.response.PortOneCheckoutResponse;
+import com.example.ossdoc.domain.payment.service.PaymentService;
+import com.example.ossdoc.domain.payment.support.PortOneWebhookVerifier;
+import com.example.ossdoc.global.apiPayload.ApiResponse;
+import com.example.ossdoc.global.security.jwt.AuthenticatedUser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/payments/portone")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    private final PortOneWebhookVerifier webhookVerifier;
+
+    @PostMapping("/checkout")
+    public ApiResponse<PortOneCheckoutResponse> prepareCheckout(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        return ApiResponse.onSuccess(
+                paymentService.prepareCheckout(authenticatedUser.getUserId())
+        );
+    }
+
+    @PostMapping("/verify")
+    public ApiResponse<PaymentVerifyResponse> verify(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody PaymentVerifyRequest request
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        return ApiResponse.onSuccess(
+                paymentService.verifyPayment(authenticatedUser.getUserId(), request)
+        );
+    }
+
+    @PostMapping("/{paymentId}/cancel")
+    public ApiResponse<PaymentCancelResponse> cancel(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @PathVariable String paymentId,
+            @RequestBody(required = false) PaymentCancelRequest request
+    ) {
+        if (authenticatedUser == null) {
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        return ApiResponse.onSuccess(
+                paymentService.cancelPayment(
+                        authenticatedUser.getUserId(),
+                        paymentId,
+                        request
+                )
+        );
+    }
+
+    @PostMapping("/webhook")
+    public ApiResponse<String> webhook(
+            @RequestBody String rawBody,
+            HttpServletRequest request
+    ) {
+        webhookVerifier.verify(rawBody, request);
+        paymentService.handleWebhook(rawBody);
+        return ApiResponse.onSuccess("OK");
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/portone/PortOneCancelRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/portone/PortOneCancelRequest.java
@@ -1,0 +1,6 @@
+package com.example.ossdoc.domain.payment.dto.portone;
+
+public record PortOneCancelRequest(
+        String reason
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/portone/PortOnePaymentSnapshot.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/portone/PortOnePaymentSnapshot.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.domain.payment.dto.portone;
+
+import java.time.LocalDateTime;
+
+public record PortOnePaymentSnapshot(
+        String paymentId,
+        String status,
+        Integer amount,
+        String currency,
+        String transactionId,
+        LocalDateTime paidAt,
+        LocalDateTime canceledAt
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,9 @@
+package com.example.ossdoc.domain.payment.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record PaymentCancelRequest(
+        @Size(max = 200, message = "취소 사유는 200자 이하로 입력해주세요.")
+        String reason
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/request/PaymentVerifyRequest.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/request/PaymentVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.example.ossdoc.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentVerifyRequest(
+        @NotBlank(message = "paymentId는 필수입니다.")
+        String paymentId
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/response/PaymentCancelResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/response/PaymentCancelResponse.java
@@ -1,0 +1,13 @@
+package com.example.ossdoc.domain.payment.dto.response;
+
+import com.example.ossdoc.domain.payment.enums.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public record PaymentCancelResponse(
+        String paymentId,
+        PaymentStatus paymentStatus,
+        LocalDateTime canceledAt,
+        String message
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/response/PaymentVerifyResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/response/PaymentVerifyResponse.java
@@ -1,0 +1,19 @@
+package com.example.ossdoc.domain.payment.dto.response;
+
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.payment.enums.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public record PaymentVerifyResponse(
+        String paymentId,
+        PaymentStatus paymentStatus,
+        MembershipPlan plan,
+        String planName,
+        int amount,
+        String currency,
+        boolean membershipActive,
+        LocalDateTime currentPeriodEnd,
+        String message
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/dto/response/PortOneCheckoutResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/dto/response/PortOneCheckoutResponse.java
@@ -1,0 +1,20 @@
+package com.example.ossdoc.domain.payment.dto.response;
+
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+
+public record PortOneCheckoutResponse(
+        String paymentId,
+        PaymentProvider paymentProvider,
+        String storeId,
+        String channelKey,
+        MembershipPlan plan,
+        String planName,
+        int amount,
+        String currency,
+        String orderName,
+        String customerKey,
+        String customerEmail,
+        String customerName
+) {
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/entity/PaymentOrder.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/entity/PaymentOrder.java
@@ -1,0 +1,161 @@
+package com.example.ossdoc.domain.payment.entity;
+
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+import com.example.ossdoc.domain.payment.enums.PaymentStatus;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "payment_order",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_payment_order_payment_id",
+                        columnNames = "payment_id"
+                )
+        },
+        indexes = {
+                @Index(
+                        name = "idx_payment_order_user_status",
+                        columnList = "user_id,status"
+                ),
+                @Index(
+                        name = "idx_payment_order_created_at",
+                        columnList = "created_at"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PaymentOrder extends BaseAuditedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_order_id")
+    private Long id;
+
+    @Column(name = "payment_id", nullable = false, length = 120)
+    private String paymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentProvider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private MembershipPlan plan;
+
+    @Column(name = "order_name", nullable = false, length = 120)
+    private String orderName;
+
+    @Column(nullable = false)
+    private int amount;
+
+    @Column(nullable = false, length = 10)
+    private String currency;
+
+    @Column(name = "customer_key", nullable = false, length = 120)
+    private String customerKey;
+
+    @Column(name = "provider_status", length = 60)
+    private String providerStatus;
+
+    @Column(name = "provider_transaction_id", length = 120)
+    private String providerTransactionId;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Column(name = "failure_reason", length = 500)
+    private String failureReason;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    public static PaymentOrder ready(
+            User user,
+            String paymentId,
+            MembershipPlan plan,
+            String orderName,
+            int amount,
+            String currency,
+            String customerKey
+    ) {
+        return PaymentOrder.builder()
+                .paymentId(paymentId)
+                .user(user)
+                .provider(PaymentProvider.PORTONE_V2)
+                .status(PaymentStatus.READY)
+                .plan(plan)
+                .orderName(orderName)
+                .amount(amount)
+                .currency(currency)
+                .customerKey(customerKey)
+                .build();
+    }
+
+    public boolean isPaid() {
+        return status == PaymentStatus.PAID;
+    }
+
+    public boolean isCanceled() {
+        return status == PaymentStatus.CANCELED;
+    }
+
+    public void markPaid(
+            String providerStatus,
+            String providerTransactionId,
+            LocalDateTime paidAt
+    ) {
+        this.status = PaymentStatus.PAID;
+        this.providerStatus = providerStatus;
+        this.providerTransactionId = providerTransactionId;
+        this.paidAt = paidAt == null ? LocalDateTime.now() : paidAt;
+        this.failedAt = null;
+        this.failureReason = null;
+        this.canceledAt = null;
+        this.cancelReason = null;
+    }
+
+    public void markFailed(
+            String providerStatus,
+            String failureReason
+    ) {
+        this.status = PaymentStatus.FAILED;
+        this.providerStatus = providerStatus;
+        this.failedAt = LocalDateTime.now();
+        this.failureReason = failureReason;
+    }
+
+    public void markCanceled(
+            String providerStatus,
+            String cancelReason,
+            LocalDateTime canceledAt
+    ) {
+        this.status = PaymentStatus.CANCELED;
+        this.providerStatus = providerStatus;
+        this.canceledAt = canceledAt == null ? LocalDateTime.now() : canceledAt;
+        this.cancelReason = cancelReason;
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.example.ossdoc.domain.payment.enums;
+
+public enum PaymentStatus {
+    READY,
+    PAID,
+    FAILED,
+    CANCELED
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/exception/PaymentException.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/exception/PaymentException.java
@@ -1,0 +1,16 @@
+package com.example.ossdoc.domain.payment.exception;
+
+import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.exception.GeneralException;
+
+public class PaymentException extends GeneralException {
+
+    public PaymentException(PaymentErrorCode code) {
+        super(code);
+    }
+
+    public PaymentException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/exception/code/PaymentErrorCode.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/exception/code/PaymentErrorCode.java
@@ -1,0 +1,95 @@
+package com.example.ossdoc.domain.payment.exception.code;
+
+import com.example.ossdoc.global.apiPayload.code.BaseCode;
+import com.example.ossdoc.global.apiPayload.code.ReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements BaseCode {
+
+    PAYMENT_ORDER_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "PAYMENT404_1",
+            "결제 요청 정보를 찾을 수 없습니다."
+    ),
+
+    PAYMENT_ACCESS_DENIED(
+            HttpStatus.FORBIDDEN,
+            "PAYMENT403_1",
+            "해당 결제 요청에 접근할 권한이 없습니다."
+    ),
+
+    PAYMENT_ALREADY_PROCESSED(
+            HttpStatus.CONFLICT,
+            "PAYMENT409_1",
+            "이미 처리된 결제입니다."
+    ),
+
+    PAYMENT_AMOUNT_MISMATCH(
+            HttpStatus.BAD_REQUEST,
+            "PAYMENT400_1",
+            "결제 금액이 일치하지 않습니다."
+    ),
+
+    PAYMENT_CURRENCY_MISMATCH(
+            HttpStatus.BAD_REQUEST,
+            "PAYMENT400_2",
+            "결제 통화가 일치하지 않습니다."
+    ),
+
+    PAYMENT_NOT_PAID(
+            HttpStatus.BAD_REQUEST,
+            "PAYMENT400_3",
+            "결제가 완료되지 않았습니다."
+    ),
+
+    PAYMENT_PROVIDER_ERROR(
+            HttpStatus.BAD_GATEWAY,
+            "PAYMENT502_1",
+            "결제 제공자 통신 중 오류가 발생했습니다."
+    ),
+
+    PAYMENT_CANCEL_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "PAYMENT502_2",
+            "결제 취소 요청에 실패했습니다."
+    ),
+
+    PAYMENT_WEBHOOK_INVALID(
+            HttpStatus.UNAUTHORIZED,
+            "PAYMENT401_1",
+            "유효하지 않은 결제 웹훅 요청입니다."
+    ),
+
+    PAYMENT_CONFIG_MISSING(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "PAYMENT500_1",
+            "결제 설정값이 누락되었습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/repository/PaymentOrderRepository.java
@@ -1,0 +1,20 @@
+package com.example.ossdoc.domain.payment.repository;
+
+import com.example.ossdoc.domain.payment.entity.PaymentOrder;
+import com.example.ossdoc.domain.payment.enums.PaymentStatus;
+import com.example.ossdoc.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
+
+    Optional<PaymentOrder> findByPaymentId(String paymentId);
+
+    Optional<PaymentOrder> findFirstByUserAndStatusOrderByCreatedAtDesc(
+            User user,
+            PaymentStatus status
+    );
+
+    boolean existsByPaymentId(String paymentId);
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/service/PaymentService.java
@@ -1,0 +1,317 @@
+package com.example.ossdoc.domain.payment.service;
+
+import com.example.ossdoc.domain.auth.exception.AuthException;
+import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
+import com.example.ossdoc.domain.membership.entity.UserSubscription;
+import com.example.ossdoc.domain.membership.enums.MembershipPlan;
+import com.example.ossdoc.domain.membership.enums.PaymentProvider;
+import com.example.ossdoc.domain.membership.enums.SubscriptionStatus;
+import com.example.ossdoc.domain.membership.exception.MembershipException;
+import com.example.ossdoc.domain.membership.exception.code.MembershipErrorCode;
+import com.example.ossdoc.domain.membership.repository.UserSubscriptionRepository;
+import com.example.ossdoc.domain.membership.service.MembershipAccessService;
+import com.example.ossdoc.domain.payment.client.PortOnePaymentClient;
+import com.example.ossdoc.domain.payment.dto.portone.PortOnePaymentSnapshot;
+import com.example.ossdoc.domain.payment.dto.request.PaymentCancelRequest;
+import com.example.ossdoc.domain.payment.dto.request.PaymentVerifyRequest;
+import com.example.ossdoc.domain.payment.dto.response.PaymentCancelResponse;
+import com.example.ossdoc.domain.payment.dto.response.PaymentVerifyResponse;
+import com.example.ossdoc.domain.payment.dto.response.PortOneCheckoutResponse;
+import com.example.ossdoc.domain.payment.entity.PaymentOrder;
+import com.example.ossdoc.domain.payment.enums.PaymentStatus;
+import com.example.ossdoc.domain.payment.exception.PaymentException;
+import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
+import com.example.ossdoc.domain.payment.repository.PaymentOrderRepository;
+import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.user.repository.UserRepository;
+import com.example.ossdoc.global.properties.PortOneProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+    private static final MembershipPlan DEFAULT_PLAN = MembershipPlan.BASIC_MONTHLY;
+    private static final String PAID_STATUS = "PAID";
+    private static final String CANCELED_STATUS = "CANCELLED";
+    private static final String CANCELED_STATUS_ALT = "CANCELED";
+
+    private final UserRepository userRepository;
+    private final PaymentOrderRepository paymentOrderRepository;
+    private final UserSubscriptionRepository userSubscriptionRepository;
+    private final MembershipAccessService membershipAccessService;
+    private final PortOnePaymentClient portOnePaymentClient;
+    private final PortOneProperties portOneProperties;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public PortOneCheckoutResponse prepareCheckout(Long userId) {
+        portOneProperties.validateCheckoutConfig();
+
+        User user = getActiveUser(userId);
+
+        if (membershipAccessService.hasActiveMembership(user)) {
+            throw new MembershipException(MembershipErrorCode.SUBSCRIPTION_ALREADY_ACTIVE);
+        }
+
+        String paymentId = generatePaymentId();
+        String orderName = DEFAULT_PLAN.getDisplayName() + " 정기 멤버십";
+        String customerKey = "user_" + user.getId();
+
+        PaymentOrder order = PaymentOrder.ready(
+                user,
+                paymentId,
+                DEFAULT_PLAN,
+                orderName,
+                DEFAULT_PLAN.getAmount(),
+                DEFAULT_PLAN.getCurrency(),
+                customerKey
+        );
+
+        paymentOrderRepository.save(order);
+
+        return new PortOneCheckoutResponse(
+                paymentId,
+                PaymentProvider.PORTONE_V2,
+                portOneProperties.getStoreId(),
+                portOneProperties.getChannelKey(),
+                DEFAULT_PLAN,
+                DEFAULT_PLAN.getDisplayName(),
+                DEFAULT_PLAN.getAmount(),
+                DEFAULT_PLAN.getCurrency(),
+                orderName,
+                customerKey,
+                user.getEmail(),
+                user.getNickname()
+        );
+    }
+
+    @Transactional
+    public PaymentVerifyResponse verifyPayment(
+            Long userId,
+            PaymentVerifyRequest request
+    ) {
+        User user = getActiveUser(userId);
+        PaymentOrder order = getMyPaymentOrder(request.paymentId(), user);
+
+        return syncPaidPayment(order);
+    }
+
+    @Transactional
+    public PaymentCancelResponse cancelPayment(
+            Long userId,
+            String paymentId,
+            PaymentCancelRequest request
+    ) {
+        User user = getActiveUser(userId);
+        PaymentOrder order = getMyPaymentOrder(paymentId, user);
+
+        if (order.isCanceled()) {
+            return new PaymentCancelResponse(
+                    order.getPaymentId(),
+                    order.getStatus(),
+                    order.getCanceledAt(),
+                    "이미 취소된 결제입니다."
+            );
+        }
+
+        String reason = request == null || request.reason() == null || request.reason().isBlank()
+                ? "테스트 결제 취소"
+                : request.reason();
+
+        PortOnePaymentSnapshot snapshot = portOnePaymentClient.cancelPayment(paymentId, reason);
+
+        order.markCanceled(
+                snapshot.status(),
+                reason,
+                snapshot.canceledAt()
+        );
+
+        userSubscriptionRepository.findFirstByLastPaymentId(order.getPaymentId())
+                .ifPresent(UserSubscription::expire);
+
+        return new PaymentCancelResponse(
+                order.getPaymentId(),
+                order.getStatus(),
+                order.getCanceledAt(),
+                "결제가 취소되었습니다."
+        );
+    }
+
+    @Transactional
+    public void handleWebhook(String rawBody) {
+        String paymentId = extractPaymentId(rawBody);
+
+        if (paymentId == null || paymentId.isBlank()) {
+            return;
+        }
+
+        PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
+                .orElse(null);
+
+        if (order == null) {
+            return;
+        }
+
+        PortOnePaymentSnapshot snapshot = portOnePaymentClient.getPayment(paymentId);
+
+        if (isPaid(snapshot.status())) {
+            syncPaidPayment(order);
+            return;
+        }
+
+        if (isCanceled(snapshot.status())) {
+            order.markCanceled(
+                    snapshot.status(),
+                    "PortOne 웹훅 결제 취소 동기화",
+                    snapshot.canceledAt()
+            );
+
+            userSubscriptionRepository.findFirstByLastPaymentId(order.getPaymentId())
+                    .ifPresent(UserSubscription::expire);
+            return;
+        }
+
+        order.markFailed(
+                snapshot.status(),
+                "PortOne 웹훅 결제 실패 또는 미완료 상태"
+        );
+    }
+
+    private PaymentVerifyResponse syncPaidPayment(PaymentOrder order) {
+        if (order.isPaid()) {
+            UserSubscription subscription = userSubscriptionRepository
+                    .findFirstByLastPaymentId(order.getPaymentId())
+                    .orElse(null);
+
+            return new PaymentVerifyResponse(
+                    order.getPaymentId(),
+                    order.getStatus(),
+                    order.getPlan(),
+                    order.getPlan().getDisplayName(),
+                    order.getAmount(),
+                    order.getCurrency(),
+                    subscription != null && subscription.isActiveAt(LocalDateTime.now()),
+                    subscription == null ? null : subscription.getCurrentPeriodEnd(),
+                    "이미 검증 완료된 결제입니다."
+            );
+        }
+
+        PortOnePaymentSnapshot snapshot = portOnePaymentClient.getPayment(order.getPaymentId());
+
+        validatePaidSnapshot(order, snapshot);
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime periodEnd = now.plusMonths(order.getPlan().getBillingCycleMonths());
+
+        order.markPaid(
+                snapshot.status(),
+                snapshot.transactionId(),
+                snapshot.paidAt()
+        );
+
+        UserSubscription subscription = userSubscriptionRepository
+                .findFirstByUserOrderByCreatedAtDesc(order.getUser())
+                .orElseGet(() -> userSubscriptionRepository.save(
+                        UserSubscription.pending(
+                                order.getUser(),
+                                order.getPlan(),
+                                PaymentProvider.PORTONE_V2
+                        )
+                ));
+
+        subscription.activateByPayment(order.getPaymentId(), now, periodEnd);
+
+        return new PaymentVerifyResponse(
+                order.getPaymentId(),
+                order.getStatus(),
+                order.getPlan(),
+                order.getPlan().getDisplayName(),
+                order.getAmount(),
+                order.getCurrency(),
+                true,
+                periodEnd,
+                "멤버십이 활성화되었습니다."
+        );
+    }
+
+    private void validatePaidSnapshot(PaymentOrder order, PortOnePaymentSnapshot snapshot) {
+        if (!isPaid(snapshot.status())) {
+            order.markFailed(snapshot.status(), "결제가 완료되지 않았습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_NOT_PAID);
+        }
+
+        if (snapshot.amount() == null || snapshot.amount() != order.getAmount()) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        if (snapshot.currency() == null
+                || !snapshot.currency().equalsIgnoreCase(order.getCurrency())) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CURRENCY_MISMATCH);
+        }
+    }
+
+    private User getActiveUser(Long userId) {
+        return userRepository.findById(userId)
+                .filter(User::isActive)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+
+    private PaymentOrder getMyPaymentOrder(String paymentId, User user) {
+        PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_ORDER_NOT_FOUND));
+
+        if (!order.getUser().getId().equals(user.getId())) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_ACCESS_DENIED);
+        }
+
+        return order;
+    }
+
+    private String generatePaymentId() {
+        String paymentId;
+        do {
+            paymentId = "membership_" + System.currentTimeMillis()
+                    + "_" + UUID.randomUUID().toString().substring(0, 8);
+        } while (paymentOrderRepository.existsByPaymentId(paymentId));
+
+        return paymentId;
+    }
+
+    private boolean isPaid(String status) {
+        return PAID_STATUS.equalsIgnoreCase(status);
+    }
+
+    private boolean isCanceled(String status) {
+        return CANCELED_STATUS.equalsIgnoreCase(status)
+                || CANCELED_STATUS_ALT.equalsIgnoreCase(status);
+    }
+
+    private String extractPaymentId(String rawBody) {
+        try {
+            JsonNode root = objectMapper.readTree(rawBody);
+
+            JsonNode dataPaymentId = root.path("data").path("paymentId");
+            if (!dataPaymentId.isMissingNode() && !dataPaymentId.isNull()) {
+                return dataPaymentId.asText();
+            }
+
+            JsonNode paymentId = root.path("paymentId");
+            if (!paymentId.isMissingNode() && !paymentId.isNull()) {
+                return paymentId.asText();
+            }
+
+            return null;
+        } catch (Exception e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/payment/support/PortOneWebhookVerifier.java
+++ b/src/main/java/com/example/ossdoc/domain/payment/support/PortOneWebhookVerifier.java
@@ -1,0 +1,112 @@
+package com.example.ossdoc.domain.payment.support;
+
+import com.example.ossdoc.domain.payment.exception.PaymentException;
+import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
+import com.example.ossdoc.global.properties.PortOneProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PortOneWebhookVerifier {
+
+    private static final long ALLOWED_TIMESTAMP_DRIFT_SECONDS = 60L * 5L;
+
+    private final PortOneProperties portOneProperties;
+
+    public void verify(String rawBody, HttpServletRequest request) {
+        portOneProperties.validateWebhookConfig();
+
+        String webhookId = request.getHeader("webhook-id");
+        String webhookTimestamp = request.getHeader("webhook-timestamp");
+        String webhookSignature = request.getHeader("webhook-signature");
+
+        if (isBlank(webhookId) || isBlank(webhookTimestamp) || isBlank(webhookSignature)) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+
+        validateTimestamp(webhookTimestamp);
+
+        String signedPayload = webhookId + "." + webhookTimestamp + "." + rawBody;
+        byte[] expectedSignature = hmacSha256(
+                portOneProperties.getWebhookSecret(),
+                signedPayload
+        );
+
+        boolean matched = parseSignatures(webhookSignature).stream()
+                .map(this::decodeBase64)
+                .anyMatch(actual -> constantTimeEquals(expectedSignature, actual));
+
+        if (!matched) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+    }
+
+    private void validateTimestamp(String webhookTimestamp) {
+        try {
+            long timestamp = Long.parseLong(webhookTimestamp);
+            long now = Instant.now().getEpochSecond();
+
+            if (Math.abs(now - timestamp) > ALLOWED_TIMESTAMP_DRIFT_SECONDS) {
+                throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+            }
+        } catch (NumberFormatException e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+    }
+
+    private List<String> parseSignatures(String webhookSignature) {
+        return List.of(webhookSignature.split(" "))
+                .stream()
+                .flatMap(part -> List.of(part.split(",")).stream())
+                .filter(part -> part.startsWith("v1,") || part.startsWith("v1="))
+                .map(part -> part.substring(3))
+                .filter(part -> !part.isBlank())
+                .toList();
+    }
+
+    private byte[] hmacSha256(String secret, String payload) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8),
+                    "HmacSHA256"
+            ));
+            return mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+    }
+
+    private byte[] decodeBase64(String value) {
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (Exception e) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_WEBHOOK_INVALID);
+        }
+    }
+
+    private boolean constantTimeEquals(byte[] expected, byte[] actual) {
+        if (expected == null || actual == null || expected.length != actual.length) {
+            return false;
+        }
+
+        int result = 0;
+        for (int i = 0; i < expected.length; i++) {
+            result |= expected[i] ^ actual[i];
+        }
+        return result == 0;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/example/ossdoc/domain/run/cache/support/InMemoryAnalysisCacheRedisStore.java
+++ b/src/main/java/com/example/ossdoc/domain/run/cache/support/InMemoryAnalysisCacheRedisStore.java
@@ -1,0 +1,4 @@
+package com.example.ossdoc.domain.run.cache.support;
+
+public class InMemoryAnalysisCacheRedisStore {
+}

--- a/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunRecentResponse.java
+++ b/src/main/java/com/example/ossdoc/domain/run/dto/response/RepoRunRecentResponse.java
@@ -1,5 +1,6 @@
 package com.example.ossdoc.domain.run.dto.response;
 
+import com.example.ossdoc.domain.membership.enums.AnalysisAccessType;
 import com.example.ossdoc.domain.run.entity.RepoRun;
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import lombok.Builder;
@@ -23,6 +24,7 @@ public class RepoRunRecentResponse {
     private String resolvedRef;
     private String commitSha;
     private RunStatus status;
+    private AnalysisAccessType analysisAccessType;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -35,6 +37,7 @@ public class RepoRunRecentResponse {
                 .repoName(run.getRepoName())
                 .resolvedRef(run.getResolvedRef())
                 .commitSha(run.getCommitSha())
+                .status(run.getStatus())
                 .status(run.getStatus())
                 .createdAt(run.getCreatedAt())
                 .updatedAt(run.getUpdatedAt())

--- a/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
+++ b/src/main/java/com/example/ossdoc/domain/run/entity/RepoRun.java
@@ -2,6 +2,7 @@ package com.example.ossdoc.domain.run.entity;
 
 import com.example.ossdoc.domain.run.enums.RunStatus;
 import com.example.ossdoc.domain.user.entity.User;
+import com.example.ossdoc.domain.membership.enums.AnalysisAccessType;
 import com.example.ossdoc.global.apiPayload.code.BaseAuditedEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
@@ -66,6 +67,10 @@ public class RepoRun extends BaseAuditedEntity {
     @Column(name = "workspace_root")
     private String workspaceRoot;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "analysis_access_type", length = 30)
+    private AnalysisAccessType analysisAccessType;
+
     public RepoRun(
             String runId,
             User owner,
@@ -74,7 +79,8 @@ public class RepoRun extends BaseAuditedEntity {
             String repoName,
             String resolvedRef,
             String commitSha,
-            String workspaceRoot
+            String workspaceRoot,
+            AnalysisAccessType analysisAccessType
     ) {
         this.runId = runId;
         this.owner = owner;
@@ -84,11 +90,15 @@ public class RepoRun extends BaseAuditedEntity {
         this.resolvedRef = resolvedRef;
         this.commitSha = commitSha;
         this.workspaceRoot = workspaceRoot;
+        this.analysisAccessType = analysisAccessType;
         this.status = RunStatus.QUEUED;
     }
 
     public void assignOwner(User owner) {
         this.owner = owner;
+    }
+    public void assignAnalysisAccessType(AnalysisAccessType analysisAccessType){
+        this.analysisAccessType = analysisAccessType;
     }
 
     public void markRunning() {

--- a/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RepoRunService.java
@@ -6,6 +6,8 @@ import com.example.ossdoc.domain.artifact.repository.ArtifactRepository;
 import com.example.ossdoc.domain.auth.exception.AuthException;
 import com.example.ossdoc.domain.auth.exception.code.AuthErrorCode;
 import com.example.ossdoc.domain.build.enums.BuildMode;
+import com.example.ossdoc.domain.membership.enums.AnalysisAccessType;
+import com.example.ossdoc.domain.membership.service.MembershipAccessService;
 import com.example.ossdoc.domain.run.cache.model.AnalysisCacheFailedCooldownResult;
 import com.example.ossdoc.domain.run.cache.model.AnalysisCacheLookupResult;
 import com.example.ossdoc.domain.run.cache.service.AnalysisCacheLockService;
@@ -54,6 +56,7 @@ public class RepoRunService {
             PipelineJobStatus.RUNNING,
             PipelineJobStatus.RETRYING
     );
+
     private static final String CACHE_WAIT_STATUS_MESSAGE =
             "[CACHE_WAIT] 동일 커밋 FULL 분석 결과를 기다리는 중입니다.";
 
@@ -69,10 +72,12 @@ public class RepoRunService {
     private final RunPipelineJobRepository runPipelineJobRepository;
     private final RunPipelineStepExecutionRepository runPipelineStepExecutionRepository;
     private final ArtifactRepository artifactRepository;
+    private final MembershipAccessService membershipAccessService;
 
     @Transactional
     public RepoRunCreateResponse createRun(RepoRunCreateRequest req, Long userId) {
         User owner = userRepository.findById(userId)
+                .filter(User::isActive)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
         GithubRepoRef parsed = GithubUrlParser.parse(req.getRepoUrl(), req.getRef());
@@ -115,12 +120,15 @@ public class RepoRunService {
                 ref,
                 abbreviateSha(commitSha)
         );
+
         log.info(
                 "[CACHE] analysis key prepared. sha={}, key={}",
                 abbreviateSha(commitSha),
                 abbreviateCacheKey(analysisCacheKey)
         );
+
         boolean forceRebuild = req.isForceRebuild();
+
         if (forceRebuild) {
             log.info(
                     "[CACHE] forceRebuild requested. read bypass enabled. sha={}, key={}",
@@ -136,130 +144,159 @@ public class RepoRunService {
                     commitSha
             );
 
-        if (cacheLookupResult.hit()) {
-            RepoRun ownedCachedRun = resolveOwnedCachedRun(cacheLookupResult.sourceRunId(), userId);
-            if (ownedCachedRun != null) {
-                if (isFullSuccessCacheSource(ownedCachedRun)) {
-                    log.info(
-                            "[CACHE] hit accepted. requestSha={}, sourceRunId={}, reason={}",
-                            abbreviateSha(commitSha),
+            if (cacheLookupResult.hit()) {
+                RepoRun ownedCachedRun = resolveOwnedCachedRun(cacheLookupResult.sourceRunId(), userId);
+
+                if (ownedCachedRun != null) {
+                    if (isFullSuccessCacheSource(ownedCachedRun)) {
+                        log.info(
+                                "[CACHE] hit accepted. requestSha={}, sourceRunId={}, reason={}",
+                                abbreviateSha(commitSha),
+                                ownedCachedRun.getRunId(),
+                                cacheLookupResult.reason()
+                        );
+
+                        /*
+                         * 내 기존 성공 run을 그대로 반환하는 경우입니다.
+                         * 새 분석 결과를 만드는 것이 아니므로 무료 분석권을 차감하지 않습니다.
+                         */
+                        return toCreateResponse(
+                                ownedCachedRun,
+                                true,
+                                cacheLookupResult.cacheKey(),
+                                cacheLookupResult.sourceRunId()
+                        );
+                    }
+
+                    log.warn(
+                            "[CACHE] hit rejected. run is not full-success. sourceRunId={}, runStatus={}",
                             ownedCachedRun.getRunId(),
-                            cacheLookupResult.reason()
+                            ownedCachedRun.getStatus()
                     );
-                    return toCreateResponse(
-                            ownedCachedRun,
-                            true,
-                            cacheLookupResult.cacheKey(),
+                }
+
+                RepoRun sourceRun = resolveAnyCachedRun(cacheLookupResult.sourceRunId());
+
+                if (sourceRun != null) {
+                    if (isFullSuccessCacheSource(sourceRun)) {
+                        /*
+                         * 타사용자의 성공 캐시 결과를 내 소유 run으로 복제하는 경우입니다.
+                         * 사용자는 새 결과 접근권을 얻는 것이므로 무료 분석권 또는 멤버십 권한을 확인합니다.
+                         */
+                        AnalysisAccessType accessType = membershipAccessService.grantAnalysisStart(owner);
+
+                        RepoRun sharedCachedRun = createSharedCachedRun(
+                                sourceRun,
+                                owner,
+                                userId,
+                                accessType
+                        );
+
+                        log.info(
+                                "[CACHE] global hit accepted. sourceRunId={}, sharedRunId={}, requestUserId={}, accessType={}",
+                                sourceRun.getRunId(),
+                                sharedCachedRun.getRunId(),
+                                userId,
+                                accessType
+                        );
+
+                        return toCreateResponse(
+                                sharedCachedRun,
+                                true,
+                                cacheLookupResult.cacheKey(),
+                                sourceRun.getRunId(),
+                                sourceRun
+                        );
+                    }
+
+                    log.warn(
+                            "[CACHE] hit rejected. source run is not full-success. sourceRunId={}, runStatus={}",
+                            sourceRun.getRunId(),
+                            sourceRun.getStatus()
+                    );
+                } else {
+                    log.warn(
+                            "[CACHE] hit payload exists but source run is missing. sourceRunId={}, fallback=MISS",
                             cacheLookupResult.sourceRunId()
                     );
                 }
-
-                log.warn(
-                        "[CACHE] hit rejected. run is not full-success. sourceRunId={}, runStatus={}",
-                        ownedCachedRun.getRunId(),
-                        ownedCachedRun.getStatus()
+            } else {
+                log.info(
+                        "[CACHE] miss. sha={}, reason={}",
+                        abbreviateSha(commitSha),
+                        cacheLookupResult.reason()
                 );
             }
 
-            RepoRun sourceRun = resolveAnyCachedRun(cacheLookupResult.sourceRunId());
-            if (sourceRun != null) {
-                if (isFullSuccessCacheSource(sourceRun)) {
-                    RepoRun sharedCachedRun = createSharedCachedRun(sourceRun, owner, userId);
-                    log.info(
-                            "[CACHE] global hit accepted. sourceRunId={}, sharedRunId={}, requestUserId={}",
-                            sourceRun.getRunId(),
-                            sharedCachedRun.getRunId(),
-                            userId
+            /*
+             * W10(완화):
+             * - READY miss 이후, 직전 FAILED 캐시의 짧은 쿨다운(기본 30초) 여부를 확인합니다.
+             * - 동일 사용자의 실패 run이면 재사용해 즉시 응답합니다.
+             * - 타사용자 실패 run은 내 요청을 막지 않고, 아래 신규 분석 경로로 그대로 진행합니다.
+             */
+            AnalysisCacheFailedCooldownResult failedCooldownResult =
+                    analysisCacheLookupService.lookupFailedCooldown(
+                            analysisCacheKey,
+                            normalizedRepoUrl,
+                            commitSha
                     );
+
+            if (failedCooldownResult.coolingDown()) {
+                log.info(
+                        "[CACHE][FAILED] cooldown active. cacheKey={}, sourceRunId={}, retryAfter={}, reason={}",
+                        abbreviateCacheKey(failedCooldownResult.cacheKey()),
+                        failedCooldownResult.sourceRunId(),
+                        failedCooldownResult.retryAfter(),
+                        failedCooldownResult.reason()
+                );
+
+                RepoRun ownedFailedRun = resolveOwnedCachedRun(failedCooldownResult.sourceRunId(), userId);
+
+                if (ownedFailedRun != null) {
+                    /*
+                     * 내 실패 run을 재사용하는 경우입니다.
+                     * 새 분석을 만드는 것이 아니므로 무료 분석권을 차감하지 않습니다.
+                     */
                     return toCreateResponse(
-                            sharedCachedRun,
-                            true,
-                            cacheLookupResult.cacheKey(),
-                            sourceRun.getRunId(),
-                            sourceRun
+                            ownedFailedRun,
+                            false,
+                            failedCooldownResult.cacheKey(),
+                            failedCooldownResult.sourceRunId()
+                    );
+                }
+
+                RepoRun sourceFailedRun = resolveAnyCachedRun(failedCooldownResult.sourceRunId());
+
+                if (sourceFailedRun != null) {
+                    /*
+                     * 타사용자 실패는 공유 복제로 막지 않습니다.
+                     * 사용자 관점에서 "남의 실패 때문에 못 도는" 답답함을 없애기 위해
+                     * 내 분석 run으로 재시도할 수 있게 아래 enqueue 경로로 폴백합니다.
+                     */
+                    if (sourceFailedRun.getOwner() != null
+                            && sourceFailedRun.getOwner().getId() != null
+                            && sourceFailedRun.getOwner().getId().equals(userId)) {
+                        return toCreateResponse(
+                                sourceFailedRun,
+                                false,
+                                failedCooldownResult.cacheKey(),
+                                sourceFailedRun.getRunId()
+                        );
+                    }
+
+                    log.info(
+                            "[CACHE][FAILED] cooldown source belongs to another user. fallback=NEW_ANALYSIS, sourceRunId={}, ownerId={}, requestUserId={}",
+                            sourceFailedRun.getRunId(),
+                            sourceFailedRun.getOwner() == null ? null : sourceFailedRun.getOwner().getId(),
+                            userId
                     );
                 }
 
                 log.warn(
-                        "[CACHE] hit rejected. source run is not full-success. sourceRunId={}, runStatus={}",
-                        sourceRun.getRunId(),
-                        sourceRun.getStatus()
-                );
-            } else {
-                log.warn(
-                        "[CACHE] hit payload exists but source run is missing. sourceRunId={}, fallback=MISS",
-                        cacheLookupResult.sourceRunId()
-                );
-            }
-        } else {
-            log.info(
-                "[CACHE] miss. sha={}, reason={}",
-                abbreviateSha(commitSha),
-                cacheLookupResult.reason()
-            );
-        }
-
-        /*
-         * W10(완화):
-         * - READY miss 이후, 직전 FAILED 캐시의 짧은 쿨다운(기본 30초) 여부를 확인합니다.
-         * - 동일 사용자의 실패 run이면 재사용해 즉시 응답합니다.
-         * - 타사용자 실패 run은 내 요청을 막지 않고, 아래 신규 분석 경로로 그대로 진행합니다.
-         */
-        AnalysisCacheFailedCooldownResult failedCooldownResult =
-                analysisCacheLookupService.lookupFailedCooldown(
-                        analysisCacheKey,
-                        normalizedRepoUrl,
-                        commitSha
-                );
-        if (failedCooldownResult.coolingDown()) {
-            log.info(
-                    "[CACHE][FAILED] cooldown active. cacheKey={}, sourceRunId={}, retryAfter={}, reason={}",
-                    abbreviateCacheKey(failedCooldownResult.cacheKey()),
-                    failedCooldownResult.sourceRunId(),
-                    failedCooldownResult.retryAfter(),
-                    failedCooldownResult.reason()
-            );
-
-            RepoRun ownedFailedRun = resolveOwnedCachedRun(failedCooldownResult.sourceRunId(), userId);
-            if (ownedFailedRun != null) {
-                return toCreateResponse(
-                        ownedFailedRun,
-                        false,
-                        failedCooldownResult.cacheKey(),
+                        "[CACHE][FAILED] cooldown source run missing. fallback=NEW_ANALYSIS, sourceRunId={}",
                         failedCooldownResult.sourceRunId()
                 );
             }
-
-            RepoRun sourceFailedRun = resolveAnyCachedRun(failedCooldownResult.sourceRunId());
-            if (sourceFailedRun != null) {
-                /*
-                 * 타사용자 실패는 공유 복제로 막지 않습니다.
-                 * 사용자 관점에서 "남의 실패 때문에 못 도는" 답답함을 없애기 위해
-                 * 내 분석 run으로 재시도할 수 있게 아래 enqueue 경로로 폴백합니다.
-                 */
-                if (sourceFailedRun.getOwner() != null
-                        && sourceFailedRun.getOwner().getId() != null
-                        && sourceFailedRun.getOwner().getId().equals(userId)) {
-                    return toCreateResponse(
-                            sourceFailedRun,
-                            false,
-                            failedCooldownResult.cacheKey(),
-                            sourceFailedRun.getRunId()
-                    );
-                }
-                log.info(
-                        "[CACHE][FAILED] cooldown source belongs to another user. fallback=NEW_ANALYSIS, sourceRunId={}, ownerId={}, requestUserId={}",
-                        sourceFailedRun.getRunId(),
-                        sourceFailedRun.getOwner() == null ? null : sourceFailedRun.getOwner().getId(),
-                        userId
-                );
-            }
-
-            log.warn(
-                    "[CACHE][FAILED] cooldown source run missing. fallback=NEW_ANALYSIS, sourceRunId={}",
-                    failedCooldownResult.sourceRunId()
-            );
-        }
         }
 
         /*
@@ -270,6 +307,7 @@ public class RepoRunService {
          *   2) 타사용자 활성 run + buildMode=FULL(또는 미확정) -> 내 소유 WAIT run 생성 후 캐시 대기
          *   3) 타사용자 활성 run + buildMode!=FULL -> 조기 탈출(독립 분석 즉시 enqueue)
          */
+
         /*
          * 락 owner token을 runId 기반으로 고정해 둡니다.
          * 이유:
@@ -279,6 +317,7 @@ public class RepoRunService {
         String runId = generateRunId();
         String lockOwnerToken = buildLockOwnerToken(runId);
         boolean lockAcquired = analysisCacheLockService.tryAcquire(analysisCacheKey, lockOwnerToken);
+
         if (!lockAcquired) {
             if (forceRebuild) {
                 /*
@@ -291,63 +330,101 @@ public class RepoRunService {
                         abbreviateCacheKey(analysisCacheKey)
                 );
             } else {
-            RepoRun activeRun = resolveActiveRunForSameRepoAndSha(
-                    parsed.getOwner(),
-                    parsed.getRepo(),
-                    commitSha
-            );
+                RepoRun activeRun = resolveActiveRunForSameRepoAndSha(
+                        parsed.getOwner(),
+                        parsed.getRepo(),
+                        commitSha
+                );
 
-            if (activeRun == null) {
-                log.info(
-                        "[CACHE][LOCK] contention but active run not found. fallback=EARLY_ESCAPE, cacheKey={}",
-                        abbreviateCacheKey(analysisCacheKey)
-                );
-            } else if (activeRun.getOwner() != null && activeRun.getOwner().getId() != null
-                    && activeRun.getOwner().getId().equals(userId)) {
-                log.info(
-                        "[CACHE][LOCK] contention resolved by attach. requestUserId={}, runId={}, status={}",
-                        userId,
-                        activeRun.getRunId(),
-                        activeRun.getStatus()
-                );
-                return toCreateResponse(
-                        activeRun,
-                        false,
-                        analysisCacheKey,
-                        null
-                );
-            } else {
-                BuildMode sourceBuildMode = resolveBuildMode(activeRun.getRunId());
-                if (sourceBuildMode != null && sourceBuildMode != BuildMode.FULL) {
+                if (activeRun == null) {
                     log.info(
-                            "[CACHE][LOCK] early-escape triggered. sourceRunId={}, sourceBuildMode={}",
-                            activeRun.getRunId(),
-                            sourceBuildMode
+                            "[CACHE][LOCK] contention but active run not found. fallback=EARLY_ESCAPE, cacheKey={}",
+                            abbreviateCacheKey(analysisCacheKey)
                     );
-                    // 조기 탈출: 아래 신규 분석 enqueue 경로로 폴백합니다.
-                } else {
-                    RepoRun waitingRun = createCacheWaitingRun(req, owner, parsed, ref, commitSha, userId);
+                } else if (activeRun.getOwner() != null
+                        && activeRun.getOwner().getId() != null
+                        && activeRun.getOwner().getId().equals(userId)) {
                     log.info(
-                            "[CACHE][LOCK] waiting run created. requestUserId={}, runId={}, sourceRunId={}, sourceBuildMode={}",
+                            "[CACHE][LOCK] contention resolved by attach. requestUserId={}, runId={}, status={}",
                             userId,
-                            waitingRun.getRunId(),
                             activeRun.getRunId(),
-                            sourceBuildMode
+                            activeRun.getStatus()
                     );
+
+                    /*
+                     * 내 활성 run에 attach하는 경우입니다.
+                     * 이미 내 run이 있으므로 무료 분석권을 차감하지 않습니다.
+                     */
                     return toCreateResponse(
-                            waitingRun,
+                            activeRun,
                             false,
                             analysisCacheKey,
-                            activeRun.getRunId()
+                            null
                     );
+                } else {
+                    BuildMode sourceBuildMode = resolveBuildMode(activeRun.getRunId());
+
+                    if (sourceBuildMode != null && sourceBuildMode != BuildMode.FULL) {
+                        log.info(
+                                "[CACHE][LOCK] early-escape triggered. sourceRunId={}, sourceBuildMode={}",
+                                activeRun.getRunId(),
+                                sourceBuildMode
+                        );
+                        /*
+                         * 조기 탈출:
+                         * 아래 신규 분석 enqueue 경로로 폴백합니다.
+                         * 신규 run을 만들 때 무료 분석권 또는 멤버십 권한을 확인합니다.
+                         */
+                    } else {
+                        /*
+                         * 타사용자의 FULL 분석을 기다리는 내 WAIT run을 생성하는 경우입니다.
+                         * 내 소유 run이 새로 만들어지므로 무료 분석권 또는 멤버십 권한을 확인합니다.
+                         */
+                        AnalysisAccessType accessType = membershipAccessService.grantAnalysisStart(owner);
+
+                        RepoRun waitingRun = createCacheWaitingRun(
+                                req,
+                                owner,
+                                parsed,
+                                ref,
+                                commitSha,
+                                userId,
+                                accessType
+                        );
+
+                        log.info(
+                                "[CACHE][LOCK] waiting run created. requestUserId={}, runId={}, sourceRunId={}, sourceBuildMode={}, accessType={}",
+                                userId,
+                                waitingRun.getRunId(),
+                                activeRun.getRunId(),
+                                sourceBuildMode,
+                                accessType
+                        );
+
+                        return toCreateResponse(
+                                waitingRun,
+                                false,
+                                analysisCacheKey,
+                                activeRun.getRunId()
+                        );
+                    }
                 }
-            }
             }
         }
 
         Path wsRoot = workspaceManager.workspaceRoot(runId);
 
         log.info("Workspace prepared runId={}, workspaceRoot={}", runId, wsRoot);
+
+        /*
+         * 신규 분석 run을 생성하는 경우입니다.
+         * GitHub URL 파싱, 기본 브랜치 조회, commitSha resolve, cache attach/wait 판단이 끝난 뒤에
+         * 무료 분석권 또는 멤버십 권한을 확인합니다.
+         *
+         * 이렇게 해야 잘못된 URL이나 GitHub 조회 실패, 내 기존 run attach 때문에
+         * 무료 분석권이 잘못 차감되는 일을 막을 수 있습니다.
+         */
+        AnalysisAccessType analysisAccessType = membershipAccessService.grantAnalysisStart(owner);
 
         RepoRun run = new RepoRun(
                 runId,
@@ -357,7 +434,8 @@ public class RepoRunService {
                 parsed.getRepo(),
                 ref,
                 commitSha,
-                wsRoot.toString()
+                wsRoot.toString(),
+                analysisAccessType
         );
 
         repoRunRepository.save(run);
@@ -374,10 +452,11 @@ public class RepoRunService {
         }
 
         log.info(
-                "Run queued runId={}, status={}, sha={}",
+                "Run queued runId={}, status={}, sha={}, accessType={}",
                 runId,
                 run.getStatus(),
-                abbreviateSha(commitSha)
+                abbreviateSha(commitSha),
+                analysisAccessType
         );
 
         return toCreateResponse(
@@ -430,6 +509,7 @@ public class RepoRunService {
         if (sourceRunId == null || sourceRunId.isBlank()) {
             return null;
         }
+
         return repoRunRepository.findByRunIdAndOwner_Id(sourceRunId, userId)
                 .orElse(null);
     }
@@ -441,6 +521,7 @@ public class RepoRunService {
         if (sourceRunId == null || sourceRunId.isBlank()) {
             return null;
         }
+
         return repoRunRepository.findById(sourceRunId)
                 .orElse(null);
     }
@@ -471,7 +552,12 @@ public class RepoRunService {
      * - 단순히 원본 runId를 반환하면 owner 검증(progress/artifact)에서 차단됩니다.
      * - 요청자 소유 run으로 메타를 복제하면 기존 권한 모델을 유지한 채 전역 캐시를 재사용할 수 있습니다.
      */
-    private RepoRun createSharedCachedRun(RepoRun sourceRun, User owner, Long requestUserId) {
+    private RepoRun createSharedCachedRun(
+            RepoRun sourceRun,
+            User owner,
+            Long requestUserId,
+            AnalysisAccessType accessType
+    ) {
         String sharedRunId = generateRunId();
 
         RepoRun sharedRun = new RepoRun(
@@ -482,8 +568,10 @@ public class RepoRunService {
                 sourceRun.getRepoName(),
                 sourceRun.getResolvedRef(),
                 sourceRun.getCommitSha(),
-                sourceRun.getWorkspaceRoot()
+                sourceRun.getWorkspaceRoot(),
+                accessType
         );
+
         repoRunRepository.save(sharedRun);
 
         RunPipelineJob sharedJob = copyJobState(sourceRun.getRunId(), sharedRun, requestUserId);
@@ -511,6 +599,7 @@ public class RepoRunService {
         }
 
         PipelineJobStatus sourceStatus = sourceJob.getStatus();
+
         if (sourceStatus == PipelineJobStatus.PARTIAL_SUCCESS) {
             sharedJob.markPartialSuccess(sourceJob.getFailureMessage());
         } else if (sourceStatus == PipelineJobStatus.FAILED) {
@@ -537,6 +626,7 @@ public class RepoRunService {
             );
 
             PipelineStepStatus sourceStatus = sourceStep.getStatus();
+
             if (sourceStatus == PipelineStepStatus.SUCCESS) {
                 copied.succeed(sourceStep.getMessage());
             } else if (sourceStatus == PipelineStepStatus.FAILED) {
@@ -615,6 +705,7 @@ public class RepoRunService {
         if (cacheKey == null || cacheKey.isBlank()) {
             return "<empty>";
         }
+
         return cacheKey.length() <= 12 ? cacheKey : cacheKey.substring(0, 12);
     }
 
@@ -631,7 +722,8 @@ public class RepoRunService {
             GithubRepoRef parsed,
             String ref,
             String commitSha,
-            Long userId
+            Long userId,
+            AnalysisAccessType accessType
     ) {
         String waitingRunId = generateRunId();
         Path waitingWsRoot = workspaceManager.workspaceRoot(waitingRunId);
@@ -644,8 +736,10 @@ public class RepoRunService {
                 parsed.getRepo(),
                 ref,
                 commitSha,
-                waitingWsRoot.toString()
+                waitingWsRoot.toString(),
+                accessType
         );
+
         repoRunRepository.save(waitingRun);
 
         RunPipelineJob waitingJob = RunPipelineJob.create(waitingRun, userId);
@@ -657,6 +751,7 @@ public class RepoRunService {
                 waitingRun,
                 RunStage.QUEUED
         );
+
         waitingStep.start(CACHE_WAIT_STATUS_MESSAGE);
         runPipelineStepExecutionRepository.save(waitingStep);
 
@@ -696,6 +791,7 @@ public class RepoRunService {
         if (raw == null || raw.isBlank()) {
             return null;
         }
+
         try {
             return BuildMode.valueOf(raw.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
+++ b/src/main/java/com/example/ossdoc/domain/run/service/RunProgressQueryService.java
@@ -15,6 +15,9 @@ import com.example.ossdoc.domain.run.exception.code.RunErrorCode;
 import com.example.ossdoc.domain.run.repository.RepoRunRepository;
 import com.example.ossdoc.domain.run.repository.RunPipelineJobRepository;
 import com.example.ossdoc.domain.run.repository.RunPipelineStepExecutionRepository;
+import com.example.ossdoc.domain.membership.exception.MembershipException;
+import com.example.ossdoc.domain.membership.exception.code.MembershipErrorCode;
+import com.example.ossdoc.domain.membership.service.MembershipAccessService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,11 +35,16 @@ public class RunProgressQueryService {
     private final RunPipelineJobRepository jobRepository;
     private final RunPipelineStepExecutionRepository stepRepository;
     private final ArtifactRepository artifactRepository;
+    private final MembershipAccessService membershipAccessService;
 
     @Transactional(readOnly = true)
     public RepoRunProgressResponse getProgress(String runId, Long userId) {
         RepoRun run = repoRunRepository.findByRunIdAndOwner_Id(runId, userId)
                 .orElseThrow(() -> new RunException(RunErrorCode.RUN_FORBIDDEN));
+
+        if (!membershipAccessService.canViewRun(run, run.getOwner())) {
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP_REQUIRED);
+        }
 
         RunPipelineJob job = jobRepository.findByRun_RunId(runId)
                 .orElseThrow(() -> new RunException(RunErrorCode.PIPELINE_JOB_NOT_FOUND));

--- a/src/main/java/com/example/ossdoc/global/config/AnalysisCacheStoreConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/AnalysisCacheStoreConfig.java
@@ -1,0 +1,4 @@
+package com.example.ossdoc.global.config;
+
+public class AnalysisCacheStoreConfig {
+}

--- a/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
@@ -52,6 +52,8 @@ public class SecurityConfig {
 
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
 
+                        .requestMatchers(HttpMethod.POST, "/api/v1/payments/portone/webhook").permitAll()
+
                         .requestMatchers("/api/v1/auth/me/**").authenticated()
                         .requestMatchers("/api/v1/auth/nicknames/**").authenticated()
                         .requestMatchers("/api/v1/runs/**").authenticated()

--- a/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/SecurityConfig.java
@@ -1,148 +1,79 @@
 package com.example.ossdoc.global.config;
 
-import com.example.ossdoc.global.properties.AuthProperties;
 import com.example.ossdoc.global.security.jwt.JwtAuthenticationFilter;
+import com.example.ossdoc.global.security.oauth.CustomOAuth2UserService;
 import com.example.ossdoc.global.security.oauth.CustomOidcUserService;
+import com.example.ossdoc.global.security.oauth.OAuth2LoginFailureHandler;
 import com.example.ossdoc.global.security.oauth.OAuth2LoginSuccessHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final CorsConfigurationSource corsConfigurationSource;
+    private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOidcUserService customOidcUserService;
-    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-    private final AuthProperties authProperties;
-    private final ObjectMapper objectMapper;
-    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final OAuth2LoginSuccessHandler oauth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oauth2LoginFailureHandler;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
-                .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint((request, response, authException) ->
-                                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."))
-                        .accessDeniedHandler((request, response, accessDeniedException) ->
-                                writeError(response, HttpServletResponse.SC_FORBIDDEN, "AUTH_002", "접근 권한이 없습니다."))
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/",
+                                "/error",
+                                "/favicon.ico",
+                                "/actuator/health",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html",
                                 "/v3/api-docs/**",
-                                "/actuator/health"
+                                "/oauth2/**",
+                                "/login/oauth2/**"
                         ).permitAll()
-                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/me").authenticated()
-                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()
+
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
+
+                        .requestMatchers("/api/v1/auth/me/**").authenticated()
+                        .requestMatchers("/api/v1/auth/nicknames/**").authenticated()
+                        .requestMatchers("/api/v1/runs/**").authenticated()
+                        .requestMatchers("/api/v1/artifacts/**").authenticated()
+                        .requestMatchers("/api/v1/membership/**").authenticated()
+                        .requestMatchers("/api/v1/payments/**").authenticated()
+
+                        .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(endpoint -> endpoint
-                                .authorizationRequestResolver(
-                                        googleAuthorizationRequestResolver(clientRegistrationRepository)
-                                )
-                        )
                         .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
                                 .oidcUserService(customOidcUserService)
                         )
-                        .successHandler(oAuth2LoginSuccessHandler)
-                        .failureHandler((request, response, exception) ->
-                                response.sendRedirect(authProperties.getFrontendFailureRedirectUri()))
+                        .successHandler(oauth2LoginSuccessHandler)
+                        .failureHandler(oauth2LoginFailureHandler)
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
-        return http.build();
-    }
-
-    private OAuth2AuthorizationRequestResolver googleAuthorizationRequestResolver(
-            ClientRegistrationRepository clientRegistrationRepository
-    ) {
-        DefaultOAuth2AuthorizationRequestResolver defaultResolver =
-                new DefaultOAuth2AuthorizationRequestResolver(
-                        clientRegistrationRepository,
-                        "/oauth2/authorization"
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
-        return new OAuth2AuthorizationRequestResolver() {
-            @Override
-            public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-                return customize(request, defaultResolver.resolve(request));
-            }
-
-            @Override
-            public OAuth2AuthorizationRequest resolve(HttpServletRequest request,
-                                                      String clientRegistrationId) {
-                return customize(request, defaultResolver.resolve(request, clientRegistrationId));
-            }
-
-            private OAuth2AuthorizationRequest customize(HttpServletRequest request,
-                                                         OAuth2AuthorizationRequest authorizationRequest) {
-                if (authorizationRequest == null) {
-                    return null;
-                }
-
-                String prompt = request.getParameter("prompt");
-
-                if (!"select_account".equals(prompt)) {
-                    return authorizationRequest;
-                }
-
-                Map<String, Object> additionalParameters =
-                        new LinkedHashMap<>(authorizationRequest.getAdditionalParameters());
-
-                additionalParameters.put("prompt", "select_account");
-
-                return OAuth2AuthorizationRequest.from(authorizationRequest)
-                        .additionalParameters(additionalParameters)
-                        .build();
-            }
-        };
-    }
-
-    private void writeError(HttpServletResponse response, int status, String code, String message) throws java.io.IOException {
-        response.setStatus(status);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("UTF-8");
-
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("isSuccess", false);
-        body.put("code", code);
-        body.put("message", message);
-        body.put("result", null);
-
-        objectMapper.writeValue(response.getWriter(), body);
+        return http.build();
     }
 }

--- a/src/main/java/com/example/ossdoc/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/ossdoc/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.example.ossdoc.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/com/example/ossdoc/global/properties/PortOneProperties.java
+++ b/src/main/java/com/example/ossdoc/global/properties/PortOneProperties.java
@@ -1,0 +1,49 @@
+package com.example.ossdoc.global.properties;
+
+import com.example.ossdoc.domain.payment.exception.PaymentException;
+import com.example.ossdoc.domain.payment.exception.code.PaymentErrorCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "portone")
+public class PortOneProperties {
+
+    private String env = "test";
+
+    private String storeId;
+
+    private String channelKey;
+
+    private String apiSecret;
+
+    private String webhookSecret;
+
+    private String apiBaseUrl = "https://api.portone.io";
+
+    public void validateCheckoutConfig() {
+        if (isBlank(storeId) || isBlank(channelKey)) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIG_MISSING);
+        }
+    }
+
+    public void validateApiConfig() {
+        if (isBlank(apiSecret) || isBlank(apiBaseUrl)) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIG_MISSING);
+        }
+    }
+
+    public void validateWebhookConfig() {
+        if (isBlank(webhookSecret)) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIG_MISSING);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,14 @@ github:
     cache-ttl-minutes: ${GITHUB_STATS_CACHE_TTL_MINUTES:360}
     api-timeout-seconds: ${GITHUB_STATS_API_TIMEOUT_SECONDS:30}
 
+portone:
+  env: ${PORTONE_ENV:test}
+  store-id: ${PORTONE_STORE_ID:}
+  channel-key: ${PORTONE_CHANNEL_KEY:}
+  api-secret: ${PORTONE_API_SECRET:}
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
+  api-base-url: ${PORTONE_API_BASE_URL:https://api.portone.io}
+
 logging:
   level:
     com:


### PR DESCRIPTION
## 작업 개요

Google OAuth 기반 회원 관리, 무료 분석 1회 정책, 멤버십 접근 제어, PortOne v2 테스트 결제 연동을 추가했습니다.

이번 PR은 인증/회원 정책부터 멤버십 권한, 결제 준비/검증/취소/웹훅 처리까지 BE 기반 기능을 포함합니다.

---

## 주요 변경 사항

### 1. Google OAuth 전용 인증/회원 구조

- 자체 회원가입/비밀번호 로그인 제거
- Google OAuth 기반 회원가입/로그인만 사용
- Google 이메일을 서비스 ID로 사용
- Google `providerId(sub)` 기준으로 사용자 식별
- 닉네임 필드 추가
- 닉네임 중복 확인 및 변경 API 추가
- 회원 탈퇴 시 row 삭제 대신 `active=false` 처리
- 탈퇴 후 30일 이내 재가입 차단
- 탈퇴 후 30일 이후 기존 계정 재활성화
- 기존 `user_id` 유지로 무료 분석권/분석 이력 초기화 방지

### 2. JWT 인증 구조 정리

- `JwtTokenProvider`는 토큰 생성/검증/userId 추출만 담당
- `JwtAuthenticationFilter`에서 DB 사용자 조회 후 인증 객체 생성
- `active=false` 사용자는 인증 처리하지 않음
- 현재 서비스는 관리자 권한을 사용하지 않으므로 권한 목록은 비워둠
- `SecurityConfig`는 `hasRole()` 중심이 아닌 `authenticated()` 중심으로 정리
- PortOne 웹훅 API는 인증 없이 허용

### 3. 무료 분석 1회 및 멤버십 접근 제어

- 사용자별 무료 분석 사용량 저장
- 모든 사용자에게 무료 분석 1회 제공
- 무료 분석 사용 후 추가 분석은 ACTIVE 멤버십 필요
- `RepoRun`에 `analysisAccessType` 추가
- `FREE_TRIAL` run은 멤버십 없이도 결과 조회 가능
- `MEMBERSHIP` run은 ACTIVE 멤버십이 있어야 조회 가능
- 최신 develop의 분석 캐시 로직과 멤버십 차감 로직 통합

### 4. PortOne v2 테스트 결제 연동

- `payment_order` 도메인 추가
- 결제 준비 API 추가
- PortOne v2 결제 단건 조회 클라이언트 추가
- 결제 검증 API 추가
- 결제 성공 시 멤버십 ACTIVE 처리
- 테스트 결제 취소 API 추가
- PortOne 웹훅 수신 API 추가
- 웹훅 시그니처 검증 로직 추가

---

## 추가/수정 API

### Auth

| Method | URL | 설명 |
|---|---|---|
| GET | `/api/v1/auth/me` | 현재 로그인 사용자 조회 |
| GET | `/api/v1/auth/nicknames/{nickname}/availability` | 닉네임 중복 확인 |
| PATCH | `/api/v1/auth/me/nickname` | 닉네임 변경 |
| POST | `/api/v1/auth/refresh` | 토큰 재발급 |
| POST | `/api/v1/auth/logout` | 로그아웃 |
| DELETE | `/api/v1/auth/me` | 회원 탈퇴 |

### Membership

| Method | URL | 설명 |
|---|---|---|
| GET | `/api/v1/membership/me` | 내 멤버십/무료 분석권 상태 조회 |

### Payment

| Method | URL | 설명 |
|---|---|---|
| POST | `/api/v1/payments/portone/checkout` | PortOne 결제 준비 |
| POST | `/api/v1/payments/portone/verify` | 결제 검증 및 멤버십 활성화 |
| POST | `/api/v1/payments/portone/{paymentId}/cancel` | 테스트 결제 취소 |
| POST | `/api/v1/payments/portone/webhook` | PortOne 웹훅 수신 |
